### PR TITLE
MWPW-186454 Support Second CTA in AX Columns

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -932,6 +932,16 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   font-size: var(--heading-font-size-m);
 }
 
+.ax-columns.fullsize .button-container.two-ctas {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--spacing-400);
+}
+
+.ax-columns.fullsize .button-container.two-ctas .button {
+  margin: 0;
+}
+
 @media (max-width: 600px) {
   :lang(ja) .ax-columns h2 {
     font-size: var(--heading-font-size-l);

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -935,7 +935,7 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
 .ax-columns.fullsize .button-container.two-ctas {
   display: flex;
   flex-flow: row wrap;
-  gap: var(--spacing-400);
+  gap: var(--spacing-300);
 }
 
 .ax-columns.fullsize .button-container.two-ctas .button {

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -212,22 +212,15 @@ const decoratePrimaryCTARow = (rowNum, cellNum, cell) => {
   const italicAnchor = cell.querySelector('p > em > a');
   if (!italicAnchor) return;
   const boldAnchor = italicAnchor.parentElement?.previousElementSibling?.querySelector('a');
+  const block = cell.closest('.ax-columns');
 
-  if (boldAnchor) {
-    boldAnchor.classList.add('button', 'accent');
+  if (boldAnchor && block?.className.includes('fullsize')) {
+    boldAnchor.classList.add('button', 'accent', 'xlarge', 'primaryCTA');
     BlockMediator.set('primaryCtaUrl', boldAnchor.href);
-    italicAnchor.classList.add('button', 'primary', 'reverse');
-    const block = cell.closest('.ax-columns');
-
-    if (block?.className.includes('fullsize')) {
-      boldAnchor.classList.add('xlarge');
-      BlockMediator.set('primaryCtaUrl', boldAnchor.href);
-      boldAnchor.classList.add('primaryCTA');
-      italicAnchor.classList.add('xlarge');
-    }
-
+    italicAnchor.classList.add('button', 'primary', 'reverse', 'xlarge');
     boldAnchor.parentElement?.replaceWith(boldAnchor);
     italicAnchor.parentElement?.replaceWith(italicAnchor);
+    boldAnchor.closest('p')?.classList.add('button-container', 'two-ctas');
     return;
   }
 

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -209,16 +209,34 @@ function injectLogo(block) {
 
 const decoratePrimaryCTARow = (rowNum, cellNum, cell) => {
   if (rowNum + cellNum !== 0) return;
-  const content = cell.querySelector('p > em');
-  if (!content) return;
-  const links = content.querySelectorAll('a');
+  const italicAnchor = cell.querySelector('p > em > a');
+  if (!italicAnchor) return;
+  const boldAnchor = italicAnchor.parentElement?.previousElementSibling?.querySelector('a');
+
+  if (boldAnchor) {
+    boldAnchor.classList.add('button', 'accent');
+    BlockMediator.set('primaryCtaUrl', boldAnchor.href);
+    italicAnchor.classList.add('button', 'primary', 'reverse');
+    const block = cell.closest('.ax-columns');
+
+    if (block?.className.includes('fullsize')) {
+      boldAnchor.classList.add('xlarge');
+      BlockMediator.set('primaryCtaUrl', boldAnchor.href);
+      boldAnchor.classList.add('primaryCTA');
+      italicAnchor.classList.add('xlarge');
+    }
+
+    boldAnchor.parentElement?.replaceWith(boldAnchor);
+    italicAnchor.parentElement?.replaceWith(italicAnchor);
+    return;
+  }
+
+  const links = italicAnchor.parentElement?.querySelectorAll('a');
   if (links.length < 2) return;
-  content.classList.add('phone-number-cta-row');
-  links[0].classList.add('button');
-  links[0].classList.add('xlarge');
-  links[0].classList.add('trial-cta');
+  italicAnchor.parentElement?.classList.add('phone-number-cta-row');
+  links[0].classList.add('button', 'xlarge', 'trial-cta');
   links[1].classList.add('phone');
-  content.parentElement.prepend(links[0]);
+  italicAnchor.closest('p')?.prepend(links[0]);
 };
 
 function addHeaderClass(block, size) {

--- a/test/blocks/ax-columns/ax-columns.test.js
+++ b/test/blocks/ax-columns/ax-columns.test.js
@@ -16,11 +16,11 @@ await import(`${getLibs()}/utils/utils.js`).then((mod) => {
 const { default: decorate } = await import('../../../express/code/blocks/ax-columns/ax-columns.js');
 
 // eslint-disable-next-line max-len
-const [buttonLight, color, fullsize, highlight, icon, iconWithSibling, iconList, notHighlight, numbered30, offer, offerIcon, picture, video, marquee] = await Promise.all(
+const [buttonLight, color, fullsize, highlight, icon, iconWithSibling, iconList, notHighlight, numbered30, offer, offerIcon, picture, video, marquee, fullsizeTwoButtons] = await Promise.all(
   [readFile({ path: './mocks/button-light.html' }), readFile({ path: './mocks/color.html' }), readFile({ path: './mocks/fullsize.html' }), readFile({ path: './mocks/highlight.html' }),
     readFile({ path: './mocks/icon.html' }), readFile({ path: './mocks/icon-with-sibling.html' }), readFile({ path: './mocks/icon-list.html' }), readFile({ path: './mocks/not-highlight.html' }), readFile({ path: './mocks/numbered-30.html' }),
     readFile({ path: './mocks/offer.html' }), readFile({ path: './mocks/offer-icon.html' }), readFile({ path: './mocks/picture.html' }), readFile({ path: './mocks/video.html' }),
-    readFile({ path: './mocks/marquee.html' })],
+    readFile({ path: './mocks/marquee.html' }), readFile({ path: './mocks/fullsize-two-buttons.html' })],
 );
 
 describe('Columns', () => {
@@ -166,5 +166,22 @@ describe('Columns', () => {
 
     const button = columns.querySelector('.button');
     expect(button.classList.contains('dark')).to.be.true;
+  });
+
+  it('Should decorate two buttons in a row', async () => {
+    document.body.innerHTML = fullsizeTwoButtons;
+    const columns = document.querySelector('.ax-columns');
+    await decorate(columns);
+
+    const buttons = columns.querySelectorAll('.button');
+    expect(buttons.length).to.equal(2);
+
+    const primaryButton = buttons[0];
+    expect(primaryButton.classList.contains('accent')).to.be.true;
+    expect(primaryButton.classList.contains('primaryCTA')).to.be.true;
+
+    const secondaryButton = buttons[1];
+    expect(secondaryButton.classList.contains('primary')).to.be.true;
+    expect(secondaryButton.classList.contains('reverse')).to.be.true;
   });
 });

--- a/test/blocks/ax-columns/mocks/fullsize-two-buttons.html
+++ b/test/blocks/ax-columns/mocks/fullsize-two-buttons.html
@@ -1,0 +1,19 @@
+<div class="ax-columns fullsize top block" data-block-name="ax-columns" data-block-status="loading">
+  <div>
+    <div>
+      <h1 id="get-started-with-adobe-express">Get started with Adobe Express</h1>
+      <p>Create stunning designs in minutes with our easy-to-use tools.</p>
+      <p><strong><a href="https://adobesparkpost.app.link/c4bWARQhWAb">Start designing</a></strong> <em><a href="https://www.adobe.com/express/">Get Adobe Express Free</a></em></p>
+    </div>
+    <div style="height: 100px;"><a
+        href="http://localhost:3000/docs/library/kitchen-sink/media_18fb392d10014c0af61979f98b9105eba851bd8d5.mp4"
+        title="https://main--express--adobecom.hlx.page/media_18fb392d10014c0af61979f98b9105eba851bd8d5.mp4">https://main--express--adobecom.hlx.page/media_18fb392d10014c0af61979f98b9105eba851bd8d5.mp4</a>
+    </div>
+    <div style="height: 100px;">
+      <picture>
+        <source media="(min-width: 600px)" srcset="">
+        <img style="height: 150px;" loading="lazy" alt="Inserting image..." src="">
+      </picture>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Adds support for secondary CTA in AX Columns.

In authoring, the first CTA should be bolded and second CTA should be italicized.

---

## Jira Ticket

Resolves: [MWPW-186454](https://jira.corp.adobe.com/browse/MWPW-186454)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/methomas/hoodie |
| **After**   | https://methomas-columns-cta--da-express-milo--adobecom.aem.page/drafts/methomas/hoodie |

---

## Verification Steps

- First CTA should be a blue button.
- Second CTA should be a button with a black outline and white background.
- The "before" link will show two inline link styles.

---

## Potential Regressions

- https://methomas-columns-cta--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/ax-columns

---

## Additional Notes


