### PR TITLE
updated hardcoded names for old repos

### DIFF
--- a/.cursor/rules/pr-template.mdc
+++ b/.cursor/rules/pr-template.mdc
@@ -22,8 +22,8 @@ Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 | Env | URL |
 |-------------|-----|
-| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
-| **After**   | https://<branch>--express-milo--adobecom.aem.page/express/?martech=off |
+| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
+| **After**   | https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off |
 
 ---
 
@@ -36,7 +36,7 @@ Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 ## Potential Regressions
 
-- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off
+- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off
 
 ---
 

--- a/.github/workflows/pr-reminder-test.yml
+++ b/.github/workflows/pr-reminder-test.yml
@@ -252,7 +252,7 @@ jobs:
                 {
                   color: "#ff6b35",
                   footer: "Express Milo • Daily Reminder [TEST MODE]",
-                  footer_icon: "https://github.com/adobecom/express-milo/raw/main/express/code/img/favicon.ico",
+                  footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico",
                   ts: Math.floor(Date.now() / 1000)
                 }
               ]

--- a/.github/workflows/qa-label-management.yml
+++ b/.github/workflows/qa-label-management.yml
@@ -170,7 +170,7 @@ jobs:
                         }
                       ],
                       footer: "Express Milo • System Online",
-                      footer_icon: "https://github.com/adobecom/express-milo/raw/main/express/code/img/favicon.ico"
+                      footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico"
                     }
                   ]
                 };

--- a/.github/workflows/ready-for-review-management.yml
+++ b/.github/workflows/ready-for-review-management.yml
@@ -170,7 +170,7 @@ jobs:
                         }
                       ],
                       footer: "Express Milo • System Online",
-                      footer_icon: "https://github.com/adobecom/express-milo/raw/main/express/code/img/favicon.ico"
+                      footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico"
                     }
                   ]
                 };

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -38,6 +38,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: adobecom/express-milo
+          slug: adobecom/da-express-milo
           files: coverage/lcov.info
 

--- a/.github/workflows/slack-release-notification.yml
+++ b/.github/workflows/slack-release-notification.yml
@@ -182,7 +182,7 @@ jobs:
                   "fields": [
                     {
                       "title": "🌐 Test URLs",
-                      "value": "• <https://main--express-milo--adobecom.aem.page/express|main--express-milo--adobecom.aem.page/express>\n• <https://adobecom.com/express|adobecom.com/express>",
+                      "value": "• <https://main--da-express-milo--adobecom.aem.page/express|main--da-express-milo--adobecom.aem.page/express>\n• <https://adobecom.com/express|adobecom.com/express>",
                       "short": false
                     }
                   ]
@@ -243,7 +243,7 @@ jobs:
                   "fields": [
                     {
                       "title": "🌐 Test URLs",
-                      "value": "• <https://main--express-milo--adobecom.aem.page/express|main--express-milo--adobecom.aem.page/express>\n• <https://adobecom.com/express|adobecom.com/express>",
+                      "value": "• <https://main--da-express-milo--adobecom.aem.page/express|main--da-express-milo--adobecom.aem.page/express>\n• <https://adobecom.com/express|adobecom.com/express>",
                       "short": false
                     }
                   ]

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ This project uses automated workflows for merging to stage and main branches. Un
 #### **Manual Triggers**
 You can manually trigger workflows either via the GitHub UI, or repository dispatch:
 
-https://github.com/adobecom/express-milo/actions
+https://github.com/adobecom/da-express-milo/actions
 
 Dispatch:
 
@@ -193,14 +193,14 @@ Dispatch:
 curl -X POST \
   -H "Authorization: token YOUR_TOKEN" \
   -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/adobecom/express-milo/dispatches \
+  https://api.github.com/repos/adobecom/da-express-milo/dispatches \
   -d '{"event_type":"merge-to-stage"}'
 
 # Trigger merge to main  
 curl -X POST \
   -H "Authorization: token YOUR_TOKEN" \
   -H "Accept: application/vnd.github.v3+json" \
-  https://api.github.com/repos/adobecom/express-milo/dispatches \
+  https://api.github.com/repos/adobecom/da-express-milo/dispatches \
   -d '{"event_type":"merge-to-main"}'
 ```
 

--- a/express/code/blocks/blog-article-marquee/blog-article-marquee.js
+++ b/express/code/blocks/blog-article-marquee/blog-article-marquee.js
@@ -7,7 +7,7 @@ const MOBILE_MAX = 600;
 const TABLET_MAX = 900;
 const HERO_IMAGE_WIDTHS = { mobile: 480, tablet: 720, desktop: 960 };
 const PRECONNECT_DATA_ATTRIBUTE = 'blogArticleMarquee';
-const DEFAULT_PRODUCT_ICON_PATH = 'https://main--express-milo--adobecom.aem.page/express/learn/blog/assets/media_1f021705c13704e1e3041b414d0aa1ce883e067ec.png';
+const DEFAULT_PRODUCT_ICON_PATH = 'https://main--da-express-milo--adobecom.aem.page/express/learn/blog/assets/media_1f021705c13704e1e3041b414d0aa1ce883e067ec.png';
 const PRODUCT_ICON_SIZE = 48;
 
 const METADATA_KEYS = {

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.js
@@ -243,7 +243,7 @@ async function convertCountryLink(block) {
   }
   const { prefix } = getConfig().locale;
   // work around akamai
-  const queryIndexJson = await fetch(`https://stage--express-milo--adobecom.aem.live${prefix}/${country}/express/query-index.json`).then((res) => {
+  const queryIndexJson = await fetch(`https://stage--da-express-milo--adobecom.aem.live${prefix}/${country}/express/query-index.json`).then((res) => {
     if (res.ok) return res.json();
     return null;
   });
@@ -254,7 +254,7 @@ async function convertCountryLink(block) {
     if (queryIndexJson.data.some(({ path }) => path === countrifiedLink)) {
       link.href = countrifiedLink;
       // work around akamai
-      if (link.hostname === 'www.stage.adobe.com') link.hostname = 'stage--express-milo--adobecom.aem.live';
+      if (link.hostname === 'www.stage.adobe.com') link.hostname = 'stage--da-express-milo--adobecom.aem.live';
     }
   });
 }

--- a/nala/assets/urls.txt
+++ b/nala/assets/urls.txt
@@ -1,27 +1,27 @@
 
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-columns/ax-columns-fullsize
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-columns/ax-columns-numbered
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-columns/ax-columns-fullsize
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-columns/ax-columns-numbered
 
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/faq/faq
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/faq/faq
 
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-feature-grid/4-cards
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-feature-grid/4-cards
 
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-fullscreen-marquee/fullscreen-marquee-image
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-fullscreen-marquee/fullscreen-marquee-video
-
-
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-gen-ai-cards/gen-ai-cards
-
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-pricing-cards/pricing-cards-1-col
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-pricing-cards/pricing-cards-2-col
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-pricing-cards/pricing-cards-3-col
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-fullscreen-marquee/fullscreen-marquee-image
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-fullscreen-marquee/fullscreen-marquee-video
 
 
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-how-to-cards/how-to-cards
-https://main--express-milo--adobecom.aem.page/drafts/nala/test-gen/ax-how-to-cards/how-to-cards-schema
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-how-to-cards/how-to-cards-center
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-gen-ai-cards/gen-ai-cards
+
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-pricing-cards/pricing-cards-1-col
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-pricing-cards/pricing-cards-2-col
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-pricing-cards/pricing-cards-3-col
 
 
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-cards/cards-dark
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-cards/card-half-card
-https://main--express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-cards/ax-cards-default
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-how-to-cards/how-to-cards
+https://main--da-express-milo--adobecom.aem.page/drafts/nala/test-gen/ax-how-to-cards/how-to-cards-schema
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-how-to-cards/how-to-cards-center
+
+
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-cards/cards-dark
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-cards/card-half-card
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-cards/ax-cards-default

--- a/nala/old-blocks/blog-article-marquee/blog-article-marquee.spec.cjs
+++ b/nala/old-blocks/blog-article-marquee/blog-article-marquee.spec.cjs
@@ -4,7 +4,7 @@ module.exports = {
     {
       tcid: '0',
       name: '@blog-article-marquee default layout',
-      path: 'https://blog-article-marquee--express-milo--adobecom.aem.live/drafts/nala/blocks/blog-article-marquee/default',
+      path: 'https://blog-article-marquee--da-express-milo--adobecom.aem.live/drafts/nala/blocks/blog-article-marquee/default',
       tags: '@blog-article-marquee @express @smoke @regression',
     },
   ],

--- a/nala/old-blocks/pricing-footer/pricing-footer.spec.cjs
+++ b/nala/old-blocks/pricing-footer/pricing-footer.spec.cjs
@@ -4,7 +4,7 @@ module.exports = {
     {
       tcid: '0',
       name: '@pricing-footer default layout',
-      path: 'https://merch-scale-pricing-footer--express-milo--adobecom.aem.live/drafts/nala/blocks/pricing-footer/pricing-footer-default',
+      path: 'https://merch-scale-pricing-footer--da-express-milo--adobecom.aem.live/drafts/nala/blocks/pricing-footer/pricing-footer-default',
       tags: '@pricing-footer @express @smoke @regression',
     },
   ],


### PR DESCRIPTION
## Summary

Replace hardcoded repo names as part of the migration. Some are PR templates and test files. Long term plan should be to use relative links for those.

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://repo-name-updates--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- All features should not be impacted
