### PR TITLE
Sticky Header Scroll End Bug Fix

### DIFF
--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -255,32 +255,18 @@ export function createStickyHeader(headerGroup, comparisonBlock) {
 }
 
 /**
- * Get the visible bottom boundary of the comparison block content
- * Accounts for collapsed tables by using section headers as boundaries
+ * Get the bottom boundary of the comparison block content
+ * Returns the bottom of the last table container regardless of collapsed state
  * @param {HTMLElement} comparisonBlock - The comparison table block element
- * @returns {number} - The bottom Y coordinate of visible content
+ * @returns {number} - The bottom Y coordinate of the block content
  */
-function getVisibleContentBottom(comparisonBlock) {
+function getContentBottom(comparisonBlock) {
   const allTableContainers = comparisonBlock.querySelectorAll('.table-container');
-  let lastVisibleBottom = comparisonBlock.getBoundingClientRect().bottom;
-
-  for (let i = allTableContainers.length - 1; i >= 0; i -= 1) {
-    const container = allTableContainers[i];
-    const table = container.querySelector('table');
-    const isCollapsed = table && table.classList.contains('hide-table');
-
-    if (!isCollapsed && table) {
-      lastVisibleBottom = container.getBoundingClientRect().bottom;
-      break;
-    } else if (isCollapsed) {
-      const firstRow = container.querySelector('.first-row');
-      if (firstRow) {
-        lastVisibleBottom = firstRow.getBoundingClientRect().bottom;
-      }
-    }
+  if (allTableContainers.length > 0) {
+    const lastContainer = allTableContainers[allTableContainers.length - 1];
+    return lastContainer.getBoundingClientRect().bottom;
   }
-
-  return lastVisibleBottom;
+  return comparisonBlock.getBoundingClientRect().bottom;
 }
 
 /**
@@ -380,9 +366,11 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     }
 
     const headerTop = headerSentinel.getBoundingClientRect().top;
-    const contentBottom = getVisibleContentBottom(comparisonBlock);
+    const contentBottom = getContentBottom(comparisonBlock);
     const isPastHeader = headerTop < 0;
-    const isContentVisible = contentBottom > 0;
+    // Offset by sticky header height for smoother transition
+    const headerOffset = stickyHeight || stickyHeader.offsetHeight;
+    const isContentVisible = contentBottom > headerOffset;
 
     if (!isPastHeader) {
       // Header is in view - remove sticky

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -10,11 +10,6 @@ const DROPDOWN = {
   MIN_COLUMNS_FOR_SELECTOR: 2,
 };
 
-const OBSERVER_CONFIG = {
-  BLOCK_ROOT_MARGIN: '0px 0px -1px 0px',
-  THRESHOLD: [0, 1],
-};
-
 let createTag;
 
 /**
@@ -33,14 +28,11 @@ function convertHeadingsToDivs(stickyHeader) {
   const headings = stickyHeader.querySelectorAll('h1, h2, h3, h4, h5, h6');
   headings.forEach((heading) => {
     const div = document.createElement('div');
-    // Copy all attributes
     Array.from(heading.attributes).forEach((attr) => {
       div.setAttribute(attr.name, attr.value);
     });
-    // Add a marker class and store original tag name
     div.classList.add('sticky-header-title');
     div.setAttribute('data-original-tag', heading.tagName.toLowerCase());
-    // Move all children
     while (heading.firstChild) {
       div.appendChild(heading.firstChild);
     }
@@ -56,19 +48,15 @@ function convertDivsToHeadings(stickyHeader) {
   const divs = stickyHeader.querySelectorAll('.sticky-header-title[data-original-tag]');
   divs.forEach((div) => {
     const originalTag = div.getAttribute('data-original-tag');
-    // Only allow safe heading tags
     const allowedTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
     const safeTag = allowedTags.includes(originalTag) ? originalTag : 'div';
     const heading = document.createElement(safeTag);
-    // Copy all attributes except our custom ones
     Array.from(div.attributes).forEach((attr) => {
       if (attr.name !== 'data-original-tag') {
         heading.setAttribute(attr.name, attr.value);
       }
     });
-    // Remove the marker class
     heading.classList.remove('sticky-header-title');
-    // Move all children
     while (div.firstChild) {
       heading.appendChild(div.firstChild);
     }
@@ -95,7 +83,6 @@ function createPlanDropdownChoices(headers) {
     option.appendChild(a);
     option.classList.add('plan-selector-choice');
     option.value = i;
-
     option.setAttribute('data-plan-index', i);
     option.setAttribute('role', 'option');
     option.setAttribute('aria-selected', 'false');
@@ -121,7 +108,6 @@ function createPlanSelector(headers, planIndex, planCellWrapper) {
   planSelector.classList.add('plan-selector');
   planSelector.setAttribute('data-plan-index', planIndex);
 
-  // Add keyboard support for opening dropdown
   selectWrapper.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -132,15 +118,12 @@ function createPlanSelector(headers, planIndex, planCellWrapper) {
   selectWrapper.appendChild(planSelector);
   planSelector.appendChild(createPlanDropdownChoices(headers));
 
-  // Add click handler to plan cell wrapper
   planCellWrapper.addEventListener('click', (e) => {
-    // Don't trigger if clicking on action button or dropdown
     if (!e.target.closest('.action-area') && !e.target.closest('.plan-selector-wrapper')) {
       planSelector.click();
     }
   });
 
-  // Add keyboard support
   planCellWrapper.addEventListener('keydown', (e) => {
     if (e.target === planCellWrapper && !e.target.closest('.action-area')) {
       if (e.key === 'Enter' || e.key === ' ') {
@@ -151,31 +134,29 @@ function createPlanSelector(headers, planIndex, planCellWrapper) {
         const isOpen = !dropdown.classList.contains('invisible-content');
 
         if (!isOpen) {
-          // Only open dropdown if it's not already open
           e.preventDefault();
           planSelector.click();
-
-          // Focus the first option after dropdown opens
           setTimeout(() => {
-            const firstOption = dropdown.querySelector('.plan-selector-choice:not(.invisible-content)');
+            const firstOption = dropdown.querySelector(
+              '.plan-selector-choice:not(.invisible-content)',
+            );
             if (firstOption) {
               firstOption.classList.add('focused');
               firstOption.focus();
             }
           }, 0);
         } else {
-          // If dropdown is already open, check if anything is focused
           const focusedOption = dropdown.querySelector('.plan-selector-choice.focused');
           if (!focusedOption) {
-            // Nothing is focused, focus the first option
             e.preventDefault();
-            const firstOption = dropdown.querySelector('.plan-selector-choice:not(.invisible-content)');
+            const firstOption = dropdown.querySelector(
+              '.plan-selector-choice:not(.invisible-content)',
+            );
             if (firstOption) {
               firstOption.classList.add('focused');
               firstOption.focus();
             }
           }
-          // If something is already focused, let the event bubble to the selector's keydown handler
         }
       }
     }
@@ -193,24 +174,19 @@ export function createStickyHeader(headerGroup, comparisonBlock) {
   const headerGroupElement = headerGroup[1];
   headerGroupElement.classList.add('sticky-header');
 
-  // Create wrapper div for all header content
   const headerWrapper = document.createElement('div');
   headerWrapper.classList.add('sticky-header-wrapper');
 
-  // Move all existing children to the wrapper
   while (headerGroupElement.firstChild) {
     headerWrapper.appendChild(headerGroupElement.firstChild);
   }
-
-  // Add the wrapper back to the header
   headerGroupElement.appendChild(headerWrapper);
 
   const headerCells = headerWrapper.querySelectorAll('div');
   const headers = Array.from(headerCells).map((cell) => {
     const children = Array.from(cell.children);
     const childContent = children.filter((child) => !child.querySelector('a'));
-    const output = childContent.map((content) => content.textContent.trim()).join(', ').replaceAll(',', '');
-    return output;
+    return childContent.map((content) => content.textContent.trim()).join(', ').replaceAll(',', '');
   });
   const totalColumns = headers.length;
   headers.splice(0, 1);
@@ -223,12 +199,10 @@ export function createStickyHeader(headerGroup, comparisonBlock) {
     } else {
       const planCellWrapper = createTag('div', { class: 'plan-cell-wrapper' });
 
-      // Add two-columns class if there are only 2 columns
       if (headers.length === DROPDOWN.MIN_COLUMNS_FOR_SELECTOR) {
         planCellWrapper.classList.add('two-columns');
       }
 
-      // Only set tabindex and interactive attributes on mobile when there are more than 2 columns
       const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
       const hasMoreThanTwoColumns = headers.length > DROPDOWN.MIN_COLUMNS_FOR_SELECTOR;
       if (!isDesktop && hasMoreThanTwoColumns) {
@@ -247,12 +221,11 @@ export function createStickyHeader(headerGroup, comparisonBlock) {
       if (cellIndex === headerCells.length - 1) {
         headerCell.classList.add('last');
       }
-      const lenght = headerCell.children.length;
-      for (let i = 0; i < lenght; i += 1) {
+      const { length } = headerCell.children;
+      for (let i = 0; i < length; i += 1) {
         planCellWrapper.appendChild(headerCell.children[0]);
       }
 
-      // Only create plan selector if there are more than 2 columns
       if (headers.length > DROPDOWN.MIN_COLUMNS_FOR_SELECTOR) {
         createPlanSelector(headers, cellIndex - 1, planCellWrapper);
       }
@@ -282,12 +255,41 @@ export function createStickyHeader(headerGroup, comparisonBlock) {
 }
 
 /**
+ * Get the visible bottom boundary of the comparison block content
+ * Accounts for collapsed tables by using section headers as boundaries
+ * @param {HTMLElement} comparisonBlock - The comparison table block element
+ * @returns {number} - The bottom Y coordinate of visible content
+ */
+function getVisibleContentBottom(comparisonBlock) {
+  const allTableContainers = comparisonBlock.querySelectorAll('.table-container');
+  let lastVisibleBottom = comparisonBlock.getBoundingClientRect().bottom;
+
+  for (let i = allTableContainers.length - 1; i >= 0; i -= 1) {
+    const container = allTableContainers[i];
+    const table = container.querySelector('table');
+    const isCollapsed = table && table.classList.contains('hide-table');
+
+    if (!isCollapsed && table) {
+      lastVisibleBottom = container.getBoundingClientRect().bottom;
+      break;
+    } else if (isCollapsed) {
+      const firstRow = container.querySelector('.first-row');
+      if (firstRow) {
+        lastVisibleBottom = firstRow.getBoundingClientRect().bottom;
+      }
+    }
+  }
+
+  return lastVisibleBottom;
+}
+
+/**
  * Initialize sticky behavior for the header element
+ * Uses visual bounds exclusively for all sticky state decisions
  * @param {HTMLElement} stickyHeader - The sticky header element
  * @param {HTMLElement} comparisonBlock - The comparison table block element
  */
 export function initStickyBehavior(stickyHeader, comparisonBlock) {
-  // Create placeholder element to maintain layout when header becomes fixed
   const placeholder = document.createElement('div');
   placeholder.classList.add('sticky-header-placeholder');
   comparisonBlock.insertBefore(placeholder, stickyHeader.nextSibling);
@@ -295,36 +297,31 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
   let isSticky = false;
   let isRetracted = false;
   let stickyHeight = 0;
-  const tableContainers = comparisonBlock.querySelectorAll('.table-container');
-  let lastTableRow = null;
-  if (tableContainers.length) {
-    const lastTable = tableContainers[tableContainers.length - 1].querySelector('table');
-    if (lastTable) {
-      lastTableRow = lastTable.querySelector('tbody tr:last-of-type')
-        || lastTable.querySelector('tr:last-of-type');
-    }
-  }
+
+  // Sentinel at the top of the block to detect when header should become sticky
   const headerSentinel = document.createElement('div');
-  headerSentinel.style.position = 'absolute';
-  headerSentinel.style.top = '0px';
-  headerSentinel.style.height = '1px';
-  headerSentinel.style.width = '100%';
-  headerSentinel.style.pointerEvents = 'none';
+  headerSentinel.style.cssText = 'position:absolute;top:0;height:1px;width:100%;pointer-events:none';
   comparisonBlock.style.position = 'relative';
   comparisonBlock.insertAdjacentElement('beforebegin', headerSentinel);
 
+  const getParentSection = () => comparisonBlock.closest('.section')
+    || comparisonBlock.closest('section');
+
+  const isSectionHidden = () => {
+    const section = getParentSection();
+    if (!section) return false;
+    return section.classList.contains('content-toggle-hidden')
+      || section.classList.contains('display-none')
+      || section.style.display === 'none';
+  };
+
   const applyStickyState = () => {
-    if (isSticky) {
-      if (isRetracted) {
-        stickyHeader.classList.remove('is-retracted');
-        isRetracted = false;
-      }
-      return;
-    }
+    if (isSticky && !isRetracted) return;
 
     const stickyHeaderHeight = stickyHeader.offsetHeight;
     stickyHeight = stickyHeaderHeight;
     stickyHeader.classList.add('is-stuck');
+    stickyHeader.classList.remove('is-retracted');
     placeholder.style.display = 'flex';
     placeholder.style.height = `${stickyHeaderHeight}px`;
 
@@ -339,19 +336,16 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
       stickyHeader.classList.add('gnav-offset');
     }
 
-    stickyHeader.classList.remove('is-retracted');
     isRetracted = false;
     isSticky = true;
   };
 
   const removeStickyState = () => {
     if (!isSticky) return;
-    stickyHeader.classList.remove('is-stuck');
+    stickyHeader.classList.remove('is-stuck', 'is-retracted', 'gnav-offset');
     placeholder.style.display = 'none';
-    stickyHeader.classList.remove('gnav-offset');
     convertDivsToHeadings(stickyHeader);
     stickyHeader.removeAttribute('aria-hidden');
-    stickyHeader.classList.remove('is-retracted');
     isRetracted = false;
     isSticky = false;
   };
@@ -375,178 +369,71 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     isRetracted = false;
   };
 
-  const getParentSection = () => comparisonBlock.closest('.section') || comparisonBlock.closest('section');
-
-  // Helper to check if section is hidden by content-toggle or other mechanisms
-  const isSectionHidden = () => {
-    const section = getParentSection();
-    if (!section) return false;
-    return section.classList.contains('content-toggle-hidden')
-      || section.classList.contains('display-none')
-      || section.style.display === 'none';
-  };
-
-  // Intersection Observer to detect when header should become sticky (at the top)
-  const headerObserver = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (isSectionHidden()) {
-          if (isSticky) {
-            removeStickyState();
-          }
-          return;
-        }
-        const isSentinelAboveViewport = entry.boundingClientRect.top < 0;
-        if (!entry.isIntersecting && !isSticky && isSentinelAboveViewport) {
-          applyStickyState();
-        } else if (entry.isIntersecting && isSticky) {
-          removeStickyState();
-        }
-      });
-    },
-    {
-      rootMargin: '0px 0px 0px 0px',
-      threshold: 0,
-    },
-  );
-
-  // Helper to check if the last table row is inside a collapsed table
-  const isLastRowInCollapsedTable = () => {
-    if (!lastTableRow) return false;
-    const parentTable = lastTableRow.closest('table');
-    return parentTable && parentTable.classList.contains('hide-table');
-  };
-
-  // Helper to get the visible bottom boundary of the comparison block content
-  const getVisibleContentBottom = () => {
-    // Find all table containers and get the last one with visible content
-    const allTableContainers = comparisonBlock.querySelectorAll('.table-container');
-    let lastVisibleBottom = comparisonBlock.getBoundingClientRect().bottom;
-
-    // Iterate through table containers to find the actual visible bottom
-    for (let i = allTableContainers.length - 1; i >= 0; i -= 1) {
-      const container = allTableContainers[i];
-      const table = container.querySelector('table');
-      const isCollapsed = table && table.classList.contains('hide-table');
-
-      if (!isCollapsed && table) {
-        // This table is visible, use its bottom
-        lastVisibleBottom = container.getBoundingClientRect().bottom;
-        break;
-      } else if (isCollapsed) {
-        // Table is collapsed, use the section header (first-row) as the bottom
-        const firstRow = container.querySelector('.first-row');
-        if (firstRow) {
-          lastVisibleBottom = firstRow.getBoundingClientRect().bottom;
-        }
-      }
+  /**
+   * Update sticky state based on visual bounds
+   * Single source of truth for all sticky behavior
+   */
+  const updateStickyState = () => {
+    if (isSectionHidden()) {
+      if (isSticky) removeStickyState();
+      return;
     }
 
-    return lastVisibleBottom;
-  };
+    const headerTop = headerSentinel.getBoundingClientRect().top;
+    const contentBottom = getVisibleContentBottom(comparisonBlock);
+    const isPastHeader = headerTop < 0;
+    const isContentVisible = contentBottom > 0;
 
-  // Intersection Observer to detect when comparison block exits/enters viewport (at the bottom)
-  const blockObserver = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        const isLastRowTarget = lastTableRow && entry.target === lastTableRow;
-
-        if (isLastRowTarget) {
-          // Check if the last table is collapsed - if so, use visible content bounds
-          if (isLastRowInCollapsedTable()) {
-            const visibleBottom = getVisibleContentBottom();
-            const contentAboveFold = visibleBottom <= 0;
-
-            if (contentAboveFold) {
-              retractStickyHeader();
-            } else if (headerSentinel.getBoundingClientRect().top < 0 && visibleBottom > 0) {
-              if (!isSticky) {
-                applyStickyState();
-              } else if (isRetracted) {
-                revealStickyHeader();
-              }
-            }
-            return;
-          }
-
-          const rowAboveFold = entry.boundingClientRect.top <= 0;
-
-          if (rowAboveFold) {
-            retractStickyHeader();
-          } else if (entry.isIntersecting && headerSentinel.getBoundingClientRect().top < 0) {
-            if (!isSticky) {
-              applyStickyState();
-            } else {
-              revealStickyHeader();
-            }
-          }
-          return;
-        }
-
-        if (!entry.isIntersecting && isSticky) {
-          // Comparison block (fallback) leaving viewport at the bottom - remove sticky
-          removeStickyState();
-        } else if (entry.isIntersecting
-          && !isSticky
-          && headerSentinel.getBoundingClientRect().top < 0) {
-          applyStickyState();
-        }
-      });
-    },
-    {
-      // Trigger when comparison block is about to leave viewport at the bottom
-      rootMargin: OBSERVER_CONFIG.BLOCK_ROOT_MARGIN,
-      threshold: OBSERVER_CONFIG.THRESHOLD,
-    },
-  );
-
-  // Observe the header sentinel for sticky behavior
-  headerObserver.observe(headerSentinel);
-
-  // Observe the last table row if available, otherwise fall back to the whole block
-  const blockObserverTarget = lastTableRow || comparisonBlock;
-  blockObserver.observe(blockObserverTarget);
-
-  // Scroll handler for collapsed table fallback - IntersectionObserver may not fire
-  // reliably when the observed element is inside a collapsed table
-  let scrollTicking = false;
-  const handleCollapsedTableScroll = () => {
-    if (isSectionHidden()) return;
-    if (!isLastRowInCollapsedTable()) return;
-
-    const visibleBottom = getVisibleContentBottom();
-    const headerSentinelTop = headerSentinel.getBoundingClientRect().top;
-    const isPastHeader = headerSentinelTop < 0;
-    const isContentVisible = visibleBottom > 0;
-
-    if (isPastHeader && !isContentVisible) {
-      // Content has scrolled above viewport - retract
-      if (isSticky && !isRetracted) {
-        retractStickyHeader();
-      }
-    } else if (isPastHeader && isContentVisible) {
-      // Content is still visible and we're past the header
+    if (!isPastHeader) {
+      // Header is in view - remove sticky
+      removeStickyState();
+    } else if (isPastHeader && !isContentVisible) {
+      // Past header and content is above viewport - retract
       if (!isSticky) {
-        // Need to apply sticky state
+        applyStickyState();
+      }
+      retractStickyHeader();
+    } else if (isPastHeader && isContentVisible) {
+      // Past header and content is visible - show sticky header
+      if (!isSticky) {
         applyStickyState();
       } else if (isRetracted) {
-        // Need to reveal from retracted state
         revealStickyHeader();
       }
     }
   };
 
+  // Single scroll listener handles all sticky state changes
+  let scrollTicking = false;
   window.addEventListener('scroll', () => {
     if (!scrollTicking) {
       requestAnimationFrame(() => {
-        handleCollapsedTableScroll();
+        updateStickyState();
         scrollTicking = false;
       });
       scrollTicking = true;
     }
   }, { passive: true });
 
-  // Watch for changes to parent section's display property or class (content-toggle)
+  // Observer for initial state and when scrolling back to top
+  const headerObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (isSectionHidden()) {
+          if (isSticky) removeStickyState();
+          return;
+        }
+        // When sentinel comes back into view, remove sticky
+        if (entry.isIntersecting && isSticky) {
+          removeStickyState();
+        }
+      });
+    },
+    { threshold: 0 },
+  );
+  headerObserver.observe(headerSentinel);
+
+  // Watch for content-toggle visibility changes
   const parentSection = getParentSection();
   if (parentSection) {
     const mutationObserver = new MutationObserver(() => {
@@ -554,7 +441,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
         removeStickyState();
       }
     });
-
     mutationObserver.observe(parentSection, {
       attributes: true,
       attributeFilter: ['style', 'class'],
@@ -575,11 +461,9 @@ export function synchronizePlanCellHeights(comparisonBlock) {
     wrapper.style.height = 'auto';
   });
 
-  // Don't synchronize heights when header is stuck (different layout)
   const stickyHeader = comparisonBlock.querySelector('.is-stuck');
   if (stickyHeader) return;
 
-  // On mobile, only synchronize visible plan cells (not hidden by invisible-content class)
   const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
   const visibleWrappers = isDesktop
     ? planCellWrappers
@@ -590,16 +474,14 @@ export function synchronizePlanCellHeights(comparisonBlock) {
 
   if (visibleWrappers.length === 0) return;
 
-  // Find the maximum height among visible wrappers
   let maxHeight = 0;
   visibleWrappers.forEach((wrapper) => {
-    const height = wrapper.offsetHeight;
-    if (height > maxHeight) {
-      maxHeight = height;
+    const { offsetHeight } = wrapper;
+    if (offsetHeight > maxHeight) {
+      maxHeight = offsetHeight;
     }
   });
 
-  // Apply the maximum height to visible wrappers only
   visibleWrappers.forEach((wrapper) => {
     wrapper.style.height = `${maxHeight}px`;
   });

--- a/test/blocks/comparison-table-v2/sticky-header.test.js
+++ b/test/blocks/comparison-table-v2/sticky-header.test.js
@@ -408,9 +408,14 @@ describe('Sticky Header', () => {
     it('should handle sticky state transitions', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
-      stickyHeader.style.height = '100px';
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
+
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
 
       // Add required parent structure
       const section = document.createElement('section');
@@ -421,24 +426,27 @@ describe('Sticky Header', () => {
 
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      const headerObserver = observerCallbacks[0];
       const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
+      const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // Simulate header scrolling past top
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -10 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
+
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
 
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(placeholder.style.display).to.equal('flex');
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 
-      // Simulate header coming back into view
-      headerObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: 0 },
-      }]);
+      // Mock header sentinel back in viewport
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: 10 });
+
+      // Trigger scroll to remove sticky
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
 
       expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.false;
@@ -449,38 +457,51 @@ describe('Sticky Header', () => {
       const section = document.createElement('section');
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
+
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
+
       comparisonBlock.appendChild(stickyHeader);
       section.appendChild(comparisonBlock);
       document.body.appendChild(section);
 
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      const headerObserver = observerCallbacks[0];
+      const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
+      const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // First make the header sticky by triggering observer
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -10 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
+
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
 
       // Verify it's now sticky
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
 
       // Add display-none class to parent element
-      comparisonBlock.parentElement.classList.add('display-none');
+      section.classList.add('display-none');
 
-      // Trigger observer again with hidden parent
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Trigger scroll again with hidden parent
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
+      // Should remove sticky when section is hidden
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
+      expect(placeholder.style.display).to.equal('none');
     });
 
     it('should close dropdown when becoming sticky', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       // Create mock dropdown structure
       const wrapper = document.createElement('div');
@@ -494,6 +515,10 @@ describe('Sticky Header', () => {
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
 
       // Add required parent structure
       const section = document.createElement('section');
@@ -514,13 +539,15 @@ describe('Sticky Header', () => {
 
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      const headerObserver = observerCallbacks[0];
+      const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // Simulate header scrolling past top
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -10 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
+
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
 
       expect(closeDropdownCalled).to.be.true;
       expect(closeDropdownArg).to.equal(selector);
@@ -529,13 +556,18 @@ describe('Sticky Header', () => {
       ComparisonTableState.closeDropdown = originalCloseDropdown;
     });
 
-    it('should remove sticky when comparison block exits viewport at bottom', () => {
+    it('should retract sticky when scrolled past content bottom', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
       comparisonBlock.appendChild(stickyHeader);
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
 
       const section = document.createElement('section');
       section.appendChild(comparisonBlock);
@@ -544,45 +576,40 @@ describe('Sticky Header', () => {
       // Initialize sticky behavior
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      // Get the placeholder that was created
+      // Get the placeholder and sentinel
       const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
+      const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // Get the header observer and make header sticky first
-      const headerObserver = observerCallbacks[0];
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Mock getBoundingClientRect - header sentinel above viewport
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -50 });
+      // Mock content bottom below sticky header height (visible)
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 200 });
 
-      // Wait for transition
+      // Trigger scroll to apply sticky state
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       // Verify header is sticky
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
-      expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
       expect(placeholder.style.display).to.equal('flex');
 
-      // Now get the block observer (second observer)
-      const blockObserver = observerCallbacks[1];
+      // Now mock content bottom above header height (not visible)
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 50 });
 
-      // Simulate comparison block leaving viewport at bottom
-      // The block observer only triggers removal when isSticky is true
-      blockObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { bottom: -10 },
-      }]);
-
+      // Trigger scroll
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
-      // Header should no longer be sticky
-      expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
-      expect(stickyHeader.classList.contains('gnav-offset')).to.be.false;
+      // Header should be retracted
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
+      expect(stickyHeader.classList.contains('is-retracted')).to.be.true;
       expect(placeholder.style.display).to.equal('none');
     });
 
-    it('should toggle sticky state when the last table row crosses the viewport threshold', () => {
+    it('should toggle sticky state based on scroll position and content visibility', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
@@ -610,52 +637,45 @@ describe('Sticky Header', () => {
       initStickyBehavior(stickyHeader, comparisonBlock);
 
       const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
-      const headerObserver = observerCallbacks[0];
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      const headerSentinel = comparisonBlock.previousElementSibling;
+
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -30 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
+
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(placeholder.style.display).to.equal('flex');
       expect(stickyHeader.classList.contains('is-retracted')).to.be.false;
 
-      const blockObserver = observerCallbacks[1];
-      const lastRow = tbody.lastElementChild;
+      // Content scrolls past (bottom <= header height)
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 50 });
 
-      // Last row crosses above the fold (top <= 0)
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: -5, bottom: 40 },
-        target: lastRow,
-      }]);
-
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('is-retracted')).to.be.true;
       expect(placeholder.style.display).to.equal('none');
 
-      // Prepare header sentinel for reapply - sentinel is inserted before block, not as child
-      const headerSentinel = comparisonBlock.previousElementSibling;
-      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -30 });
+      // Content comes back into view
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 300 });
 
-      // Last row re-enters viewport (top > 0)
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: 20, bottom: 60 },
-        target: lastRow,
-      }]);
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
 
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('is-retracted')).to.be.false;
       expect(placeholder.style.display).to.equal('flex');
     });
 
-    it('should only respond to the last row of the final table container', () => {
+    it('should use last table container bottom for visibility check', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
@@ -689,46 +709,35 @@ describe('Sticky Header', () => {
       initStickyBehavior(stickyHeader, comparisonBlock);
 
       const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
-      const headerObserver = observerCallbacks[0];
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      const headerSentinel = comparisonBlock.previousElementSibling;
+
+      // Mock header sentinel above viewport
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -20 });
+      // Last container is still visible
+      second.container.getBoundingClientRect = sinon.stub().returns({ bottom: 300 });
+
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('is-retracted')).to.be.false;
       expect(placeholder.style.display).to.equal('flex');
 
-      const blockObserver = observerCallbacks[1];
+      // Last container scrolls past header height
+      second.container.getBoundingClientRect = sinon.stub().returns({ bottom: 50 });
 
-      // First container last row exits viewport - should NOT toggle sticky
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: -5, bottom: 30 },
-        target: first.lastRow,
-      }]);
-      expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
-
-      // Second container last row exits viewport - should toggle off
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: -5, bottom: 30 },
-        target: second.lastRow,
-      }]);
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
+
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('is-retracted')).to.be.true;
 
-      // Re-enter with header sentinel still above viewport
-      // Sentinel is inserted before block, not as child
-      const headerSentinel = comparisonBlock.previousElementSibling;
-      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -20 });
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: 10, bottom: 40 },
-        target: second.lastRow,
-      }]);
+      // Last container comes back into view
+      second.container.getBoundingClientRect = sinon.stub().returns({ bottom: 200 });
+
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('is-retracted')).to.be.false;
     });
@@ -736,9 +745,15 @@ describe('Sticky Header', () => {
     it('should handle parent section style.display changes via MutationObserver', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
+
       comparisonBlock.appendChild(stickyHeader);
 
       const section = document.createElement('section');
@@ -763,17 +778,16 @@ describe('Sticky Header', () => {
       // Initialize sticky behavior
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      // Get the placeholder that was created
+      // Get the placeholder and sentinel
       const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
+      const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // Get the header observer and make header sticky
-      const headerObserver = observerCallbacks[0];
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -10 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
 
-      // Wait for transition
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       // Verify header is sticky
@@ -801,14 +815,18 @@ describe('Sticky Header', () => {
       expect(placeholder.style.display).to.equal('none');
     });
 
-    it('should reapply sticky header when scrolling back up after block exits viewport', () => {
+    it('should reveal sticky header when scrolling back up into content', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
-      stickyHeader.style.height = '100px';
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
       comparisonBlock.appendChild(stickyHeader);
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
 
       const section = document.createElement('section');
       section.appendChild(comparisonBlock);
@@ -819,61 +837,56 @@ describe('Sticky Header', () => {
 
       // Get the placeholder and header sentinel
       const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
-      // Sentinel is inserted before block, not as child
       const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // Mock getBoundingClientRect for header sentinel
-      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -50 }); // Above viewport
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -50 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 300 });
 
-      // Get observers
-      const headerObserver = observerCallbacks[0];
-      const blockObserver = observerCallbacks[1];
-
-      // First make header sticky by scrolling past it
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       // Verify header is sticky
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 
-      // Now simulate block exiting viewport at bottom
-      blockObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { bottom: -10 },
-      }]);
+      // Content scrolls past (retract)
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 50 });
 
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
-      // Sticky should be removed
-      expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
-      expect(stickyHeader.classList.contains('gnav-offset')).to.be.false;
+      // Should be retracted
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
+      expect(stickyHeader.classList.contains('is-retracted')).to.be.true;
       expect(placeholder.style.display).to.equal('none');
 
-      // Now simulate block re-entering viewport (scrolling back up)
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: 0, bottom: 100 },
-      }]);
+      // Scroll back up - content visible again
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 300 });
 
-      // Should reapply sticky since header sentinel is above viewport
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
+      // Should reveal sticky header
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
+      expect(stickyHeader.classList.contains('is-retracted')).to.be.false;
       expect(placeholder.style.display).to.equal('flex');
-      expect(placeholder.style.height).to.equal('100px');
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
     });
 
-    it('should not reapply sticky header when block re-enters but header sentinel is in viewport', () => {
+    it('should not apply sticky when header sentinel is in viewport', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
-      stickyHeader.style.height = '100px';
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
       comparisonBlock.appendChild(stickyHeader);
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
 
       const section = document.createElement('section');
       section.appendChild(comparisonBlock);
@@ -882,20 +895,16 @@ describe('Sticky Header', () => {
       // Initialize sticky behavior
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      // Get the header sentinel - it's inserted before block, not as child
+      // Get the header sentinel
       const headerSentinel = comparisonBlock.previousElementSibling;
 
-      // Mock getBoundingClientRect for header sentinel - visible in viewport
-      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: 50 }); // Below top
+      // Mock header sentinel visible in viewport (not past it)
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: 50 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
 
-      // Get block observer
-      const blockObserver = observerCallbacks[1];
-
-      // Simulate block re-entering viewport when header sentinel is visible
-      blockObserver.callback([{
-        isIntersecting: true,
-        boundingClientRect: { top: 0, bottom: 100 },
-      }]);
+      // Trigger scroll
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
 
       // Should not apply sticky since header sentinel is in viewport
       expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
@@ -905,9 +914,15 @@ describe('Sticky Header', () => {
     it('should maintain gnav-offset when sticky on desktop', () => {
       const stickyHeader = document.createElement('div');
       stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
 
       const comparisonBlock = document.createElement('div');
       comparisonBlock.classList.add('comparison-table-v2');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
+
       comparisonBlock.appendChild(stickyHeader);
 
       const section = document.createElement('section');
@@ -916,27 +931,30 @@ describe('Sticky Header', () => {
 
       initStickyBehavior(stickyHeader, comparisonBlock);
 
-      const headerObserver = observerCallbacks[0];
-      headerObserver.callback([{
-        isIntersecting: false,
-        boundingClientRect: { top: -10 },
-      }]);
+      const headerSentinel = comparisonBlock.previousElementSibling;
+
+      // Mock header sentinel above viewport, content visible
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -10 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
+
+      // Trigger scroll to apply sticky
+      window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
       // gnav-offset should be added on desktop when sticky
       expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 
-      // gnav-offset should remain while sticky
-      window.pageYOffset = 200;
+      // gnav-offset should remain while sticky (content still visible)
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 400 });
       window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
 
-      window.pageYOffset = 150;
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 300 });
       window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
       expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
-
-      window.pageYOffset = 0;
     });
   });
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Fix the sticky header not disappearing at the bottom of the comparison table in certain edge cases (such as when the bottom table is collapsed)

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-186316

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/why-choose-express |
| **After**   | https://sticky-header-scroll-end--da-express-milo--adobecom.aem.page/express/why-choose-express |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page and scroll down, the sticky header should disappear after you pass the comparison table content entirely and should reappear if you scroll up to an open table.

---

## Potential Regressions

- https://sticky-header-scroll-end--da-express-milo--adobecom.aem.live/express/why-choose-express

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
