### PR TITLE
MWPW-186998 Discover Page Bugs

### DIFF
--- a/express/code/blocks/collapsible-rows/collapsible-rows.css
+++ b/express/code/blocks/collapsible-rows/collapsible-rows.css
@@ -54,10 +54,22 @@
     text-align: left;
     color: var(--color-gray-700-variant);
 }
-.collapsible-row-sub-header:not([class*='heading-']):not([class*='body-']):not([class*='detail-']) {
+.collapsible-row-sub-header:not([class*='heading-']):not([class*='body-']):not([class*='detail-']),
+main .collapsible-row-sub-header:not([class*='heading-']):not([class*='body-']):not([class*='detail-']) p {
     font-size: var(--body-font-size-m);
     font-weight: var(--ax-body-weight-bold);
     line-height: 130%;
+}
+.collapsible-row-sub-header:is([class*="heading-"],[class*="body-"],[class*="detail-"]) p {
+  font-size: unset;
+  line-height: unset;
+}
+main .section .collapsible-row-sub-header p {
+  margin-top: 0;
+  margin-bottom: var(--spacing-100);
+}
+main .section .collapsible-row-sub-header p:last-of-type {
+  margin-bottom: 0;
 }
 .collapsible-rows .collapsible-row-toggle-btn {
     display: block;
@@ -244,7 +256,8 @@
         font-weight: 400;
         line-height: 130%;
     }
-    .collapsible-row-sub-header:not([class*='heading-']):not([class*='body-']):not([class*='detail-']) {
+    .collapsible-row-sub-header:not([class*='heading-']):not([class*='body-']):not([class*='detail-']),
+    main .collapsible-row-sub-header:not([class*='heading-']):not([class*='body-']):not([class*='detail-']) p {
         font-size: var(--body-font-size-m);
         font-weight: 400;
         line-height: 130%; 

--- a/express/code/blocks/template-x-promo/template-x-promo.js
+++ b/express/code/blocks/template-x-promo/template-x-promo.js
@@ -515,7 +515,7 @@ async function handleOneUpFromApiData(block, templateData) {
 }
 
 /* c8 ignore next 41 */
-async function createTemplateElementForCarousel(templateData) {
+async function createTemplateElementForCarousel(templateData, isFullsize) {
   const { default: renderTemplate } = await import('../template-x/template-rendering.js');
 
   const singlePageTemplate = {
@@ -523,7 +523,7 @@ async function createTemplateElementForCarousel(templateData) {
     pages: templateData.pages ? [templateData.pages[0]] : [],
   };
 
-  const templateEl = await renderTemplate(singlePageTemplate, [], {});
+  const templateEl = await renderTemplate(singlePageTemplate, isFullsize ? ['fullsize'] : [], {});
 
   templateEl.classList.add('template');
 
@@ -561,21 +561,24 @@ async function createDesktopLayout(block, templates) {
   try {
     const currentHoveredElementRef = { current: null };
     const eventListeners = new Map();
-    const templateElements = await Promise.all(
-      templates.map((template) => createTemplateElementForCarousel(template)),
-    );
 
     const parent = block.parentElement;
     parent.classList.add('multiple-up');
 
     const templateCount = templates.length;
+    let isFullsize = false;
     if (templateCount === 2) {
       parent.classList.add('two-up');
+      isFullsize = true;
     } else if (templateCount === 3) {
       parent.classList.add('three-up');
     } else if (templateCount >= 4) {
       parent.classList.add('four-up');
     }
+
+    const templateElements = await Promise.all(
+      templates.map((template) => createTemplateElementForCarousel(template, isFullsize)),
+    );
 
     const addTrackedListener = (element, event, handler) => {
       element.addEventListener(event, handler);
@@ -709,21 +712,24 @@ export async function createCustomCarousel(block, templates) {
   try {
     const currentHoveredElementRef = { current: null };
     const eventListeners = new Map();
-    const templateElements = await Promise.all(
-      templates.map((template) => createTemplateElementForCarousel(template)),
-    );
 
     const parent = block.parentElement;
     parent.classList.add('multiple-up');
+    let isFullsize = false;
 
     const templateCount = templates.length;
     if (templateCount === 2) {
       parent.classList.add('two-up');
+      isFullsize = true;
     } else if (templateCount === 3) {
       parent.classList.add('three-up');
     } else if (templateCount >= 4) {
       parent.classList.add('four-up');
     }
+
+    const templateElements = await Promise.all(
+      templates.map((template) => createTemplateElementForCarousel(template, isFullsize)),
+    );
 
     const addTrackedListener = (element, event, handler) => {
       element.addEventListener(event, handler);

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -54,7 +54,7 @@ function extractImageThumbnail(page) {
 
 function getImageThumbnailSrc(renditionLinkHref, componentLinkHref, page) {
   const thumbnail = extractImageThumbnail(page);
-  if (!thumbnail) {
+  if (!thumbnail || variants?.includes('fullsize')) {
     // webpages
     return renditionLinkHref.replace('{&page,size,type,fragment}', '');
   }
@@ -83,8 +83,8 @@ const videoMetadataType = 'application/vnd.adobe.ccv.videometadata';
 
 /* c8 ignore next */
 async function getVideoUrls(renditionLinkHref, componentLinkHref, page) {
-  const videoThumbnail = page.rendition?.video?.thumbnail;
-  const { componentId } = videoThumbnail;
+  const videoData = variants?.includes('fullsize') ? page.rendition?.video?.preview : page.rendition?.video?.thumbnail;
+  const { componentId } = videoData;
   const preLink = renditionLinkHref.replace(
     '{&page,size,type,fragment}',
     `&type=${videoMetadataType}&fragment=id=${componentId}`,

--- a/express/code/blocks/toc-seo/toc-seo.css
+++ b/express/code/blocks/toc-seo/toc-seo.css
@@ -292,6 +292,12 @@
       padding: var(--spacing-300);
     }
   }
+
+  @media (min-width: 1680px) {
+    .toc-container {
+      left: calc((100% - 1680px) / 2);
+    }
+  }
   
   @media print {
     .toc-container {

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -10,7 +10,7 @@ const CONFIG = {
     section: 'main .section',
     headers: 'main .section.long-form .content h2, main .section.long-form .content h3, main .section.long-form .content h4',
     navigation: '.global-navigation, header',
-    stopElement: '.ax-link-list-v2-container',
+    stopElement: '.faqv2, .ax-link-list-v2-container',
   },
   scrollOffset: {
     mobile: 75,


### PR DESCRIPTION
## Summary

Fixes the following bugs from the discover page:

- (Bug 1) On extra large desktops, there shouldn't be so much space between the Tablet of Contents (TOC) and the page content.
- (Bug 2) Template promos in two-up shouldn't be grainy (poor image quality).
- (Bug 3) TOC should stop before FAQ block.
- (Bug 5) In the collapsible-rows block, a subheading with two paragraphs should have the same font styling as a subheading with one paragraph.

---

## Jira Ticket

Resolves: [MWPW-186998](https://jira.corp.adobe.com/browse/MWPW-186998)

---

## Test URLs

| Env | URL | Bugs |
|-------------|-----|---|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/stella/discover/new-layout/2en/ideas/infographic | Bugs 1 and 2 |
| **After**   | https://methomas-discover-bugs--da-express-milo--adobecom.aem.page/drafts/stella/discover/new-layout/2en/ideas/infographic | Bugs 1 and 2 |
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/methomas/discover/friend | Bug 3 |
| **After**   | https://methomas-discover-bugs--da-express-milo--adobecom.aem.page/drafts/methomas/discover/friend | Bug 3 |
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/stella/discover/new-layout/2en/ideas/card/valentines-day | Bug 5 |
| **After**   | https://methomas-discover-bugs--da-express-milo--adobecom.aem.page/drafts/stella/discover/new-layout/2en/ideas/card/valentines-day | Bug 5 |

---

## Verification Steps

Bug 1:
1. Open the page on a window > 1900px.
2. Scroll down to view the TOC.

"Before" result: Too much space between the TOC and the main page content.
"After" result: Appropriate amount of space.

Bug 2:
1. Open the page on desktop.
2. Scroll to a two-up template promo section (such as "Ancient Greece" template).

"Before" result: Image is grainy.
"After" result: Image is clear.

Bug 3:
1. Open the page on desktop.
2. Scroll down to the FAQ block, almost at the bottom of the page.

"Before" result: TOC overlaps FAQ block.
"After" result: TOC stops above FAQ block.

Bug 5:
1. Open page on desktop or mobile.
4. Scroll down to the collapsible-rows block with heading "A bookmark-style card." and observe the two-paragraph subheading underneath.

"Before" result: Two-paragraph subheading has larger font than the one-paragraph subheading in the block below it. There's also too much spacing between the paragraphs.
"After" result: Two-paragraph subheading styles match one-paragraph styles.

---

## Potential Regressions

- https://methomas-discover-bugs--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/toc-seo
- https://methomas-discover-bugs--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/template-x
- https://methomas-discover-bugs--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/collapsible-rows

---