### PR TITLE
Ribbon banner link update

### DIFF
--- a/express/code/blocks/ribbon-banner/ribbon-banner.css
+++ b/express/code/blocks/ribbon-banner/ribbon-banner.css
@@ -16,10 +16,12 @@
 
 .section .ribbon-banner a:any-link {
   color: var(--content-neutral-default);
+  text-decoration: underline;
 }
 .section .ribbon-banner.light a:any-link,
 .section .ribbon-banner.light a:any-link:hover{
   color: var(--color-white);
+  text-decoration: underline;
 }
 
 .ribbon-banner strong {
@@ -37,6 +39,7 @@
     outline: 2px solid var(--color-gray-900);
     outline-offset: 0;
     border: none;
+    text-decoration: none;
     transition: background-color 0.2s ease;
 }
 .section .ribbon-banner a.con-button.outline:hover {

--- a/express/code/blocks/ribbon-banner/ribbon-banner.css
+++ b/express/code/blocks/ribbon-banner/ribbon-banner.css
@@ -14,6 +14,14 @@
     gap: var(--spacing-300);
 }
 
+.section .ribbon-banner a:any-link {
+  color: var(--content-neutral-default);
+}
+.section .ribbon-banner.light a:any-link,
+.section .ribbon-banner.light a:any-link:hover{
+  color: var(--color-white);
+}
+
 .ribbon-banner strong {
     font-weight: var(--heading-font-weight-extra);
     font-size: var(--ax-body-s-size);


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Changes the color of the hyper links in the `ribbon-banner` block to something more accessible

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-185219

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://ribbon-banner-link-update--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://ribbon-banner-link-update--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/ribbon-banner |
---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page, if it has the ribbon banner, then the link color should be #222 and underlined. The cta text should not be underlined

---
