### PR TITLE
Update qa-label-management.yml

### DIFF
--- a/.github/workflows/qa-label-management.yml
+++ b/.github/workflows/qa-label-management.yml
@@ -46,7 +46,7 @@ jobs:
             
             // Start fresh - only keep non-Ready labels
             const targetLabels = currentLabels.filter(label => 
-              !['Ready for Review', 'Ready for review', 'Ready for QA', 'Ready for qa'].includes(label)
+              !['Ready for Review', 'Ready for review'].includes(label)
             );
             
             // Add the correct Ready label based on state


### PR DESCRIPTION
**Summary**

This PR updates the QA Label Management workflow to prevent the unintended removal of the Ready for QA label.

Previously, the workflow filtered out all “ready” labels (Ready for Review and Ready for QA) every time it ran.
Because the workflow triggers on many PR events—including labeled—adding Ready for QA would immediately cause the workflow to run again and delete it.

This change updates the label-filtering logic so that only review-related labels are cleared, leaving Ready for QA untouched.
This ensures that when a developer or QA engineer applies Ready for QA, the label persists and no longer gets overwritten by the automation.

**Test URLs**

(No environment URLs apply — this is a workflow-only change.)

**Verification Steps**

**Before**

Adding Ready for QA to a PR caused the workflow to fire again and automatically remove the label.
The workflow treated Ready for QA the same as Ready for Review, preventing QA from marking PRs appropriately.

**After**

Adding Ready for QA leaves the label in place.
Only Ready for Review labels are managed by the workflow.
No other workflow behavior changes.

**Potential Regressions**

None expected — this update only adjusts how labels are filtered and does not alter Slack notifications or other PR state logic.

**Additional Notes**

If external bots or manual workflows add or remove labels, they may still trigger this workflow.
This PR ensures that the automation itself no longer removes Ready for QA unless explicitly directed to do so in the future.