### PR TITLE
allow authors control of additional query params for template-x-carousel

### DIFF
--- a/express/code/blocks/template-list/template-list.js
+++ b/express/code/blocks/template-list/template-list.js
@@ -255,7 +255,9 @@ async function fetchBlueprint(pathname) {
 
 function populateTemplates(block, templates, props) {
   for (let tmplt of templates) {
-    const isPlaceholder = tmplt.querySelector(':scope > div:first-of-type > img[src*=".svg"], :scope > div:first-of-type > svg');
+    const isPlaceholder = tmplt.querySelector(
+      ':scope > div:first-of-type > img[src*=".svg"], :scope > div:first-of-type > img[src^="data:image/svg+xml"], :scope > div:first-of-type > svg',
+    );
     const linkContainer = tmplt.querySelector(':scope > div:nth-of-type(2)');
     const rowWithLinkInFirstCol = tmplt.querySelector(':scope > div:first-of-type > a');
 
@@ -1739,7 +1741,9 @@ export async function decorateTemplateList(block, props) {
     && block.classList.contains('mini')) {
     const links = block.querySelectorAll('a:any-link');
     links.forEach((link) => {
-      const isPlaceholder = link.querySelector(':scope > div:first-of-type > img[src*=".svg"], :scope > div:first-of-type > svg');
+      const isPlaceholder = link.querySelector(
+        ':scope > div:first-of-type > img[src*=".svg"], :scope > div:first-of-type > img[src^="data:image/svg+xml"], :scope > div:first-of-type > svg',
+      );
       const secondDiv = link.querySelector(':scope > div:last-of-type');
 
       if (isPlaceholder) {

--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -20,7 +20,7 @@ async function createTemplates(recipe, customProperties = null) {
  * Creates a templates container configured for search bar functionality
  * Uses custom URL config for desktop/Android, default links for iOS
  */
-async function createTemplatesContainer(recipe, el, isPanel = false) {
+async function createTemplatesContainer(recipe, el, isPanel = false, queryParams = '') {
   const containerClass = isPanel ? 'templates-container search-bar-gallery' : 'templates-container';
   const templatesContainer = createTag('div', { class: containerClass });
 
@@ -30,7 +30,7 @@ async function createTemplatesContainer(recipe, el, isPanel = false) {
   const customProperties = isIOS ? null : {
     customUrlConfig: {
       baseUrl: 'https://adobesparkpost.app.link/8JaoEy0DrSb',
-      queryParams: 'source=seo-template',
+      queryParams: ['source=seo-template', queryParams].filter(Boolean).join('&'),
     },
   };
 
@@ -59,12 +59,12 @@ async function createTemplatesContainer(recipe, el, isPanel = false) {
   };
 }
 
-async function renderTemplates(el, recipe, toolbar, isPanel = false) {
+async function renderTemplates(el, recipe, toolbar, isPanel = false, queryParams = '') {
   try {
     const {
       templatesContainer,
       control: galleryControl,
-    } = await createTemplatesContainer(recipe, el, isPanel);
+    } = await createTemplatesContainer(recipe, el, isPanel, queryParams);
 
     const controlsContainer = createTag('div', { class: 'controls-container' });
     controlsContainer.append(galleryControl);
@@ -86,6 +86,7 @@ async function initPanelVariant(el) {
   const rows = el.querySelectorAll(':scope > div');
   const recipeRow = rows[rows.length - 1];
   const recipe = recipeRow.textContent.trim();
+  const queryParamsRow = rows[3];
 
   const toolbar = createTag('div', { class: 'toolbar' });
 
@@ -98,7 +99,13 @@ async function initPanelVariant(el) {
     el.replaceChildren(toolbar);
   }
 
-  await renderTemplates(el, recipe, toolbar, true);
+  let queryParams = '';
+  if (queryParamsRow) {
+    queryParams = queryParamsRow.textContent.trim();
+    queryParamsRow.remove();
+  }
+
+  await renderTemplates(el, recipe, toolbar, true, queryParams);
 }
 
 async function initDefaultVariant(el) {
@@ -106,6 +113,7 @@ async function initDefaultVariant(el) {
   const toolbar = rows[0];
   const recipeRow = rows[1];
   const viewAllRow = rows[2];
+  const queryParamsRow = rows[3];
 
   const heading = toolbar.querySelector('h1,h2,h3');
   const description = toolbar.querySelector('p');
@@ -143,7 +151,13 @@ async function initDefaultVariant(el) {
     viewAllRow.remove();
   }
 
-  await renderTemplates(el, recipe, toolbar);
+  let queryParams = '';
+  if (queryParamsRow) {
+    queryParams = queryParamsRow.textContent.trim();
+    queryParamsRow.remove();
+  }
+
+  await renderTemplates(el, recipe, toolbar, false, queryParams);
 }
 
 export default async function init(el) {

--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -59,6 +59,13 @@ async function createTemplatesContainer(recipe, el, isPanel = false, queryParams
   };
 }
 
+const extractQueryParams = (row) => {
+  if (!row) return '';
+  const value = row.textContent.trim();
+  row.remove();
+  return value;
+};
+
 async function renderTemplates(el, recipe, toolbar, isPanel = false, queryParams = '') {
   try {
     const {
@@ -99,11 +106,7 @@ async function initPanelVariant(el) {
     el.replaceChildren(toolbar);
   }
 
-  let queryParams = '';
-  if (queryParamsRow) {
-    queryParams = queryParamsRow.textContent.trim();
-    queryParamsRow.remove();
-  }
+  const queryParams = extractQueryParams(queryParamsRow);
 
   await renderTemplates(el, recipe, toolbar, true, queryParams);
 }
@@ -151,11 +154,7 @@ async function initDefaultVariant(el) {
     viewAllRow.remove();
   }
 
-  let queryParams = '';
-  if (queryParamsRow) {
-    queryParams = queryParamsRow.textContent.trim();
-    queryParamsRow.remove();
-  }
+  const queryParams = extractQueryParams(queryParamsRow);
 
   await renderTemplates(el, recipe, toolbar, false, queryParams);
 }

--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -91,8 +91,8 @@ async function renderTemplates(el, recipe, toolbar, isPanel = false, queryParams
 async function initPanelVariant(el) {
   const headings = el.querySelectorAll('h1, h2, h3');
   const rows = el.querySelectorAll(':scope > div');
-  const recipeRow = rows[rows.length - 1];
-  const recipe = recipeRow.textContent.trim();
+  const recipeRow = rows[1];
+  const recipe = recipeRow ? recipeRow.textContent.trim() : '';
   const queryParamsRow = rows[3];
 
   const toolbar = createTag('div', { class: 'toolbar' });
@@ -135,8 +135,8 @@ async function initDefaultVariant(el) {
   }
 
   toolbar.classList.add('toolbar');
-  const recipe = recipeRow.textContent.trim();
-  recipeRow.remove();
+  const recipe = recipeRow ? recipeRow.textContent.trim() : '';
+  recipeRow?.remove();
 
   // Handle optional view-all link (last row)
   if (viewAllRow) {

--- a/test/blocks/template-list/template-list.test.js
+++ b/test/blocks/template-list/template-list.test.js
@@ -27,12 +27,6 @@ describe('Template List Block', () => {
       }),
     });
 
-    // Mock window.location properties
-    window.location = {
-      origin: 'https://example.com',
-      pathname: '/test',
-    };
-
     // Mock window.spark
     window.spark = {};
 
@@ -164,9 +158,12 @@ describe('Template List Block', () => {
 
     it('should handle placeholder templates', () => {
       const placeholder = window.createTag('div');
-      placeholder.innerHTML = '<div><img src="test.svg" alt="placeholder"></div><div>16:9</div>';
+      const svgDataUri = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
+      placeholder.innerHTML = `<div><img src="${svgDataUri}" alt="placeholder"></div><div>16:9</div>`;
 
-      const isPlaceholder = placeholder.querySelector(':scope > div:first-of-type > img[src*=".svg"], :scope > div:first-of-type > svg');
+      const isPlaceholder = placeholder.querySelector(
+        ':scope > div:first-of-type > img[src*=".svg"], :scope > div:first-of-type > img[src^="data:image/svg+xml"], :scope > div:first-of-type > svg',
+      );
       expect(isPlaceholder).to.exist;
     });
   });

--- a/test/blocks/template-x-carousel/template-x-carousel.test.js
+++ b/test/blocks/template-x-carousel/template-x-carousel.test.js
@@ -84,6 +84,38 @@ describe('template-x-carousel', () => {
     expect(templatesContainer.classList.contains('search-bar-gallery')).to.be.true;
   });
 
+  it('applies custom query params to template links (default variant)', async () => {
+    const queryParams = 'utm_source=test&foo=bar';
+    const defaultBlock = document.createElement('div');
+    defaultBlock.className = 'template-x-carousel';
+    defaultBlock.innerHTML = `
+      <div>
+        <div>
+          <h2>Default Heading</h2>
+          <p>Default description</p>
+        </div>
+      </div>
+      <div>
+        <div>tasks=card&orderBy=-remixCount&limit=10&collection=default</div>
+      </div>
+      <div></div>
+      <div>
+        <div>${queryParams}</div>
+      </div>
+    `;
+    document.body.appendChild(defaultBlock);
+
+    await decorate(defaultBlock);
+
+    const templateLink = defaultBlock.querySelector('.template a.button, .template a.cta-link');
+    expect(templateLink).to.exist;
+    const href = templateLink.getAttribute('href');
+    expect(href).to.include('source=seo-template');
+    expect(href).to.include(queryParams);
+
+    defaultBlock.remove();
+  });
+
   it('heading is properly positioned', async () => {
     const heading = block.querySelector('.heading');
     expect(heading).to.exist;


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR:
* ability to author query params of hardcoded Sparkpost link that determine where user is brought in product after clicking "Edit this link"

---

## Jira Ticket

Resolves: [MWPW-185423](https://jira.corp.adobe.com/browse/MWPW-185423)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/rafts/jsandlan/template-x-carousel |
| **After**   | https://tx-carousel-author-link--da-express-milo--adobecom.aem.page/drafts/jsandlan/template-x-carousel?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
**Before**
Prior to the change authors could not set query params
**After**
 After this change authors can set query params that determine where in product the user is brought after they click "Edit this template" ie resume maker, meme maker, card maker etc

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
