### PR TITLE
Prevent auto-reapplying "Ready for Review" when manually removed

### DIFF
--- a/.github/workflows/qa-label-management.yml
+++ b/.github/workflows/qa-label-management.yml
@@ -54,9 +54,16 @@ jobs:
               // Draft PRs should have no Ready labels
               console.log(`Draft PR - no Ready labels needed`);
             } else {
-              // Ready for Review - default for non-draft PRs
-              targetLabels.push('Ready for Review');
-              console.log(`Adding Ready for Review label`);
+              const userRemovedReady =
+                context.payload.action === 'unlabeled' &&
+                context.payload.label?.name === 'Ready for Review';
+            
+              if (userRemovedReady) {
+                console.log(`User manually removed Ready for Review — not reapplying`);
+              } else {
+                console.log(`Adding Ready for Review label`);
+                targetLabels.push('Ready for Review');
+              }
             }
             
             // Check if labels actually changed to avoid unnecessary operations


### PR DESCRIPTION
**Summary**
This update ensures the QA Label Management bot does not automatically re-add the “Ready for Review” label when a user intentionally removes it.
Previously, the workflow always reapplied the label for any non-draft PR, which caused spammy Slack notifications and label churn.

**What Changed**
The workflow now detects when the PR event is:
action === 'unlabeled' and the removed label is "Ready for Review"
In that case, the bot skips adding the Ready for Review label.
All other behavior remains unchanged (draft PRs get no label, non-draft PRs get the label as usual).

**Why**

Users sometimes remove the Ready for Review label deliberately (review not actually ready, wrong state, etc.).
The bot was immediately reapplying it, which:
Generated duplicate Slack notifications
Overrode user intent
Caused noise in PR label history

This fix respects explicit user action and prevents unnecessary re-labeling and notifications.

**Testing / Verification**
Open non-draft PR → label gets added ✔️
Convert to draft → label removed ✔️
Change from draft → label re-added ✔️
Manually remove Ready for Review → label stays removed ✔️
Slack notifications still fire only when the label is actually added ✔️

**Risk**
Low.
The change is tightly scoped to one condition and does not alter any other label-management or notification logic.