### PR TITLE
Sticky Header Comp Chart Bug Fix

### DIFF
--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -643,6 +643,7 @@ flex-grow: 1;
 .comparison-table-v2.accordion .table-container table.hide-table {
   display: grid;
   grid-template-rows: 0fr;
+  padding: 0;
 }
 
 .comparison-table-v2.accordion .table-container table > * {

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -899,7 +899,8 @@ color: var(--color-gray-700-variant);
 }
 
 .comparison-table-v2 .feature-cell.gray-text p,
-.comparison-table-v2 .feature-cell.gray p {
+.comparison-table-v2 .feature-cell.gray p,
+.comparison-table-v2 .feature-cell:has(.icon-crossmark) p {
   color: var(--color-gray-700-variant);
 }
 

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -125,6 +125,10 @@ main .section .comparison-table-v2 p {
 body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck {
   top: var(--spacing-0);
 }
+body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-offset {
+  top: 64px;
+}
+
 
 .comparison-table-v2 .sticky-header.is-stuck.is-retracted {
   transform: translateY(-100%);

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -219,7 +219,6 @@ body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-of
   display: none;
 }
 
-/* Disable plan-cell-wrapper clicks on mobile when sticky header is engaged */
 @media (max-width: 1023px) {
   .comparison-table-v2 .sticky-header.is-stuck .plan-cell-wrapper {
     pointer-events: none;
@@ -459,7 +458,6 @@ main .comparison-table-v2 .sticky-header .plan-cell p {
   margin-bottom: var(--spacing-100);
 }
 
-/* Ensure 8px gap above plan-selector-wrapper when no subcopy (p) exists */
 main .comparison-table-v2 .sticky-header .plan-cell-wrapper:not(:has(p)) > :is(h2, h3, h4, h5, h6, .sticky-header-title) {
   margin-bottom: var(--spacing-100);
 }
@@ -644,7 +642,6 @@ flex-grow: 1;
   display: none;
 }
 
-/* Accordion variant - use grid for animatable collapse instead of display:none */
 .comparison-table-v2.accordion .table-container table {
   display: grid;
   grid-template-rows: 1fr;
@@ -1268,7 +1265,6 @@ color: var(--color-gray-700-variant);
 
 }
 
-/* Accordion variant - desktop overrides */
 @media (min-width: 1024px) {
   .comparison-table-v2.accordion .table-container table {
     display: grid;

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -630,8 +630,8 @@ flex-grow: 1;
 
 .comparison-table-v2 .table-container table.hide-table {
   display: none;
+  transition: ease-in 300ms;
 }
-
 /* Plan selector */
 .comparison-table-v2 .plan-selector-wrapper {
   bottom: 0;
@@ -1132,6 +1132,8 @@ color: var(--color-gray-700-variant);
       height: 100%;
       width: 100%;
       padding: var(--spacing-300);
+      transition: ease-in 300ms;
+      
   }
 
   .comparison-table-v2 table tbody th,

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -630,7 +630,24 @@ flex-grow: 1;
 
 .comparison-table-v2 .table-container table.hide-table {
   display: none;
-  transition: ease-in 300ms;
+}
+
+/* Accordion variant - use grid for animatable collapse instead of display:none */
+.comparison-table-v2.accordion .table-container table {
+  display: grid;
+  grid-template-rows: 1fr;
+  overflow: hidden;
+  transition: grid-template-rows 300ms ease-out;
+}
+
+.comparison-table-v2.accordion .table-container table.hide-table {
+  display: grid;
+  grid-template-rows: 0fr;
+}
+
+.comparison-table-v2.accordion .table-container table > * {
+  min-height: 0;
+  overflow: hidden;
 }
 /* Plan selector */
 .comparison-table-v2 .plan-selector-wrapper {
@@ -1236,6 +1253,20 @@ color: var(--color-gray-700-variant);
       font-size: var(--body-font-size-m);
   }
 
+}
+
+/* Accordion variant - desktop overrides */
+@media (min-width: 1024px) {
+  .comparison-table-v2.accordion .table-container table {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 300ms ease-out;
+  }
+
+  .comparison-table-v2.accordion .table-container table.hide-table {
+    grid-template-rows: 0fr;
+    padding: 0;
+  }
 }
 
 /* removed empty media queries to reduce CSS size */

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -219,6 +219,13 @@ body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-of
   display: none;
 }
 
+/* Disable plan-cell-wrapper clicks on mobile when sticky header is engaged */
+@media (max-width: 1023px) {
+  .comparison-table-v2 .sticky-header.is-stuck .plan-cell-wrapper {
+    pointer-events: none;
+  }
+}
+
 .comparison-table-v2 .sticky-header .action-area {
   opacity: 1;
   transform: translateY(0);

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -452,6 +452,11 @@ main .comparison-table-v2 .sticky-header .plan-cell p {
   margin-bottom: var(--spacing-100);
 }
 
+/* Ensure 8px gap above plan-selector-wrapper when no subcopy (p) exists */
+main .comparison-table-v2 .sticky-header .plan-cell-wrapper:not(:has(p)) > :is(h2, h3, h4, h5, h6, .sticky-header-title) {
+  margin-bottom: var(--spacing-100);
+}
+
 /* Table container - Mobile */
 .comparison-table-v2 .table-container {
   border-radius: var(--spacing-100);

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -1215,6 +1215,7 @@ color: var(--color-gray-700-variant);
       display: revert; 
   }
 
+  .comparison-table-v2 .invisible-content.plan-cell,
   .comparison-table-v2 .invisible-content.feature-cell {
       display: flex;
   }
@@ -1335,4 +1336,11 @@ color: var(--color-gray-700-variant);
 /* Placeholder element to prevent content jumping */
 .comparison-table-v2 .sticky-header-placeholder {
   display: none; 
+}
+
+
+.comparison-table-v2 .sticky-header .plan-cell .action-area {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column-reverse;
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -63,7 +63,7 @@ main .section .comparison-table-v2 p {
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
   /* Ensure dropdown menus can layer above the table when header is not stuck */
-  z-index: 15;
+  z-index: 1;
   
   /* Base transition for all state changes */
   transition: 
@@ -331,7 +331,7 @@ min-height: calc(var(--plan-cell-height) - 4px);
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   min-height: var(--plan-cell-height);
   padding-bottom: var(--spacing-400);
@@ -440,6 +440,7 @@ main .comparison-table-v2 .sticky-header .plan-cell :is(h2, h3, h4, h5, h6, .sti
   font-style: normal;
   font-weight: var(--ax-heading-weight);
   line-height: var(--heading-line-height);
+  flex-grow: 0;
 }
 
 main .comparison-table-v2 .sticky-header .plan-cell p {
@@ -450,6 +451,7 @@ main .comparison-table-v2 .sticky-header .plan-cell p {
   font-style: normal;
   font-weight: var(--ax-body-weight-bold);
   line-height: var(--heading-line-height);
+  margin-bottom: var(--spacing-100);
 }
 
 /* Table container - Mobile */

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -8,6 +8,7 @@
   --icon-color: #05834E;
   --cell-width: var(--ax-grid-5-col-width);
   --plan-cell-background-color: #F5F5F5;
+  --gnav-offset-height: 64px;
   --plan-cell-height: 65px;
   --header-cell-width: var(--ax-grid-12-col-width);
   
@@ -126,7 +127,7 @@ body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck {
   top: var(--spacing-0);
 }
 body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-offset {
-  top: 64px;
+  top: var(--gnav-offset-height);
 }
 
 
@@ -155,15 +156,11 @@ body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-of
 /* Hidden state for when header is completely retracted */
 .comparison-table-v2 .sticky-header.is-hidden {
   opacity: 0;
- 
   transform: translateY(-100%);
   pointer-events: none;
-  
-  /* Faster hide transition */
   transition: 
       transform 0.3s cubic-bezier(0.4, 0, 1, 1),
-      opacity 0.2s ease-out,
- 
+      opacity 0.2s ease-out;
 }
 
 /* Performance optimization - reduce paint areas during transitions */
@@ -411,11 +408,6 @@ min-height: calc(var(--plan-cell-height) - 4px);
   outline-offset: var(--border-width-2);
 }
 
-.comparison-table-v2 .sticky-header.is-stuck .plan-cell.premium .plan-cell-wrapper {
-  background: none;
-  transition: background var(--transition-fade);
-}
-
 .comparison-table-v2 .sticky-header .plan-cell.premium .plan-cell-wrapper {
   z-index: 6;
   border-radius: var(--spacing-100);
@@ -426,9 +418,11 @@ min-height: calc(var(--plan-cell-height) - 4px);
   border: var(--border-width-2) solid transparent;
   flex-grow: 1;
 }
- 
+
 .comparison-table-v2 .sticky-header.is-stuck .plan-cell.premium .plan-cell-wrapper {
-border: 1px solid transparent;
+  background: none;
+  border: 1px solid transparent;
+  transition: background var(--transition-fade);
 }
 
 .comparison-table-v2 .sticky-header .plan-cell.gray .plan-cell-wrapper {
@@ -645,11 +639,9 @@ flex-grow: 1;
   right: 0;
   width: 100%;
   position: absolute;
-  
-  /* Add smooth transitions for plan selector */
   transition: 
       opacity var(--transition-fade),
-      transform var(--transition-smooth), 
+      transform var(--transition-smooth);
 }
 
 .comparison-table-v2 .plan-selector {

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -959,14 +959,13 @@ color: var(--color-gray-700-variant);
 
   .comparison-table-v2 {
       max-width: 1300px;
-      padding: var(--spacing-0) var(--spacing-400);
+      padding: var(--spacing-0) var(--spacing-400) var(--spacing-900) var(--spacing-400);
       /* width: fit-content; */
       gap: var(--spacing-300);
       display: flex;
       flex-direction: column;
       --header-cell-width: var(--ax-grid-3-col-width);
       --cell-width: var(--ax-grid-3-col-width);
-      padding-bottom: var(--spacing-600);
       --plan-cell-height: 73px;
       --footer-width: 945px; 
   }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -407,7 +407,6 @@ function initializeAccordionBehavior(comparisonBlock) {
   const tableContainers = comparisonBlock.querySelectorAll('.table-container:not(.no-accordion)');
   if (tableContainers.length === 0) return;
 
-  // Set initial state: first section open, others closed
   tableContainers.forEach((container, index) => {
     const table = container.querySelector('table');
     const toggleButton = container.querySelector('.toggle-button');
@@ -424,7 +423,6 @@ function initializeAccordionBehavior(comparisonBlock) {
     }
   });
 
-  // Override click handlers to enforce one-open-at-a-time behavior
   tableContainers.forEach((container) => {
     const toggleButton = container.querySelector('.toggle-button');
     if (!toggleButton) return;
@@ -434,7 +432,6 @@ function initializeAccordionBehavior(comparisonBlock) {
     toggleButton.onclick = () => {
       const wasExpanded = !table.classList.contains('hide-table');
 
-      // If opening this section, close all others first
       if (!wasExpanded) {
         tableContainers.forEach((otherContainer) => {
           if (otherContainer !== container) {

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -190,7 +190,6 @@ function createAccessibilityHeaders(sectionTitle, colTitles) {
 function createTableRow(featureRowDiv) {
   const tableRow = document.createElement('tr');
   tableRow.classList.add('ctv2-tr');
-  // tableRow.classList.add('ax-grid-container');
   const featureCells = featureRowDiv.children;
   const noText = featureRowDiv.querySelectorAll('p').length === 0;
   Array.from(featureCells).forEach((cellContent, cellIndex) => {

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -484,6 +484,10 @@ export function synchronizePlanCellHeights(comparisonBlock) {
     wrapper.style.height = 'auto';
   });
 
+  // Don't synchronize heights when header is stuck (different layout)
+  const stickyHeader = comparisonBlock.querySelector('.is-stuck');
+  if (stickyHeader) return;
+
   // On mobile, only synchronize visible plan cells (not hidden by invisible-content class)
   const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
   const visibleWrappers = isDesktop

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -504,7 +504,7 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
  * @param {HTMLElement} comparisonBlock - The comparison table block element
  */
 export function synchronizePlanCellHeights(comparisonBlock) {
-  const planCellWrappers = comparisonBlock.querySelectorAll('.plan-cell-wrapper');
+  const planCellWrappers = Array.from(comparisonBlock.querySelectorAll('.plan-cell-wrapper'));
 
   if (planCellWrappers.length === 0) return;
 
@@ -513,19 +513,29 @@ export function synchronizePlanCellHeights(comparisonBlock) {
     wrapper.style.height = 'auto';
   });
 
-  if (comparisonBlock.querySelector('.is-stuck')) return;
+  // if (comparisonBlock.querySelector('.is-stuck')) return;
 
-  // Find the maximum height
+  // On mobile, only synchronize visible plan cells (not hidden by invisible-content class)
+  const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
+  const visibleWrappers = isDesktop
+    ? planCellWrappers
+    : planCellWrappers.filter((wrapper) => {
+      const parentCell = wrapper.closest('.plan-cell');
+      return !parentCell || !parentCell.classList.contains('invisible-content');
+    });
+ 
+  if (visibleWrappers.length === 0) return;
+
+  // Find the maximum height among visible wrappers
   let maxHeight = 0;
-  planCellWrappers.forEach((wrapper) => {
+  visibleWrappers.forEach((wrapper) => {
     const height = wrapper.offsetHeight;
     if (height > maxHeight) {
       maxHeight = height;
     }
-  });
-
-  // Apply the maximum height to all wrappers
-  planCellWrappers.forEach((wrapper) => {
+  }); 
+  // Apply the maximum height to visible wrappers only
+  visibleWrappers.forEach((wrapper) => {
     wrapper.style.height = `${maxHeight}px`;
   });
 }

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -7,10 +7,11 @@ const BREAKPOINTS = {
   TABLET: '(min-width: 768px)',
 };
 
-const SCROLL_DIRECTION = {
-  UP: 'up',
-  DOWN: 'down',
-};
+// Scroll direction tracking disabled - see note in initStickyBehavior
+// const SCROLL_DIRECTION = {
+//   UP: 'up',
+//   DOWN: 'down',
+// };
 
 const DROPDOWN = {
   MIN_COLUMNS_FOR_SELECTOR: 2,
@@ -302,8 +303,9 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
   let isSticky = false;
   let isRetracted = false;
   let stickyHeight = 0;
-  let lastScrollY = window.scrollY || window.pageYOffset || 0;
-  let currentDirection = SCROLL_DIRECTION.DOWN;
+  // Scroll direction tracking disabled - see note at bottom of function
+  // let lastScrollY = window.scrollY || window.pageYOffset || 0;
+  // let currentDirection = SCROLL_DIRECTION.DOWN;
   const tableContainers = comparisonBlock.querySelectorAll('.table-container');
   let lastTableRow = null;
   if (tableContainers.length) {
@@ -344,9 +346,13 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     }
     convertHeadingsToDivs(stickyHeader);
     stickyHeader.setAttribute('aria-hidden', 'true');
-    stickyHeader.classList.add('gnav-offset');
-    currentDirection = SCROLL_DIRECTION.DOWN;
-    lastScrollY = window.scrollY || window.pageYOffset || 0;
+    // Only add gnav offset on desktop - mobile sticky header sits at top of viewport
+    if (window.matchMedia(BREAKPOINTS.DESKTOP).matches) {
+      stickyHeader.classList.add('gnav-offset');
+    }
+    // Scroll direction tracking disabled - see note at bottom of function
+    // currentDirection = SCROLL_DIRECTION.DOWN;
+    // lastScrollY = window.scrollY || window.pageYOffset || 0;
 
     stickyHeader.classList.remove('is-retracted');
     isRetracted = false;
@@ -377,7 +383,10 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     if (!isSticky || !isRetracted) return;
     placeholder.style.display = 'flex';
     placeholder.style.height = `${stickyHeight}px`;
-    stickyHeader.classList.add('gnav-offset');
+    // Only add gnav offset on desktop - mobile sticky header sits at top of viewport
+    if (window.matchMedia(BREAKPOINTS.DESKTOP).matches) {
+      stickyHeader.classList.add('gnav-offset');
+    }
     stickyHeader.classList.remove('is-retracted');
     isRetracted = false;
   };
@@ -477,26 +486,30 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     });
   }
 
-  const handleScrollDirection = () => {
-    const currentScroll = window.scrollY || window.pageYOffset || 0;
-    if (!isSticky || isRetracted) {
-      lastScrollY = currentScroll;
-      return;
-    }
-
-    const newDirection = currentScroll < lastScrollY ? SCROLL_DIRECTION.UP : SCROLL_DIRECTION.DOWN;
-    if (newDirection !== currentDirection) {
-      if (newDirection === SCROLL_DIRECTION.UP) {
-        stickyHeader.classList.remove('gnav-offset');
-      } else {
-        stickyHeader.classList.add('gnav-offset');
-      }
-      currentDirection = newDirection;
-    }
-    lastScrollY = currentScroll;
-  };
-
-  window.addEventListener('scroll', handleScrollDirection, { passive: true });
+  // NOTE: Previously, gnav-offset was removed on scroll up and added on scroll down.
+  // This was disabled because we want the sticky header to always stay below the gnav.
+  // If visual glitches reappear, consider re-enabling scroll direction handling.
+  // const handleScrollDirection = () => {
+  //   const currentScroll = window.scrollY || window.pageYOffset || 0;
+  //   if (!isSticky || isRetracted) {
+  //     lastScrollY = currentScroll;
+  //     return;
+  //   }
+  //
+  //   const scrolledUp = currentScroll < lastScrollY;
+  //   const newDirection = scrolledUp ? SCROLL_DIRECTION.UP : SCROLL_DIRECTION.DOWN;
+  //   if (newDirection !== currentDirection) {
+  //     if (newDirection === SCROLL_DIRECTION.UP) {
+  //       stickyHeader.classList.remove('gnav-offset');
+  //     } else {
+  //       stickyHeader.classList.add('gnav-offset');
+  //     }
+  //     currentDirection = newDirection;
+  //   }
+  //   lastScrollY = currentScroll;
+  // };
+  //
+  // window.addEventListener('scroll', handleScrollDirection, { passive: true });
 }
 
 /**
@@ -523,7 +536,7 @@ export function synchronizePlanCellHeights(comparisonBlock) {
       const parentCell = wrapper.closest('.plan-cell');
       return !parentCell || !parentCell.classList.contains('invisible-content');
     });
- 
+
   if (visibleWrappers.length === 0) return;
 
   // Find the maximum height among visible wrappers
@@ -533,7 +546,8 @@ export function synchronizePlanCellHeights(comparisonBlock) {
     if (height > maxHeight) {
       maxHeight = height;
     }
-  }); 
+  });
+
   // Apply the maximum height to visible wrappers only
   visibleWrappers.forEach((wrapper) => {
     wrapper.style.height = `${maxHeight}px`;

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -404,7 +404,10 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
           return;
         }
 
-        if (!entry.isIntersecting && !isSticky) {
+        // Only apply sticky state if sentinel is actually above the viewport (scrolled past)
+        // This prevents the sticky header from appearing on initial page load
+        const isSentinelAboveViewport = entry.boundingClientRect.top < 0;
+        if (!entry.isIntersecting && !isSticky && isSentinelAboveViewport) {
           applyStickyState();
         } else if (entry.isIntersecting && isSticky) {
           removeStickyState();

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -1,24 +1,16 @@
 import { getIconElementDeprecated } from '../../scripts/utils.js';
 import { ComparisonTableState } from './comparison-table-state.js';
 
-// Import constants from main file
 const BREAKPOINTS = {
   DESKTOP: '(min-width: 1024px)',
   TABLET: '(min-width: 768px)',
 };
-
-// Scroll direction tracking disabled - see note in initStickyBehavior
-// const SCROLL_DIRECTION = {
-//   UP: 'up',
-//   DOWN: 'down',
-// };
 
 const DROPDOWN = {
   MIN_COLUMNS_FOR_SELECTOR: 2,
 };
 
 const OBSERVER_CONFIG = {
-  HEADER_ROOT_MARGIN: '-1px 0px 0px 0px',
   BLOCK_ROOT_MARGIN: '0px 0px -1px 0px',
   THRESHOLD: [0, 1],
 };
@@ -303,9 +295,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
   let isSticky = false;
   let isRetracted = false;
   let stickyHeight = 0;
-  // Scroll direction tracking disabled - see note at bottom of function
-  // let lastScrollY = window.scrollY || window.pageYOffset || 0;
-  // let currentDirection = SCROLL_DIRECTION.DOWN;
   const tableContainers = comparisonBlock.querySelectorAll('.table-container');
   let lastTableRow = null;
   if (tableContainers.length) {
@@ -346,13 +335,9 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     }
     convertHeadingsToDivs(stickyHeader);
     stickyHeader.setAttribute('aria-hidden', 'true');
-    // Only add gnav offset on desktop - mobile sticky header sits at top of viewport
     if (window.matchMedia(BREAKPOINTS.DESKTOP).matches) {
       stickyHeader.classList.add('gnav-offset');
     }
-    // Scroll direction tracking disabled - see note at bottom of function
-    // currentDirection = SCROLL_DIRECTION.DOWN;
-    // lastScrollY = window.scrollY || window.pageYOffset || 0;
 
     stickyHeader.classList.remove('is-retracted');
     isRetracted = false;
@@ -383,7 +368,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     if (!isSticky || !isRetracted) return;
     placeholder.style.display = 'flex';
     placeholder.style.height = `${stickyHeight}px`;
-    // Only add gnav offset on desktop - mobile sticky header sits at top of viewport
     if (window.matchMedia(BREAKPOINTS.DESKTOP).matches) {
       stickyHeader.classList.add('gnav-offset');
     }
@@ -485,31 +469,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
       attributeFilter: ['style', 'class'],
     });
   }
-
-  // NOTE: Previously, gnav-offset was removed on scroll up and added on scroll down.
-  // This was disabled because we want the sticky header to always stay below the gnav.
-  // If visual glitches reappear, consider re-enabling scroll direction handling.
-  // const handleScrollDirection = () => {
-  //   const currentScroll = window.scrollY || window.pageYOffset || 0;
-  //   if (!isSticky || isRetracted) {
-  //     lastScrollY = currentScroll;
-  //     return;
-  //   }
-  //
-  //   const scrolledUp = currentScroll < lastScrollY;
-  //   const newDirection = scrolledUp ? SCROLL_DIRECTION.UP : SCROLL_DIRECTION.DOWN;
-  //   if (newDirection !== currentDirection) {
-  //     if (newDirection === SCROLL_DIRECTION.UP) {
-  //       stickyHeader.classList.remove('gnav-offset');
-  //     } else {
-  //       stickyHeader.classList.add('gnav-offset');
-  //     }
-  //     currentDirection = newDirection;
-  //   }
-  //   lastScrollY = currentScroll;
-  // };
-  //
-  // window.addEventListener('scroll', handleScrollDirection, { passive: true });
 }
 
 /**
@@ -521,12 +480,9 @@ export function synchronizePlanCellHeights(comparisonBlock) {
 
   if (planCellWrappers.length === 0) return;
 
-  // Reset heights to auto to get natural heights
   planCellWrappers.forEach((wrapper) => {
     wrapper.style.height = 'auto';
   });
-
-  // if (comparisonBlock.querySelector('.is-stuck')) return;
 
   // On mobile, only synchronize visible plan cells (not hidden by invisible-content class)
   const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -403,9 +403,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
           }
           return;
         }
-
-        // Only apply sticky state if sentinel is actually above the viewport (scrolled past)
-        // This prevents the sticky header from appearing on initial page load
         const isSentinelAboveViewport = entry.boundingClientRect.top < 0;
         if (!entry.isIntersecting && !isSticky && isSentinelAboveViewport) {
           applyStickyState();

--- a/test/blocks/comparison-table-v2/sticky-header.test.js
+++ b/test/blocks/comparison-table-v2/sticky-header.test.js
@@ -33,6 +33,18 @@ describe('Sticky Header', () => {
     document.body.innerHTML = body;
     clock = sinon.useFakeTimers();
 
+    // Mock window.matchMedia to return desktop by default
+    window.matchMedia = (query) => ({
+      matches: query.includes('1024px'),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+
     // Mock createTag function
     mockCreateTag = (tag, attrs = {}) => {
       const el = document.createElement(tag);
@@ -890,14 +902,17 @@ describe('Sticky Header', () => {
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.false;
     });
 
-    it('should adjust sticky header offset based on scroll direction', () => {
+    it('should maintain gnav-offset when sticky on desktop', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
       comparisonBlock.appendChild(stickyHeader);
-      document.body.appendChild(comparisonBlock);
+
+      const section = document.createElement('section');
+      section.appendChild(comparisonBlock);
+      document.body.appendChild(section);
 
       initStickyBehavior(stickyHeader, comparisonBlock);
 
@@ -908,19 +923,16 @@ describe('Sticky Header', () => {
       }]);
       clock.tick(100);
 
+      // gnav-offset should be added on desktop when sticky
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 
+      // gnav-offset should remain while sticky
       window.pageYOffset = 200;
       window.dispatchEvent(new Event('scroll'));
-
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 
       window.pageYOffset = 150;
-      window.dispatchEvent(new Event('scroll'));
-      expect(stickyHeader.classList.contains('gnav-offset')).to.be.false;
-
-      window.pageYOffset = 250;
       window.dispatchEvent(new Event('scroll'));
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Fixes issue with sticky header of `comparison-table-v2` where it prematurely initializes. 

Sticky header cell heights should also be synchronized on mobile when the sticky header is engaged now.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-186316

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://sticky-header-comp-chart-patch--da-express-milo--adobecom.aem.page/express/why-choose-express?tab=2 |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page on 3 resolutions, the sticky header should not prematurely initialize before you scrolled past it.


<img width="1186" height="205" alt="Screenshot 2026-01-15 at 4 32 24 PM" src="https://github.com/user-attachments/assets/f515b26d-f914-49e0-b53c-4c327293294d" />
<img width="438" height="687" alt="Screenshot 2026-01-15 at 4 32 28 PM" src="https://github.com/user-attachments/assets/d1c8799c-54c5-4ab5-a719-867f6f077024" />


---

## Potential Regressions

- https://sticky-header-comp-chart-patch--da-express-milo--adobecom.aem.page/express/why-choose-express?tab=2

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
