### PR TITLE
Adding additional JSON-LD properties to print-product-detail block. 

### DIFF
--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -198,6 +198,11 @@ export default async function decorate(block) {
     } catch (e) {
       /* no-op */
     }
+    try {
+      document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
+    } catch (e) {
+      /* no-op */
+    }
     updatePageWithProductDetails(dataObject, globalContainer);
     // SEO: title/description (respect authored), initial Product JSON-LD
     // (updated later when price arrives)
@@ -205,6 +210,7 @@ export default async function decorate(block) {
     upsertTitleAndDescriptionRespectingAuthored(dataObject);
     const overrides = getAuthoredOverrides(document);
     const initialJsonLd = await buildProductJsonLd(dataObject, overrides, canonicalUrl);
+    console.log(productDetailsResponse.product.productType);
     upsertLdJson('pdp-product-jsonld', initialJsonLd);
     const breadcrumbsLd = buildBreadcrumbsJsonLdFromDom();
     if (breadcrumbsLd) upsertLdJson('pdp-breadcrumbs-jsonld', breadcrumbsLd);

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -215,7 +215,6 @@ export default async function decorate(block) {
     // (updated later when price arrives)
     upsertTitleAndDescriptionRespectingAuthored(dataObject);
     await upsertProductJsonLdFromData(dataObject);
-    console.log(productDetailsResponse.product.productType);
     const breadcrumbsLd = buildBreadcrumbsJsonLdFromDom();
     if (breadcrumbsLd) upsertLdJson('pdp-breadcrumbs-jsonld', breadcrumbsLd);
     const productId = productDetailsResponse.product.id;

--- a/express/code/blocks/print-product-detail/utilities/seo.js
+++ b/express/code/blocks/print-product-detail/utilities/seo.js
@@ -117,6 +117,19 @@ export async function buildProductJsonLd(apiData, overrides, canonicalUrl) {
       url: canonicalUrl,
     };
   }
+
+  // Aggregate rating (if reviews available)
+  const ratingValue = Number(apiData.averageRating);
+  const reviewCount = Number(apiData.totalReviews);
+  if (!Number.isNaN(ratingValue) && !Number.isNaN(reviewCount) && reviewCount > 0) {
+    json.aggregateRating = {
+      '@type': 'AggregateRating',
+      ratingValue: ratingValue.toFixed(1),
+      reviewCount,
+      bestRating: 5,
+      worstRating: 1,
+    };
+  }
   return json;
 }
 

--- a/express/code/blocks/print-product-detail/utilities/seo.js
+++ b/express/code/blocks/print-product-detail/utilities/seo.js
@@ -4,6 +4,31 @@ export function getCanonicalUrl() {
   return href && href.trim() ? href : window.location.href;
 }
 
+export function getProductCategory(productType) {
+  const productCategoryMap = {
+    zazzle_shirt: 'T-shirt',
+    zazzle_businesscard: 'Business card',
+    mojo_throwpillow: 'Pillow',
+    zazzle_mug: 'Mug',
+    zazzle_bag: 'Bag',
+    zazzle_flyer: 'Flyer',
+    zazzle_print: 'Print',
+    zazzle_sticker: 'Sticker',
+    zazzle_invitation3: 'Invitation',
+    zazzle_foldedthankyoucard: 'Thank you card',
+    zazzle_poster: 'Poster',
+    zazzle_card: 'Card',
+    zazzle_banner: 'Banner',
+    zazzle_sign: 'Sign',
+    zazzle_label: 'Label',
+    zazzle_envelope: 'Envelope',
+    zazzle_envelopeset: 'Envelope set',
+    zazzle_booklet: 'Booklet',
+    default: 'Printed product',
+  };
+  return productCategoryMap[productType] || productCategoryMap.default;
+}
+
 export function getAuthoredOverrides(doc = document) {
   const overrides = {};
   const titleEl = doc.querySelector('title');
@@ -54,15 +79,25 @@ export async function buildProductJsonLd(apiData, overrides, canonicalUrl) {
     || (Array.isArray(apiData.productDescriptions) && apiData.productDescriptions[0]?.description)
     || '';
   const description = stripHtml(descriptionSource);
-  const image = overrides?.image || apiData.heroImage || '';
+  const category = getProductCategory(apiData.productType);
+  // if image is default, use the hero image
+  const imageURL = overrides?.image === 'https://www.adobe.com/default-meta-image.png?width=1200&format=pjpg&optimize=medium' ? apiData.heroImage : overrides?.image;
   const sku = apiData.id || apiData.templateId || '';
-
+  const url = canonicalUrl;
   const json = {
     '@context': 'https://schema.org/',
     '@type': 'Product',
     name,
     description,
-    image,
+    category,
+    image: {
+      '@type': 'ImageObject',
+      url: imageURL,
+      height: '644',
+      width: '644',
+      caption: name,
+    },
+    url,
     brand: {
       '@type': 'Brand',
       name: 'Adobe Express',
@@ -82,7 +117,6 @@ export async function buildProductJsonLd(apiData, overrides, canonicalUrl) {
       url: canonicalUrl,
     };
   }
-
   return json;
 }
 

--- a/express/code/blocks/print-product-detail/utilities/seo.js
+++ b/express/code/blocks/print-product-detail/utilities/seo.js
@@ -101,6 +101,7 @@ export async function buildProductJsonLd(apiData, overrides, canonicalUrl) {
     brand: {
       '@type': 'Brand',
       name: 'Adobe Express',
+      logo: 'https://www.adobe.com/content/dam/cc/icons/AdobeExpressAppIcon.svg',
     },
   };
 
@@ -115,6 +116,12 @@ export async function buildProductJsonLd(apiData, overrides, canonicalUrl) {
       priceCurrency,
       availability: 'https://schema.org/InStock',
       url: canonicalUrl,
+      seller: {
+        '@type': 'Organization',
+        name: 'Adobe Express',
+        url: 'https://www.adobe.com/express/',
+      },
+      itemCondition: 'https://schema.org/NewCondition',
     };
   }
 


### PR DESCRIPTION
## Summary

The print-product-detail block should now contain all of the json-ld propertied mentioned in this ticket:
https://jira.corp.adobe.com/browse/MWPW-185274

---

## Jira Ticket

Resolves: [MWPW-185274](https://jira.corp.adobe.com/browse/MWPW-185274)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.live/express/create/print/t-shirt/white-and-red-university-music-club-t-shirt |
| **After**   | https://mwpw-185274--da-express-milo--adobecom.aem.live/express/create/print/t-shirt/white-and-red-university-music-club-t-shirt |

---

## Verification Steps

- Since this update is to the metadata in the <head> tag of the page and doesnt contain any visible updates, you'll need to inspect the <head> tag and search for the following script tag:
<script type="application/ld+json" id="pdp-product-jsonld">
- The object contained within this script tag should include all of the metadata properties and values mentioned in the JIRA ticket.

You can also use this tool:

https://search.google.com/test/rich-results

to check the validity of the json-ld content. In order to do this you'll need to copy the object contained within the script tag into this tool and select Run Test. I've done this, with the following result:

https://search.google.com/test/rich-results/result?id=aWgyfrjCOhi7R5fkmn0BJg



---

## Potential Regressions

-

---

## Additional Notes

-
