### PR TITLE
Jsandland patch 6

### DIFF
--- a/.github/workflows/add-ready-for-review-label.yml
+++ b/.github/workflows/add-ready-for-review-label.yml
@@ -1,0 +1,30 @@
+name: Add Ready for Review Label
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label to new PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo, number } = context.issue;
+            const isDraft = context.payload.pull_request.draft;
+            
+            if (isDraft) {
+              console.log(`PR #${number} is a draft - skipping`);
+              return;
+            }
+            
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: number,
+              labels: ['Ready for Review']
+            });
+            console.log(`✅ Added Ready for Review label to PR #${number}`);
+

--- a/.github/workflows/add-ready-for-review-label.yml
+++ b/.github/workflows/add-ready-for-review-label.yml
@@ -1,30 +1,30 @@
-name: Add Ready for Review Label
+# name: Add Ready for Review Label
 
-on:
-  pull_request:
-    types: [opened]
+# on:
+#   pull_request:
+#     types: [opened]
 
-jobs:
-  add-label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add label to new PRs
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo, number } = context.issue;
-            const isDraft = context.payload.pull_request.draft;
+# jobs:
+#   add-label:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Add label to new PRs
+#         uses: actions/github-script@v7
+#         with:
+#           script: |
+#             const { owner, repo, number } = context.issue;
+#             const isDraft = context.payload.pull_request.draft;
             
-            if (isDraft) {
-              console.log(`PR #${number} is a draft - skipping`);
-              return;
-            }
+#             if (isDraft) {
+#               console.log(`PR #${number} is a draft - skipping`);
+#               return;
+#             }
             
-            await github.rest.issues.addLabels({
-              owner,
-              repo,
-              issue_number: number,
-              labels: ['Ready for Review']
-            });
-            console.log(`✅ Added Ready for Review label to PR #${number}`);
+#             await github.rest.issues.addLabels({
+#               owner,
+#               repo,
+#               issue_number: number,
+#               labels: ['Ready for Review']
+#             });
+#             console.log(`✅ Added Ready for Review label to PR #${number}`);
 

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -1,0 +1,37 @@
+name: Add Ready for Review Label + Slack Notification
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label and send Slack notification
+        uses: actions/github-script@v7
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL_PR }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            
+            if (pr.draft) return;
+            
+            // Add label
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: ['Ready for Review']
+            });
+            
+            // Notify Slack
+            if (process.env.SLACK_WEBHOOK) {
+              await fetch(process.env.SLACK_WEBHOOK, {
+                method: 'POST',
+                body: JSON.stringify({
+                  text: `🔔 <${pr.html_url}|${pr.title}> by ${pr.user.login}`
+                })
+              });
+            }
+

--- a/.github/workflows/qa-label-management.yml
+++ b/.github/workflows/qa-label-management.yml
@@ -1,211 +1,211 @@
-name: QA Label Management
+# name: QA Label Management
 
-on:
-  pull_request:
-    types: [opened, edited, ready_for_review, converted_to_draft, labeled, unlabeled, synchronize, reopened]
+# on:
+#   pull_request:
+#     types: [opened, edited, ready_for_review, converted_to_draft, labeled, unlabeled, synchronize, reopened]
 
-jobs:
-  manage-labels:
-    name: Manage All PR Labels
-    runs-on: ubuntu-latest
-    steps:
-      - name: Manage labels based on PR state and approvals
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo, number } = context.issue;
+# jobs:
+#   manage-labels:
+#     name: Manage All PR Labels
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Manage labels based on PR state and approvals
+#         uses: actions/github-script@v7
+#         with:
+#           script: |
+#             const { owner, repo, number } = context.issue;
             
-            console.log(`Workflow triggered for PR #${number}, action: ${context.payload.action}`);
+#             console.log(`Workflow triggered for PR #${number}, action: ${context.payload.action}`);
             
-            // Get PR details with error handling
-            let pr;
-            try {
-              pr = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: number
-              });
-              console.log(`Successfully retrieved PR #${number} details`);
-            } catch (error) {
-              console.log(`❌ Failed to get PR details: ${error.message}`);
-              if (error.status === 404) {
-                console.log(`PR #${number} not found - may have been deleted`);
-              } else if (error.status === 403) {
-                console.log(`Insufficient permissions to access PR #${number}`);
-              }
-              return; // Exit gracefully
-            }
+#             // Get PR details with error handling
+#             let pr;
+#             try {
+#               pr = await github.rest.pulls.get({
+#                 owner,
+#                 repo,
+#                 pull_number: number
+#               });
+#               console.log(`Successfully retrieved PR #${number} details`);
+#             } catch (error) {
+#               console.log(`❌ Failed to get PR details: ${error.message}`);
+#               if (error.status === 404) {
+#                 console.log(`PR #${number} not found - may have been deleted`);
+#               } else if (error.status === 403) {
+#                 console.log(`Insufficient permissions to access PR #${number}`);
+#               }
+#               return; // Exit gracefully
+#             }
             
-            // No approval checking needed - just Ready for Review
+#             // No approval checking needed - just Ready for Review
             
-            const currentLabels = pr.data.labels.map(label => label.name);
-            const isDraft = pr.data.draft;
+#             const currentLabels = pr.data.labels.map(label => label.name);
+#             const isDraft = pr.data.draft;
             
-            console.log(`Current labels on PR #${number}:`, currentLabels);
-            console.log(`Is draft: ${isDraft}`);
+#             console.log(`Current labels on PR #${number}:`, currentLabels);
+#             console.log(`Is draft: ${isDraft}`);
             
-            // Start fresh - only keep non-Ready labels
-            const targetLabels = currentLabels.filter(label => 
-              !['Ready for Review', 'Ready for review'].includes(label)
-            );
+#             // Start fresh - only keep non-Ready labels
+#             const targetLabels = currentLabels.filter(label => 
+#               !['Ready for Review', 'Ready for review'].includes(label)
+#             );
             
-            // Add the correct Ready label based on state
-            if (isDraft) {
-              // Draft PRs should have no Ready labels
-              console.log(`Draft PR - no Ready labels needed`);
-            } else {
-              const userRemovedReady =
-                context.payload.action === 'unlabeled' &&
-                context.payload.label?.name === 'Ready for Review';
+#             // Add the correct Ready label based on state
+#             if (isDraft) {
+#               // Draft PRs should have no Ready labels
+#               console.log(`Draft PR - no Ready labels needed`);
+#             } else {
+#               const userRemovedReady =
+#                 context.payload.action === 'unlabeled' &&
+#                 context.payload.label?.name === 'Ready for Review';
             
-              if (userRemovedReady) {
-                console.log(`User manually removed Ready for Review — not reapplying`);
-              } else {
-                console.log(`Adding Ready for Review label`);
-                targetLabels.push('Ready for Review');
-              }
-            }
+#               if (userRemovedReady) {
+#                 console.log(`User manually removed Ready for Review — not reapplying`);
+#               } else {
+#                 console.log(`Adding Ready for Review label`);
+#                 targetLabels.push('Ready for Review');
+#               }
+#             }
             
-            // Check if labels actually changed to avoid unnecessary operations
-            const currentReadyLabels = currentLabels.filter(label => 
-              label.includes('Ready for')
-            );
-            const targetReadyLabels = targetLabels.filter(label => 
-              label.includes('Ready for')
-            );
+#             // Check if labels actually changed to avoid unnecessary operations
+#             const currentReadyLabels = currentLabels.filter(label => 
+#               label.includes('Ready for')
+#             );
+#             const targetReadyLabels = targetLabels.filter(label => 
+#               label.includes('Ready for')
+#             );
             
-            // More efficient label comparison
-            const labelsChanged = currentReadyLabels.length !== targetReadyLabels.length || 
-              !currentReadyLabels.every(label => targetReadyLabels.includes(label));
+#             // More efficient label comparison
+#             const labelsChanged = currentReadyLabels.length !== targetReadyLabels.length || 
+#               !currentReadyLabels.every(label => targetReadyLabels.includes(label));
             
-            if (labelsChanged) {
-              console.log(`Labels changed: ${currentReadyLabels.join(', ')} → ${targetReadyLabels.join(', ')}`);
+#             if (labelsChanged) {
+#               console.log(`Labels changed: ${currentReadyLabels.join(', ')} → ${targetReadyLabels.join(', ')}`);
               
-              // Set the exact label list with error handling
-              try {
-                await github.rest.issues.setLabels({
-                  owner,
-                  repo,
-                  issue_number: number,
-                  labels: targetLabels
-                });
-                console.log(`✅ Successfully set labels to: ${targetLabels.join(', ')}`);
-              } catch (error) {
-                console.log(`❌ Failed to set labels: ${error.message}`);
-                if (error.status === 404) {
-                  console.log(`PR #${number} not found - may have been deleted`);
-                } else if (error.status === 403) {
-                  console.log(`Insufficient permissions to modify labels on PR #${number}`);
-                } else if (error.status === 422) {
-                  console.log(`Invalid label data provided: ${JSON.stringify(targetLabels)}`);
-                }
-                return; // Exit gracefully
-              }
-            } else {
-              console.log(`No label changes needed - Ready labels already correct`);
-            }
+#               // Set the exact label list with error handling
+#               try {
+#                 await github.rest.issues.setLabels({
+#                   owner,
+#                   repo,
+#                   issue_number: number,
+#                   labels: targetLabels
+#                 });
+#                 console.log(`✅ Successfully set labels to: ${targetLabels.join(', ')}`);
+#               } catch (error) {
+#                 console.log(`❌ Failed to set labels: ${error.message}`);
+#                 if (error.status === 404) {
+#                   console.log(`PR #${number} not found - may have been deleted`);
+#                 } else if (error.status === 403) {
+#                   console.log(`Insufficient permissions to modify labels on PR #${number}`);
+#                 } else if (error.status === 422) {
+#                   console.log(`Invalid label data provided: ${JSON.stringify(targetLabels)}`);
+#                 }
+#                 return; // Exit gracefully
+#               }
+#             } else {
+#               console.log(`No label changes needed - Ready labels already correct`);
+#             }
             
-            // Send Slack notification only when "Ready for Review" label is actually added
-            if (!isDraft && targetLabels.includes('Ready for Review') && labelsChanged) {
-              console.log(`Sending Ready for Review notification...`);
-              await sendSlackNotification(pr.data);
-            }
+#             // Send Slack notification only when "Ready for Review" label is actually added
+#             if (!isDraft && targetLabels.includes('Ready for Review') && labelsChanged) {
+#               console.log(`Sending Ready for Review notification...`);
+#               await sendSlackNotification(pr.data);
+#             }
             
-            // No approval checking functions needed - simplified to just Ready for Review
+#             // No approval checking functions needed - simplified to just Ready for Review
             
-            // Helper function to escape JSON special characters
-            function escapeJson(str) {
-              return str
-                .replace(/\\/g, '\\\\')
-                .replace(/"/g, '\\"')
-                .replace(/\n/g, '\\n')
-                .replace(/\r/g, '\\r')
-                .replace(/\t/g, '\\t');
-            }
+#             // Helper function to escape JSON special characters
+#             function escapeJson(str) {
+#               return str
+#                 .replace(/\\/g, '\\\\')
+#                 .replace(/"/g, '\\"')
+#                 .replace(/\n/g, '\\n')
+#                 .replace(/\r/g, '\\r')
+#                 .replace(/\t/g, '\\t');
+#             }
             
-            // Helper function to send Slack notification
-            async function sendSlackNotification(prData) {
-              try {
-                const title = prData.title;
-                const author = prData.user.login;
-                const url = prData.html_url;
-                const branch = prData.head.ref;
-                const baseBranch = prData.base.ref;
+#             // Helper function to send Slack notification
+#             async function sendSlackNotification(prData) {
+#               try {
+#                 const title = prData.title;
+#                 const author = prData.user.login;
+#                 const url = prData.html_url;
+#                 const branch = prData.head.ref;
+#                 const baseBranch = prData.base.ref;
                 
-                // Extract Jira ticket if present
-                let jiraTicket = null;
-                const titleMatch = title.match(/(MWPW-\d+)/);
-                if (titleMatch) {
-                  jiraTicket = titleMatch[1];
-                } else {
-                  const bodyMatch = (prData.body || '').match(/(MWPW-\d+)/);
-                  if (bodyMatch) {
-                    jiraTicket = bodyMatch[1];
-                  }
-                }
+#                 // Extract Jira ticket if present
+#                 let jiraTicket = null;
+#                 const titleMatch = title.match(/(MWPW-\d+)/);
+#                 if (titleMatch) {
+#                   jiraTicket = titleMatch[1];
+#                 } else {
+#                   const bodyMatch = (prData.body || '').match(/(MWPW-\d+)/);
+#                   if (bodyMatch) {
+#                     jiraTicket = bodyMatch[1];
+#                   }
+#                 }
                 
-                // Format the message
-                const displayTitle = jiraTicket ? `${jiraTicket}: ${title.replace(`${jiraTicket}: `, '')}` : title;
-                const jiraLink = jiraTicket ? `\n🔗 <https://jira.corp.adobe.com/browse/${jiraTicket}|${jiraTicket}>` : '';
+#                 // Format the message
+#                 const displayTitle = jiraTicket ? `${jiraTicket}: ${title.replace(`${jiraTicket}: `, '')}` : title;
+#                 const jiraLink = jiraTicket ? `\n🔗 <https://jira.corp.adobe.com/browse/${jiraTicket}|${jiraTicket}>` : '';
                 
-                const isTestMode = prData.head.ref === 'feature/pr-label-management';
-                const message = {
-                  text: `@ax-devs 🚀 *CODE DEPLOYED*${isTestMode ? ' [TEST_MODE]' : ''} - Ready for Review`,
-                  attachments: [
-                    {
-                      color: isTestMode ? "#ff6b35" : "#00ff00",
-                      fields: [
-                        {
-                          title: "💻 TARGET",
-                          value: escapeJson(displayTitle),
-                          short: false
-                        },
-                        {
-                          title: "👨‍💻 HACKER",
-                          value: escapeJson(author),
-                          short: true
-                        },
-                        {
-                          title: "🌐 ROUTE",
-                          value: escapeJson(`\`${branch}\` → \`${baseBranch}\``),
-                          short: true
-                        },
-                        {
-                          title: "🔗 ACCESS_POINT",
-                          value: escapeJson(`<${url}|PR #${prData.number}>${jiraLink}`),
-                          short: false
-                        }
-                      ],
-                      footer: "Express Milo • System Online",
-                      footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico"
-                    }
-                  ]
-                };
+#                 const isTestMode = prData.head.ref === 'feature/pr-label-management';
+#                 const message = {
+#                   text: `@ax-devs 🚀 *CODE DEPLOYED*${isTestMode ? ' [TEST_MODE]' : ''} - Ready for Review`,
+#                   attachments: [
+#                     {
+#                       color: isTestMode ? "#ff6b35" : "#00ff00",
+#                       fields: [
+#                         {
+#                           title: "💻 TARGET",
+#                           value: escapeJson(displayTitle),
+#                           short: false
+#                         },
+#                         {
+#                           title: "👨‍💻 HACKER",
+#                           value: escapeJson(author),
+#                           short: true
+#                         },
+#                         {
+#                           title: "🌐 ROUTE",
+#                           value: escapeJson(`\`${branch}\` → \`${baseBranch}\``),
+#                           short: true
+#                         },
+#                         {
+#                           title: "🔗 ACCESS_POINT",
+#                           value: escapeJson(`<${url}|PR #${prData.number}>${jiraLink}`),
+#                           short: false
+#                         }
+#                       ],
+#                       footer: "Express Milo • System Online",
+#                       footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico"
+#                     }
+#                   ]
+#                 };
                 
-                // Send to Slack
-                const webhookUrl = process.env.SLACK_WEBHOOK_URL;
-                if (!webhookUrl) {
-                  console.log('❌ SLACK_WEBHOOK_URL not configured');
-                  return;
-                }
+#                 // Send to Slack
+#                 const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+#                 if (!webhookUrl) {
+#                   console.log('❌ SLACK_WEBHOOK_URL not configured');
+#                   return;
+#                 }
                 
-                const response = await fetch(webhookUrl, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                  body: JSON.stringify(message)
-                });
+#                 const response = await fetch(webhookUrl, {
+#                   method: 'POST',
+#                   headers: {
+#                     'Content-Type': 'application/json',
+#                   },
+#                   body: JSON.stringify(message)
+#                 });
                 
-                if (response.ok) {
-                  console.log('✅ Ready for Review notification sent successfully');
-                } else {
-                  console.log(`❌ Failed to send notification: ${response.status} ${response.statusText}`);
-                }
-              } catch (error) {
-                console.log(`❌ Error sending notification: ${error.message}`);
-              }
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ github.event.pull_request.head.ref == 'feature/pr-label-management' && secrets.SLACK_WEBHOOK_URL_PR_TEST || secrets.SLACK_WEBHOOK_URL_PR }}
+#                 if (response.ok) {
+#                   console.log('✅ Ready for Review notification sent successfully');
+#                 } else {
+#                   console.log(`❌ Failed to send notification: ${response.status} ${response.statusText}`);
+#                 }
+#               } catch (error) {
+#                 console.log(`❌ Error sending notification: ${error.message}`);
+#               }
+#             }
+#         env:
+#           SLACK_WEBHOOK_URL: ${{ github.event.pull_request.head.ref == 'feature/pr-label-management' && secrets.SLACK_WEBHOOK_URL_PR_TEST || secrets.SLACK_WEBHOOK_URL_PR }}
 

--- a/.github/workflows/ready-for-review-management.yml
+++ b/.github/workflows/ready-for-review-management.yml
@@ -1,203 +1,203 @@
-name: Ready for Review Label Management
+# name: Ready for Review Label Management
 
-on:
-  pull_request:
-    types: [opened, ready_for_review, converted_to_draft, reopened]
+# on:
+#   pull_request:
+#     types: [opened, ready_for_review, converted_to_draft, reopened]
 
-jobs:
-  manage-labels:
-    name: Manage Ready for Review Labels
-    runs-on: ubuntu-latest
-    steps:
-      - name: Manage Ready for Review labels based on PR state
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo, number } = context.issue;
+# jobs:
+#   manage-labels:
+#     name: Manage Ready for Review Labels
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Manage Ready for Review labels based on PR state
+#         uses: actions/github-script@v7
+#         with:
+#           script: |
+#             const { owner, repo, number } = context.issue;
             
-            console.log(`Workflow triggered for PR #${number}, action: ${context.payload.action}`);
+#             console.log(`Workflow triggered for PR #${number}, action: ${context.payload.action}`);
             
-            // Only handle draft ↔ non-draft transitions
-            // All manual label changes are respected and ignored
+#             // Only handle draft ↔ non-draft transitions
+#             // All manual label changes are respected and ignored
 
-            // Get PR details with error handling
-            let pr;
-            try {
-              pr = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: number
-              });
-              console.log(`Successfully retrieved PR #${number} details`);
-            } catch (error) {
-              console.log(`❌ Failed to get PR details: ${error.message}`);
-              if (error.status === 404) {
-                console.log(`PR #${number} not found - may have been deleted`);
-              } else if (error.status === 403) {
-                console.log(`Insufficient permissions to access PR #${number}`);
-              }
-              return; // Exit gracefully
-            }
+#             // Get PR details with error handling
+#             let pr;
+#             try {
+#               pr = await github.rest.pulls.get({
+#                 owner,
+#                 repo,
+#                 pull_number: number
+#               });
+#               console.log(`Successfully retrieved PR #${number} details`);
+#             } catch (error) {
+#               console.log(`❌ Failed to get PR details: ${error.message}`);
+#               if (error.status === 404) {
+#                 console.log(`PR #${number} not found - may have been deleted`);
+#               } else if (error.status === 403) {
+#                 console.log(`Insufficient permissions to access PR #${number}`);
+#               }
+#               return; // Exit gracefully
+#             }
             
-            const currentLabels = pr.data.labels.map(label => label.name);
-            const isDraft = pr.data.draft;
-            const action = context.payload.action;
+#             const currentLabels = pr.data.labels.map(label => label.name);
+#             const isDraft = pr.data.draft;
+#             const action = context.payload.action;
             
-            console.log(`Current labels on PR #${number}:`, currentLabels);
-            console.log(`Is draft: ${isDraft}, Action: ${action}`);
+#             console.log(`Current labels on PR #${number}:`, currentLabels);
+#             console.log(`Is draft: ${isDraft}, Action: ${action}`);
             
-            // Only handle specific draft ↔ non-draft transitions
-            if (action === 'opened') {
-              // New PR opened - add Ready for Review if not draft
-              if (!isDraft) {
-                console.log(`New PR opened (non-draft) - adding Ready for Review label`);
-                const targetLabels = [...currentLabels, 'Ready for Review'];
-                await setLabels(owner, repo, number, targetLabels);
-                await sendSlackNotification(pr.data);
-              } else {
-                console.log(`New PR opened (draft) - no Ready for Review label needed`);
-              }
-            } else if (action === 'ready_for_review') {
-              // PR converted from draft to ready - add Ready for Review label
-              console.log(`PR marked ready for review - adding Ready for Review label`);
-              const targetLabels = [...currentLabels, 'Ready for Review'];
-              await setLabels(owner, repo, number, targetLabels);
-              await sendSlackNotification(pr.data);
-            } else if (action === 'converted_to_draft') {
-              // PR converted back to draft - remove Ready for Review labels
-              console.log(`PR converted to draft - removing Ready for Review labels`);
-              const targetLabels = currentLabels.filter(label => 
-                !['Ready for Review', 'Ready for review'].includes(label)
-              );
-              await setLabels(owner, repo, number, targetLabels);
-            } else if (action === 'reopened') {
-              // PR reopened - add Ready for Review if not draft
-              if (!isDraft) {
-                console.log(`PR reopened (non-draft) - adding Ready for Review label`);
-                const targetLabels = [...currentLabels, 'Ready for Review'];
-                await setLabels(owner, repo, number, targetLabels);
-                await sendSlackNotification(pr.data);
-              } else {
-                console.log(`PR reopened (draft) - no Ready for Review label needed`);
-              }
-            }
+#             // Only handle specific draft ↔ non-draft transitions
+#             if (action === 'opened') {
+#               // New PR opened - add Ready for Review if not draft
+#               if (!isDraft) {
+#                 console.log(`New PR opened (non-draft) - adding Ready for Review label`);
+#                 const targetLabels = [...currentLabels, 'Ready for Review'];
+#                 await setLabels(owner, repo, number, targetLabels);
+#                 await sendSlackNotification(pr.data);
+#               } else {
+#                 console.log(`New PR opened (draft) - no Ready for Review label needed`);
+#               }
+#             } else if (action === 'ready_for_review') {
+#               // PR converted from draft to ready - add Ready for Review label
+#               console.log(`PR marked ready for review - adding Ready for Review label`);
+#               const targetLabels = [...currentLabels, 'Ready for Review'];
+#               await setLabels(owner, repo, number, targetLabels);
+#               await sendSlackNotification(pr.data);
+#             } else if (action === 'converted_to_draft') {
+#               // PR converted back to draft - remove Ready for Review labels
+#               console.log(`PR converted to draft - removing Ready for Review labels`);
+#               const targetLabels = currentLabels.filter(label => 
+#                 !['Ready for Review', 'Ready for review'].includes(label)
+#               );
+#               await setLabels(owner, repo, number, targetLabels);
+#             } else if (action === 'reopened') {
+#               // PR reopened - add Ready for Review if not draft
+#               if (!isDraft) {
+#                 console.log(`PR reopened (non-draft) - adding Ready for Review label`);
+#                 const targetLabels = [...currentLabels, 'Ready for Review'];
+#                 await setLabels(owner, repo, number, targetLabels);
+#                 await sendSlackNotification(pr.data);
+#               } else {
+#                 console.log(`PR reopened (draft) - no Ready for Review label needed`);
+#               }
+#             }
             
-            // Helper function to set labels with error handling
-            async function setLabels(owner, repo, number, labels) {
-              try {
-                await github.rest.issues.setLabels({
-                  owner,
-                  repo,
-                  issue_number: number,
-                  labels: labels
-                });
-                console.log(`✅ Successfully set labels to: ${labels.join(', ')}`);
-              } catch (error) {
-                console.log(`❌ Failed to set labels: ${error.message}`);
-                if (error.status === 404) {
-                  console.log(`PR #${number} not found - may have been deleted`);
-                } else if (error.status === 403) {
-                  console.log(`Insufficient permissions to modify labels on PR #${number}`);
-                } else if (error.status === 422) {
-                  console.log(`Invalid label data provided: ${JSON.stringify(labels)}`);
-                }
-              }
-            }
+#             // Helper function to set labels with error handling
+#             async function setLabels(owner, repo, number, labels) {
+#               try {
+#                 await github.rest.issues.setLabels({
+#                   owner,
+#                   repo,
+#                   issue_number: number,
+#                   labels: labels
+#                 });
+#                 console.log(`✅ Successfully set labels to: ${labels.join(', ')}`);
+#               } catch (error) {
+#                 console.log(`❌ Failed to set labels: ${error.message}`);
+#                 if (error.status === 404) {
+#                   console.log(`PR #${number} not found - may have been deleted`);
+#                 } else if (error.status === 403) {
+#                   console.log(`Insufficient permissions to modify labels on PR #${number}`);
+#                 } else if (error.status === 422) {
+#                   console.log(`Invalid label data provided: ${JSON.stringify(labels)}`);
+#                 }
+#               }
+#             }
             
-            // Only manages Ready for Review labels - QA labels are not touched
+#             // Only manages Ready for Review labels - QA labels are not touched
             
-            // Helper function to escape JSON special characters
-            function escapeJson(str) {
-              return str
-                .replace(/\\/g, '\\\\')
-                .replace(/"/g, '\\"')
-                .replace(/\n/g, '\\n')
-                .replace(/\r/g, '\\r')
-                .replace(/\t/g, '\\t');
-            }
+#             // Helper function to escape JSON special characters
+#             function escapeJson(str) {
+#               return str
+#                 .replace(/\\/g, '\\\\')
+#                 .replace(/"/g, '\\"')
+#                 .replace(/\n/g, '\\n')
+#                 .replace(/\r/g, '\\r')
+#                 .replace(/\t/g, '\\t');
+#             }
             
-            // Helper function to send Slack notification
-            async function sendSlackNotification(prData) {
-              try {
-                const title = prData.title;
-                const author = prData.user.login;
-                const url = prData.html_url;
-                const branch = prData.head.ref;
-                const baseBranch = prData.base.ref;
+#             // Helper function to send Slack notification
+#             async function sendSlackNotification(prData) {
+#               try {
+#                 const title = prData.title;
+#                 const author = prData.user.login;
+#                 const url = prData.html_url;
+#                 const branch = prData.head.ref;
+#                 const baseBranch = prData.base.ref;
                 
-                // Extract Jira ticket if present
-                let jiraTicket = null;
-                const titleMatch = title.match(/(MWPW-\d+)/);
-                if (titleMatch) {
-                  jiraTicket = titleMatch[1];
-                } else {
-                  const bodyMatch = (prData.body || '').match(/(MWPW-\d+)/);
-                  if (bodyMatch) {
-                    jiraTicket = bodyMatch[1];
-                  }
-                }
+#                 // Extract Jira ticket if present
+#                 let jiraTicket = null;
+#                 const titleMatch = title.match(/(MWPW-\d+)/);
+#                 if (titleMatch) {
+#                   jiraTicket = titleMatch[1];
+#                 } else {
+#                   const bodyMatch = (prData.body || '').match(/(MWPW-\d+)/);
+#                   if (bodyMatch) {
+#                     jiraTicket = bodyMatch[1];
+#                   }
+#                 }
                 
-                // Format the message
-                const displayTitle = jiraTicket ? `${jiraTicket}: ${title.replace(`${jiraTicket}: `, '')}` : title;
-                const jiraLink = jiraTicket ? `\n🔗 <https://jira.corp.adobe.com/browse/${jiraTicket}|${jiraTicket}>` : '';
+#                 // Format the message
+#                 const displayTitle = jiraTicket ? `${jiraTicket}: ${title.replace(`${jiraTicket}: `, '')}` : title;
+#                 const jiraLink = jiraTicket ? `\n🔗 <https://jira.corp.adobe.com/browse/${jiraTicket}|${jiraTicket}>` : '';
                 
-                const isTestMode = prData.head.ref === 'feature/pr-label-management';
-                const message = {
-                  text: `@here 🚀 *CODE DEPLOYED*${isTestMode ? ' [TEST_MODE]' : ''} - Ready for Review`,
-                  attachments: [
-                    {
-                      color: isTestMode ? "#ff6b35" : "#00ff00",
-                      fields: [
-                        {
-                          title: "💻 TARGET",
-                          value: escapeJson(displayTitle),
-                          short: false
-                        },
-                        {
-                          title: "👨‍💻 HACKER",
-                          value: escapeJson(author),
-                          short: true
-                        },
-                        {
-                          title: "🌐 ROUTE",
-                          value: escapeJson(`\`${branch}\` → \`${baseBranch}\``),
-                          short: true
-                        },
-                        {
-                          title: "🔗 ACCESS_POINT",
-                          value: escapeJson(`<${url}|PR #${prData.number}>${jiraLink}`),
-                          short: false
-                        }
-                      ],
-                      footer: "Express Milo • System Online",
-                      footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico"
-                    }
-                  ]
-                };
+#                 const isTestMode = prData.head.ref === 'feature/pr-label-management';
+#                 const message = {
+#                   text: `@here 🚀 *CODE DEPLOYED*${isTestMode ? ' [TEST_MODE]' : ''} - Ready for Review`,
+#                   attachments: [
+#                     {
+#                       color: isTestMode ? "#ff6b35" : "#00ff00",
+#                       fields: [
+#                         {
+#                           title: "💻 TARGET",
+#                           value: escapeJson(displayTitle),
+#                           short: false
+#                         },
+#                         {
+#                           title: "👨‍💻 HACKER",
+#                           value: escapeJson(author),
+#                           short: true
+#                         },
+#                         {
+#                           title: "🌐 ROUTE",
+#                           value: escapeJson(`\`${branch}\` → \`${baseBranch}\``),
+#                           short: true
+#                         },
+#                         {
+#                           title: "🔗 ACCESS_POINT",
+#                           value: escapeJson(`<${url}|PR #${prData.number}>${jiraLink}`),
+#                           short: false
+#                         }
+#                       ],
+#                       footer: "Express Milo • System Online",
+#                       footer_icon: "https://github.com/adobecom/da-express-milo/raw/main/express/code/img/favicon.ico"
+#                     }
+#                   ]
+#                 };
                 
-                // Send to Slack
-                const webhookUrl = process.env.SLACK_WEBHOOK_URL_PR;
-                if (!webhookUrl) {
-                  console.log('❌ SLACK_WEBHOOK_URL_PR not configured');
-                  return;
-                }
+#                 // Send to Slack
+#                 const webhookUrl = process.env.SLACK_WEBHOOK_URL_PR;
+#                 if (!webhookUrl) {
+#                   console.log('❌ SLACK_WEBHOOK_URL_PR not configured');
+#                   return;
+#                 }
                 
-                const response = await fetch(webhookUrl, {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                  body: JSON.stringify(message)
-                });
+#                 const response = await fetch(webhookUrl, {
+#                   method: 'POST',
+#                   headers: {
+#                     'Content-Type': 'application/json',
+#                   },
+#                   body: JSON.stringify(message)
+#                 });
                 
-                if (response.ok) {
-                  console.log('✅ Ready for Review notification sent successfully');
-                } else {
-                  console.log(`❌ Failed to send notification: ${response.status} ${response.statusText}`);
-                }
-              } catch (error) {
-                console.log(`❌ Error sending notification: ${error.message}`);
-              }
-            }
-        env:
-          SLACK_WEBHOOK_URL_PR: ${{ github.event.pull_request.head.ref == 'feature/pr-label-management' && secrets.SLACK_WEBHOOK_URL_PR_TEST || secrets.SLACK_WEBHOOK_URL_PR }}
+#                 if (response.ok) {
+#                   console.log('✅ Ready for Review notification sent successfully');
+#                 } else {
+#                   console.log(`❌ Failed to send notification: ${response.status} ${response.statusText}`);
+#                 }
+#               } catch (error) {
+#                 console.log(`❌ Error sending notification: ${error.message}`);
+#               }
+#             }
+#         env:
+#           SLACK_WEBHOOK_URL_PR: ${{ github.event.pull_request.head.ref == 'feature/pr-label-management' && secrets.SLACK_WEBHOOK_URL_PR_TEST || secrets.SLACK_WEBHOOK_URL_PR }}


### PR DESCRIPTION
## Summary

Simplifies PR label management to a single, focused workflow. When a new PR is opened (non-draft), the "Ready for Review" label is automatically added. No other automation or interference with manual label changes.

**Changes:**
- Created `add-ready-for-review-label.yml` - simple workflow that adds label on PR open
- Commented out `qa-label-management.yml` - was causing label conflicts
- Commented out `ready-for-review-management.yml` - duplicate workflow

---

## Jira Ticket

N/A (Internal workflow fix)

---

## Test URLs

N/A - GitHub Actions workflow change, not a page change.

---

## Verification Steps

1. Open a new non-draft PR
2. **Expected:** "Ready for Review" label is automatically added
3. Manually remove the label
4. Push a commit or edit the PR
5. **Expected:** Label stays removed (no re-adding)

---

## Potential Regressions

- Draft PRs should NOT get the label (unchanged)
- Manual label changes are now fully respected

---

## Additional Notes

Previously, the label management workflows were interfering with manual label changes. When users added "Ready for QA" and removed "Ready for Review", the bot would re-add "Ready for Review". 

This simplification reduces ~500+ lines of workflow code down to ~30 lines with a single responsibility: add label when PR is opened.