### PR TITLE
Emergency Homepage Fixes

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -102,7 +102,7 @@
   text-align: left; 
   margin-bottom: 8px;
   font-size: var(--heading-font-size-m);
-  line-height: 2.925rem;
+  line-height: 130%;
   max-width: 800px;
 }
 
@@ -458,7 +458,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
 
 .gen-ai-cards.homepage .gen-ai-cards-heading-section h3 {
   font-size: var(--heading-font-size-l);
-  line-height: 2.925rem;
+  line-height: 130%;
 }
 
 .gen-ai-cards.homepage:not(.spotlight) .gen-ai-cards-heading-section h3,

--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -286,7 +286,7 @@ main .section .grid-marquee h1 {
   flex-wrap: wrap;
   align-items: center;
   padding-top: var(--spacing-600);
-  gap: var(--spacing-200) var(--spacing-650);
+  gap: var(--spacing-200) var(--spacing-700);
   min-height: 39px;
 }
 

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -126,6 +126,7 @@
   --spacing-400: 24px;
   --spacing-500: 32px;
   --spacing-600: 40px;
+  --spacing-650: 44px;
   --spacing-700: 48px;
   --spacing-800: 64px;
   --spacing-900: 80px;

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -126,7 +126,6 @@
   --spacing-400: 24px;
   --spacing-500: 32px;
   --spacing-600: 40px;
-  --spacing-650: 44px;
   --spacing-700: 48px;
   --spacing-800: 64px;
   --spacing-900: 80px;


### PR DESCRIPTION
Hotfix for the homepage.

1) Incorrect spacing in ratings section of the `grid-marquee` block caused by invalid variable.

2) Incorrect `line-height` value in the `gen-ai-cards` block


https://ratings-fix--da-express-milo--adobecom.aem.page/express/?audience=individuals