### PR TITLE
Disable focus for hidden links in Faq V2 

### DIFF
--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -7,10 +7,8 @@ function toggleContentLinksDisabledState(contentEl, disabled) {
   if (!links || links.length === 0) return;
   links.forEach((link) => {
     if (disabled) {
-      link.setAttribute('disabled', 'true');
       link.setAttribute('tabindex', '-1');
     } else {
-      link.removeAttribute('disabled');
       link.removeAttribute('tabindex');
     }
   });

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -2,6 +2,19 @@ import { createTag, getLibs, getMetadata } from '../../scripts/utils.js';
 
 let replaceKey;
 let getConfig;
+function toggleContentLinksDisabledState(contentEl, disabled) {
+  const links = contentEl?.querySelectorAll('a');
+  if (!links || links.length === 0) return;
+  links.forEach((link) => {
+    if (disabled) {
+      link.setAttribute('disabled', 'true');
+      link.setAttribute('tabindex', '-1');
+    } else {
+      link.removeAttribute('disabled');
+      link.removeAttribute('tabindex');
+    }
+  });
+}
 function buildTableLayout(block) {
   const config = getConfig();
   const isLongFormVariant = block.classList.contains('longform');
@@ -91,6 +104,7 @@ function buildTableLayout(block) {
       });
       content.innerHTML = subHeader;
       toggle.appendChild(content);
+      toggleContentLinksDisabledState(content, true);
 
       // Set initial state
       content.style.maxHeight = '0';
@@ -111,6 +125,7 @@ function buildTableLayout(block) {
             otherContent.classList.remove('open');
             otherContent.style.maxHeight = '0';
             otherContent.setAttribute('aria-hidden', 'true');
+            toggleContentLinksDisabledState(otherContent, true);
             allHeaders[idx].setAttribute('aria-expanded', 'false');
             allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
           }
@@ -125,6 +140,7 @@ function buildTableLayout(block) {
           content.classList.add('open');
           content.style.maxHeight = `${height}px`;
           content.setAttribute('aria-hidden', 'false');
+          toggleContentLinksDisabledState(content, false);
           headerDiv.setAttribute('aria-expanded', 'true');
           iconElement.src = `${config.codeRoot}/icons/minus-heavy.svg`;
 
@@ -137,6 +153,7 @@ function buildTableLayout(block) {
           content.classList.remove('open');
           content.style.maxHeight = '0';
           content.setAttribute('aria-hidden', 'true');
+          toggleContentLinksDisabledState(content, true);
           headerDiv.setAttribute('aria-expanded', 'false');
           iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
 
@@ -192,6 +209,7 @@ function buildTableLayout(block) {
       });
       content.innerHTML = subHeader;
       toggle.appendChild(content);
+      toggleContentLinksDisabledState(content, true);
 
       // Set initial state
       content.style.maxHeight = '0';
@@ -212,6 +230,7 @@ function buildTableLayout(block) {
             otherContent.classList.remove('open');
             otherContent.style.maxHeight = '0';
             otherContent.setAttribute('aria-hidden', 'true');
+            toggleContentLinksDisabledState(otherContent, true);
             allHeaders[idx].setAttribute('aria-expanded', 'false');
             allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
           }
@@ -226,6 +245,7 @@ function buildTableLayout(block) {
           content.classList.add('open');
           content.style.maxHeight = `${height}px`;
           content.setAttribute('aria-hidden', 'false');
+          toggleContentLinksDisabledState(content, false);
           headerDiv.setAttribute('aria-expanded', 'true');
           iconElement.src = `${config.codeRoot}/icons/minus-heavy.svg`;
 
@@ -238,6 +258,7 @@ function buildTableLayout(block) {
           content.classList.remove('open');
           content.style.maxHeight = '0';
           content.setAttribute('aria-hidden', 'true');
+          toggleContentLinksDisabledState(content, true);
           headerDiv.setAttribute('aria-expanded', 'false');
           iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
 


### PR DESCRIPTION
## Summary

- Disable and remove hidden FAQv2 links from the tab order whenever an accordion closes, and restore them when it opens so screen readers and keyboard users can’t reach concealed content.

---

## Jira Ticket

Resolves: [MWPW-183804](https://jira.corp.adobe.com/browse/MWPW-183804)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/create/post/instagram?martech=off |
| **After**   | https://faqv2-hide-link--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/faqv2|

---

## Verification Steps

- Open both URLs and scroll to the FAQv2 block (bottom of the template page).
- Collapse every accordion and press `Tab`; before the change focus moves into hidden links, after it stops at the next visible control.
- Expand an accordion and tab again; links inside the open answer become focusable only when the panel is open.

---

## Potential Regressions

- https://faqv2-hide-link--da-express-milo--adobecom.aem.live/uk/express/entitled

---

## Additional Notes

- Change touches the FAQv2 block used across `express/create/post/instagram`, so spot-check any other pages using this block if they have custom content with inline links.
