### PR TITLE
Blog posts v2 ct 2

### DIFF
--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -41,7 +41,15 @@ async function fetchBlogIndex(locales) {
 }
 
 function getFeatured(index, urls) {
-  const paths = urls.map((url) => new URL(url).pathname.split('.')[0]);
+  const paths = urls.map((url) => {
+    // Handle both full URLs and pathnames
+    try {
+      return new URL(url).pathname.split('.')[0];
+    } catch {
+      // Already a pathname
+      return url.split('.')[0];
+    }
+  });
   const results = [];
   paths.forEach((path) => {
     const post = index.byPath[path];
@@ -117,6 +125,29 @@ function filterBlogPosts(config, index) {
   return result;
 }
 
+// Normalize URLs in config to pathnames only (for cross-environment comparison)
+function normalizeConfigUrls(config) {
+  const normalized = { ...config };
+  if (normalized.featured) {
+    if (Array.isArray(normalized.featured)) {
+      normalized.featured = normalized.featured.map((url) => {
+        try {
+          return new URL(url).pathname;
+        } catch {
+          return url;
+        }
+      });
+    } else {
+      try {
+        normalized.featured = new URL(normalized.featured).pathname;
+      } catch {
+        // Keep as is if not a valid URL
+      }
+    }
+  }
+  return normalized;
+}
+
 // Given a block element, construct a config object from all the links that children of the block.
 function getBlogPostsConfig(block) {
   let config = {};
@@ -126,13 +157,20 @@ function getBlogPostsConfig(block) {
 
   if (rows.length === 1 && firstRow.length === 1) {
     /* handle links */
-    const links = [...block.querySelectorAll('a')].map((a) => a.href);
+    const links = [...block.querySelectorAll('a')].map((a) => {
+      try {
+        return new URL(a.href).pathname;
+      } catch {
+        return a.href;
+      }
+    });
     config = {
       featured: links,
       featuredOnly: true,
     };
   } else {
     config = readBlockConfig(block);
+    config = normalizeConfigUrls(config);
   }
   return config;
 }
@@ -150,7 +188,8 @@ async function filterAllBlogPostsOnPage() {
       const locales = [getConfig().locale.prefix];
       const allBlogLinks = document.querySelectorAll('.blog-posts-v2 a');
       allBlogLinks.forEach((l) => {
-        const blogLocale = getLocale(getConfig().locales, new URL(l).pathname).prefix;
+        const pathname = l.pathname || new URL(l.href).pathname;
+        const blogLocale = getLocale(getConfig().locales, pathname).prefix;
         if (!locales.includes(blogLocale)) {
           locales.push(blogLocale);
         }


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

There is a bug with the way the Blog Posts V2 block filters blog posts. Does not affect production, but it expects an exact match for the origin of the fetched blog posts with our branch name currently if the environment is not prod or localhost. Create a more flexible filtering check that ignores the origin.



---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-186303

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
