### PR TITLE
Adjusted carousel toolbar items to stop from being rendered at heights above their original image resolution

### DIFF
--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.css
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.css
@@ -234,7 +234,7 @@
 .template-x-carousel-toolbar .template img:not(.icon),
 .template-x-carousel-toolbar .template video {
   display: block;
-  height: 100%;
+  max-height: 100%;
   pointer-events: none;
   object-fit: cover;
 }


### PR DESCRIPTION
## Summary

Adjusted carousel toolbar items to stop from being rendered at heights above their original image resolution

---

## Jira Ticket

Resolves: [MWPW-177237](https://jira.corp.adobe.com/browse/MWPW-177237)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/drafts/maxn/template-x-carousel-toolbar |
| **After**   | https://mwpw-177237--da-express-milo--adobecom.aem.page/drafts/maxn/template-x-carousel-toolbar?mep=off |

---

## Verification Steps

Visit the Before and After links above and compare the treatment of long images (any image with intrinsic height less than 200px, which is the fixed size of the container.)

---

## Potential Regressions

This affects the temple-x-carousel-toolbar block which is used on many pages including all of the /create pages, i.e. 
https://mwpw-177237--da-express-milo--adobecom.aem.page/express/create/flyer
https://mwpw-177237--da-express-milo--adobecom.aem.page/express/create/calendar
https://mwpw-177237--da-express-milo--adobecom.aem.page/express/create/family-tree
https://mwpw-177237--da-express-milo--adobecom.aem.page/express/create/wallpaper/desktop
https://mwpw-177237--da-express-milo--adobecom.aem.page/express/create/banner/youtube-channel-art
etc.


---

## Additional Notes

Changed CSS property 'height' to 'max-height'. 1 line change.
