### PR TITLE
[DOTCOM-176415] Fixed Remove BG, Resize workflow not working in iOS mWeb

### DIFF
--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -467,6 +467,7 @@ export function createSDKConfig(getConfig, urlParams) {
     configParams: {
       locale: ietf?.replace('-', '_'),
       env: isStageEnv ? 'stage' : 'prod',
+      skipBrowserSupportCheck: true,
     },
     authOption: () => ({ mode: 'delayed' }),
   };


### PR DESCRIPTION
## Summary

Added skipBrowserSupportCheck to the config parameters as suggested by the Embed team to fix the Embed SDK not loading on Chrome iOS devices.
Thread Linl: https://cclight.slack.com/archives/C02LX9HHQKH/p1769145870654479

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-176415

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://frictionless-experiment--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://frictionless-experiment--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
