### PR TITLE
Update qa-label-management.yml

### DIFF
--- a/.github/workflows/qa-label-management.yml
+++ b/.github/workflows/qa-label-management.yml
@@ -54,12 +54,21 @@ jobs:
               // Draft PRs should have no Ready labels
               console.log(`Draft PR - no Ready labels needed`);
             } else {
+             // Check if PR has progressed past review stage (has QA labels)
+              const qaProgressionLabels = ['Ready for QA', 'ready for qa', 'QA Approved', 'qa approved'];
+              const hasQaLabel = currentLabels.some(label => 
+                qaProgressionLabels.some(qaLabel => label.toLowerCase() === qaLabel.toLowerCase())
+              );
+              
               const userRemovedReady =
                 context.payload.action === 'unlabeled' &&
                 context.payload.label?.name === 'Ready for Review';
             
               if (userRemovedReady) {
                 console.log(`User manually removed Ready for Review — not reapplying`);
+              } else if (hasQaLabel) {
+                // PR has progressed to QA stage - don't add Ready for Review
+                console.log(`PR has QA label(s) - not adding Ready for Review (PR has progressed past review stage)`);
               } else {
                 console.log(`Adding Ready for Review label`);
                 targetLabels.push('Ready for Review');


### PR DESCRIPTION
**Summary**
Fixes a bug in the QA Label Management workflow where the bot would automatically re-add the "Ready for Review" label when a user added QA-stage labels ("Ready for QA" or "QA Approved"). The workflow now recognizes when a PR has progressed past the review stage and respects the label progression flow.

**Jira Ticket**
Resolves: N/A (Internal workflow fix)

**Test URLs**
N/A - This is a GitHub Actions workflow change, not a page change.

**Verification Steps**
Open any non-draft PR
Add the "Ready for QA" label and remove the "Ready for Review" label
Before: The bot would automatically re-add the "Ready for Review" label
After: The "Ready for Review" label stays removed because the PR has progressed to the QA stage
Additional scenario:

On a PR with "Ready for QA" label, add "QA Approved" and remove "Ready for QA"
Before: The bot would add "Ready for Review" label
After: The "Ready for Review" label is not added because "QA Approved" indicates the PR has progressed past review

**Potential Regressions**

*PRs that are converted from draft to ready-for-review should still get the "Ready for Review" label automatically (unchanged behavior)
*New PRs should still get the "Ready for Review" label automatically (unchanged behavior)

**Additional Notes**
*The fix adds a check for QA progression labels (Ready for QA, QA Approved) before adding the "Ready for Review" label. *This respects the natural PR workflow progression:
*Ready for Review → Ready for QA → QA Approved