### PR TITLE
MWPW-182453: Fix icons 404 CRP

### DIFF
--- a/express/code/blocks/drawer-cards/drawer-cards.js
+++ b/express/code/blocks/drawer-cards/drawer-cards.js
@@ -41,7 +41,7 @@ async function decorateDrawer(videoSrc, poster, titleText, panels, panelsFrag, d
   titleRow.append(createTag('strong', { class: 'drawer-title' }, titleText), closeButton);
   await yieldToMain();
 
-  const icons = panelsFrag.querySelectorAll('.icon');
+  const icons = panelsFrag.querySelectorAll('.express-icon, .icon');
   const anchors = [...panelsFrag.querySelectorAll('a')];
   anchors.forEach((anchor, i) => {
     const parent = anchor.parentElement;

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -42,7 +42,7 @@ async function decorateDrawer(videoSrc, poster, titleText, panels, panelsFrag, d
   titleRow.append(createTag('strong', { class: 'drawer-title' }, titleText), closeButton);
   await yieldToMain();
 
-  const icons = panelsFrag.querySelectorAll('.icon');
+  const icons = panelsFrag.querySelectorAll('.express-icon, .icon');
   const anchors = [...panelsFrag.querySelectorAll('a')];
   anchors.forEach((anchor, i) => {
     const parent = anchor.parentElement;

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -381,7 +381,12 @@ async function loadPage() {
     const { default: replaceContent } = await import('./utils/content-replace.js');
     await replaceContent(document.querySelector('main'));
   }
-  // Decorate the page with site specific needs.
+
+  document.querySelectorAll('span.icon').forEach((icon) => {
+    icon.classList.remove('icon');
+    icon.classList.add('express-icon');
+  });
+
   decorateArea();
 
   loadLana({ clientId: 'express' });


### PR DESCRIPTION
## Summary

This PR prevents 40+ wasted 404 network requests by filtering Express icons before Milo's icon loader runs. Express has 447 icons in `/express/code/icons/` that don't exist on Adobe's federal icon server.

---

## Jira Ticket

Resolves: [MWPW-182453](https://jira.corp.adobe.com/browse/MWPW-182453)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://fix-icons-404-CRP--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Changes Made

### Code Changes:
- **scripts.js**: Remove `icon` class and add `express-icon` class to all icons before Milo's `decorateArea` runs
- **grid-marquee.js**: Update icon selector to query for both `.icon` and `.express-icon` classes
- **drawer-cards.js**: Update icon selector to query for both `.icon` and `.express-icon` classes

### Impact:
- **40+ fewer 404 requests** before LCP
- **Faster page load** - eliminates wasted network calls to federal icon server
- **No visual changes** - icons still render correctly using Express icon system

---

## Verification Steps

1. **Check Network Tab:**
   - Open DevTools → Network tab
   - Load homepage
   - Filter by "404"
   - Should see NO requests to `/federal/assets/icons/svgs/` for Express icons (ax-*, etc.)

2. **Verify Icons Still Work:**
   - All icons should render correctly
   - Check grid-marquee drawer icons
   - Check drawer-cards icons
   - Icons should have `express-icon` class instead of `icon`

### Expected behavior:
- **Before:** 40+ 404 requests for icons like `ax-blank.svg`, `ax-checkmark.svg`, etc.
- **After:** Zero 404 requests for Express icons, all icons still render correctly

---

## Technical Details

### Why This Works:
1. Express has its own icon system (`getIconElementDeprecated`) with 447 icons
2. These icons are stored in `/express/code/icons/` (local)
3. Milo's icon loader looks for icons on federal server (remote)
4. Express icons don't exist on federal server → 404s
5. By removing `icon` class before Milo runs, we prevent these lookups

---

## Potential Regressions

- https://fix-icons-404-CRP--da-express-milo--adobecom.aem.live/express/?martech=off

Test specifically:
- Grid marquee drawer icons
- Drawer cards icons
- Any page with Express-specific icons

---
