### PR TITLE
Comparison table header subcopy

### DIFF
--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -611,7 +611,7 @@ flex-grow: 1;
   font-size: var(--ax-body-xs-size);
   font-weight: var(--ax-body-weight);
   line-height: var(--heading-line-height);
-  color: #505050;
+  color: var(--color-dark-gray);
   display: inline;
   padding-top: 2px;
 }
@@ -989,7 +989,6 @@ color: var(--color-gray-700-variant);
     .comparison-table-v2 .feature-cell-header { 
       text-align: left;
       padding: 0; 
-       /* var(--spacing-400) var(--spacing-400) var(--spacing-400) 0; */
       margin-right: var(--spacing-100);
       box-sizing: border-box;
       width: var(--header-cell-width);
@@ -1186,7 +1185,6 @@ color: var(--color-gray-700-variant);
   .comparison-table-v2 table td .icon-wrapper {
       box-sizing: border-box;
       width: 100%;
-      /* margin: var(--spacing-400) 0 0 0; */
       display: flex;
       align-items: center;
   }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -566,7 +566,7 @@ flex-grow: 1;
   align-items: center;
   gap: var(--spacing-75);
   margin: 0;
-  min-height: 40px;
+  /* min-height: 40px; */
   padding: 0 0 var(--spacing-200);
   text-align: center;
   font-family: var(--body-font-family);
@@ -575,8 +575,9 @@ flex-grow: 1;
   line-height: 18px;
 }
 
+
 .comparison-table-v2 table tbody th,
-.comparison-table-v2 .ctv2-th {
+.comparison-table-v2 .ctv2-th .ctv2-th-header {
 
   padding: var(--spacing-200) var(--spacing-300);
   flex-direction: column;
@@ -594,7 +595,27 @@ flex-grow: 1;
   font-size: var(--ax-body-xs-size);
 }
 
-.comparison-table-v2 .table-container table tbody th p,
+
+.comparison-table-v2 .ctv2-th {
+  flex-wrap: wrap;
+  margin : auto;
+}
+
+.comparison-table-v2 .ctv2-th .ctv2-th-header {
+  padding: 0;
+  width: 100%;
+}
+
+
+.comparison-table-v2 .ctv2-th .ctv2-th-subheader {
+  font-size: var(--ax-body-xs-size);
+  font-weight: var(--ax-body-weight);
+  line-height: var(--heading-line-height);
+  color: var(--color-gray-700-variant);
+  display: inline;
+}
+
+/* .comparison-table-v2 .table-container table tbody th p,
 .comparison-table-v2 .ctv2-th p {
   border-radius: var(--spacing-75);
   border: 1px solid var(--color-gray-200);
@@ -605,7 +626,7 @@ flex-grow: 1;
   align-items: center;
   gap: var(--spacing-100);
   align-self: stretch;
-}
+} */
 
 /* Invisible/hidden elements */
 .comparison-table-v2 .invisible-headers {
@@ -963,6 +984,9 @@ color: var(--color-gray-700-variant);
   }
 
 
+  .comparison-table-v2 .ctv2-th .ctv2-th-header {
+    text-align: left
+  }
   
 
   .comparison-table-v2 .table-container {
@@ -976,7 +1000,8 @@ color: var(--color-gray-700-variant);
 
     .comparison-table-v2 .feature-cell-header { 
       text-align: left;
-      padding: var(--spacing-400) var(--spacing-400) var(--spacing-400) 0;
+      padding: 0; 
+       /* var(--spacing-400) var(--spacing-400) var(--spacing-400) 0; */
       margin-right: var(--spacing-100);
       box-sizing: border-box;
       width: var(--header-cell-width);
@@ -1173,7 +1198,7 @@ color: var(--color-gray-700-variant);
   .comparison-table-v2 table td .icon-wrapper {
       box-sizing: border-box;
       width: 100%;
-      margin: var(--spacing-400) 0 0 0;
+      /* margin: var(--spacing-400) 0 0 0; */
       display: flex;
       align-items: center;
   }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -611,7 +611,7 @@ flex-grow: 1;
   font-size: var(--ax-body-xs-size);
   font-weight: var(--ax-body-weight);
   line-height: var(--heading-line-height);
-  color: var(--color-gray-700-variant);
+  color: #505050;
   display: inline;
 }
 

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -616,19 +616,6 @@ flex-grow: 1;
   padding-top: 2px;
 }
 
-/* .comparison-table-v2 .table-container table tbody th p,
-.comparison-table-v2 .ctv2-th p {
-  border-radius: var(--spacing-75);
-  border: 1px solid var(--color-gray-200);
-  background: var(--color-white);
-  display: flex;
-  padding: var(--spacing-200) 0;
-  justify-content: center;
-  align-items: center;
-  gap: var(--spacing-100);
-  align-self: stretch;
-} */
-
 /* Invisible/hidden elements */
 .comparison-table-v2 .invisible-headers {
   position: absolute;

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -613,6 +613,7 @@ flex-grow: 1;
   line-height: var(--heading-line-height);
   color: #505050;
   display: inline;
+  padding-top: 2px;
 }
 
 /* .comparison-table-v2 .table-container table tbody th p,

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -566,7 +566,6 @@ flex-grow: 1;
   align-items: center;
   gap: var(--spacing-75);
   margin: 0;
-  /* min-height: 40px; */
   padding: 0 0 var(--spacing-200);
   text-align: center;
   font-family: var(--body-font-family);

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -447,6 +447,8 @@ function createTabindexUpdateHandler(comparisonBlock, colTitles) {
  */
 function synchronizeIconWrapperTextHeights(comparisonBlock) {
   const rows = comparisonBlock.querySelectorAll('.table-container tbody tr');
+  const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
+
   rows.forEach((row) => {
     const iconTextElements = Array.from(row.querySelectorAll('.icon-wrapper'));
     if (iconTextElements.length === 0) return;
@@ -456,10 +458,13 @@ function synchronizeIconWrapperTextHeights(comparisonBlock) {
       iconText.style.height = 'auto';
     });
 
-    const visibleIconTextElements = iconTextElements.filter((iconText) => {
-      const parentCell = iconText.closest('.feature-cell');
-      return !parentCell || !parentCell.classList.contains('invisible-content');
-    });
+    // On desktop, synchronize all cells. On mobile/tablet, only synchronize visible cells.
+    const visibleIconTextElements = isDesktop
+      ? iconTextElements
+      : iconTextElements.filter((iconText) => {
+        const parentCell = iconText.closest('.feature-cell');
+        return !parentCell || !parentCell.classList.contains('invisible-content');
+      });
 
     if (visibleIconTextElements.length <= 1) return;
 

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -199,6 +199,7 @@ function createTableRow(featureRowDiv) {
       tableCell = document.createElement('th');
       tableCell.classList.add('feature-cell-header');
       tableCell.classList.add('ctv2-th');
+
       tableCell.setAttribute('scope', 'row');
     } else {
       tableCell = document.createElement('td');
@@ -206,6 +207,13 @@ function createTableRow(featureRowDiv) {
       tableCell.classList.add('ctv2-td');
     }
     tableCell.innerHTML = cellContent.innerHTML;
+
+    if (tableCell.children.length > 0) {
+      tableCell.children[0].classList.add('ctv2-th-header');
+      for (let i = 1; i < tableCell.children.length; i += 1) {
+        tableCell.children[i].classList.add('ctv2-th-subheader');
+      }
+    }
     tableCell.setAttribute('data-plan-index', cellIndex - 1);
 
     if (noText) {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.
Adds the option for authors to specify custom subheaders + tooltip content for the first cell of feature rows of the comparison table

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-186063

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://comparison-table-header-subcopy--da-express-milo--adobecom.aem.page/drafts/echen/comparison-v2 |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
Visit the page and verify that the new content in the first cell of the rows has its subheader + tooltip properly displayed.,
---

## Potential Regressions

- https://comparison-table-header-subcopy--da-express-milo--adobecom.aem.page/drafts/echen/comparison-v2

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
