### PR TITLE
Comparison accordion bug fix

### DIFF
--- a/drafts/nala/blocks/comparison-table-v2/accordion/index.html
+++ b/drafts/nala/blocks/comparison-table-v2/accordion/index.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Comparison Table V2 Accordion Test</title>
+    <link rel="stylesheet" href="/express/code/styles/styles.css" />
+    <link rel="stylesheet" href="/express/code/blocks/comparison-table-v2/comparison-table-v2.css" />
+  </head>
+  <body>
+    <main>
+      <div class="section" daa-lh="s1">
+        <div class="comparison-table-v2 accordion" daa-lh="b1|comparison-table-v2">
+          <div>
+            <div></div>
+            <div>premium</div>
+            <div>gray</div>
+            <div>premium</div>
+            <div>gray</div>
+          </div>
+          <div>
+            <div>Compare Plans</div>
+            <div>
+              <h3 id="plan-alpha">Express Pro</h3>
+              <p>Teams</p>
+            </div>
+            <div>
+              <h3 id="plan-beta">Express Basic</h3>
+              <p>Teams</p>
+            </div>
+            <div>
+              <h3 id="plan-gamma">Express Starter</h3>
+              <p>Free</p>
+            </div>
+            <div>
+              <h3 id="plan-delta">Express Lite</h3>
+              <p>Free</p>
+            </div>
+          </div>
+          <div>
+            <div>+++</div>
+          </div>
+          <div>
+            <div>
+              <h3 id="creative-suite">Creative Power</h3>
+            </div>
+            <div><p>Included</p></div>
+            <div><p>Limited</p></div>
+            <div><p>Included</p></div>
+            <div><p>Limited</p></div>
+          </div>
+          <div>
+            <div>Generative credits</div>
+            <div>
+              <p>+</p>
+              <p>100</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>50</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+          </div>
+          <div>
+            <div>Brand kits</div>
+            <div>
+              <p>+</p>
+              <p>Multiple</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Single</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+          </div>
+          <div>
+            <div>+++</div>
+          </div>
+          <div>
+            <div>
+              <h3 id="productivity">Productivity</h3>
+            </div>
+            <div><p>Included</p></div>
+            <div><p>Included</p></div>
+            <div><p>Limited</p></div>
+            <div><p>Limited</p></div>
+          </div>
+          <div>
+            <div>Storage</div>
+            <div>
+              <p>+</p>
+              <p>1 TB</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>500 GB</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>100 GB</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>50 GB</p>
+            </div>
+          </div>
+          <div>
+            <div>Collaboration seats</div>
+            <div>
+              <p>+</p>
+              <p>Unlimited</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Unlimited</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+          </div>
+          <div>
+            <div>===</div>
+          </div>
+          <div>
+            <div>
+              <h3 id="support">Support</h3>
+            </div>
+            <div><p>Included</p></div>
+            <div><p>Included</p></div>
+            <div><p>Email</p></div>
+            <div><p>Community</p></div>
+          </div>
+          <div>
+            <div>Live chat</div>
+            <div>
+              <p>+</p>
+            </div>
+            <div>
+              <p>+</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+          </div>
+          <div>
+            <div>Phone support</div>
+            <div>
+              <p>+</p>
+            </div>
+            <div>
+              <p>+</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+            <div>
+              <p>-</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+    <script type="module" src="/express/code/scripts/scripts.js"></script>
+    <script type="module" src="/express/code/blocks/comparison-table-v2/comparison-table-v2.js"></script>
+  </body>
+</html>

--- a/drafts/nala/blocks/comparison-table-v2/no-variants/index.html
+++ b/drafts/nala/blocks/comparison-table-v2/no-variants/index.html
@@ -1,0 +1,791 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Comparison Table V2 Default Test</title>
+    <link rel="stylesheet" href="/express/code/styles/styles.css" />
+    <link rel="stylesheet" href="/express/code/blocks/comparison-table-v2/comparison-table-v2.css" />
+  </head>
+  <body>
+    <main>
+      <div class="section" daa-lh="s1">
+        <div class="comparison-table-v2" daa-lh="b1|comparison-table-v2">
+          <div>
+            <div></div>
+            <div></div>
+            <div>gray</div>
+            <div>Premium</div>
+            <div>gray</div>
+          </div>
+          <div>
+            <div>Compare Features</div>
+            <div>
+              <h2 id="adobe-express">Adobe Express</h2>
+              <p>Free</p>
+              <p><strong><a href="https://adobesparkpost.app.link/GJrBPFUWBBb#_button-fill">Start free#_button-fill</a></strong></p>
+            </div>
+            <div>
+              <h2 id="canva">Canva</h2>
+              <p>Free</p>
+            </div>
+            <div>
+              <h2 id="adobe-express-1">Adobe Express</h2>
+              <p>Premium (for 1 person)</p>
+              <p><strong><a href="https://commerce.adobe.com/store/segmentation?cli=cc_express&amp;co=us&amp;lang=en&amp;pa=PA-55&amp;ot=trial&amp;svar=express_M2M">Start 30-day free trial</a></strong></p>
+            </div>
+            <div>
+              <h2 id="canva-1">Canva</h2>
+              <p>Pro (for 1 person)</p>
+            </div>
+          </div>
+          <div>
+            <div>+++</div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="generative-ai">Generative AI</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Commercially safe generative AI features</div>
+            <div>
+              <p>+</p>
+              <p>Powered by Adobe Firefly</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Powered by Adobe Firefly</p>
+            </div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Insert and remove objects</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Generate images, templates, and more</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Generate text effects</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Generate videos</div>
+            <div>
+              <p>-</p>
+              <p>2 free lifetime uses</p>
+            </div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="make-standout-content-fast">Make standout content fast</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Create and edit designs, photos, and videos</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Templates for social posts, flyers, videos, presentations, and more</div>
+            <div>
+              <p>+</p>
+              <p>Curated by Adobe professionals</p>
+            </div>
+            <div>+</div>
+            <div>
+              <p>+</p>
+              <p>Curated by Adobe professionals</p>
+            </div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Stock photos, videos, graphics, audio and sound effects</div>
+            <div>
+              <p>+</p>
+              <p>1M+, powered by<br />Adobe Stock</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>4.7M+</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>280M+, powered by<br />Adobe Stock</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>141M+</p>
+            </div>
+          </div>
+          <div>
+            <div>Fonts</div>
+            <div>
+              <p>+</p>
+              <p>4k Free Fonts from Adobe</p>
+            </div>
+            <div>+</div>
+            <div>
+              <p>+</p>
+              <p>30k Premium Fonts from Adobe</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>3k Premium Fonts</p>
+            </div>
+          </div>
+          <div>
+            <div>Comprehensive photo editing capabilities</div>
+            <div>
+              <p>+</p>
+              <p>Robust photo effects and blend modes, powered by Photoshop</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via add-on</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Robust photo effects and blend modes, powered by Photoshop</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via add-on</p>
+            </div>
+          </div>
+          <div>
+            <div>Remove image background</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Automatically turn video podcasts, educational videos, and product reviews into social clips with captions</div>
+            <div>
+              <p>+</p>
+              <p>Clip Maker<br />(Based on video transcript, English only)</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Clip Maker<br />(Based on video transcript, English only)</p>
+            </div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Auto caption videos</div>
+            <div>
+              <p>+</p>
+              <p>Quick Action</p>
+            </div>
+            <div>+</div>
+            <div>
+              <p>+</p>
+              <p>Quick Action</p>
+            </div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Enhance Speech</div>
+            <div>-</div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Powered by Adobe Podcast</p>
+            </div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Remove video background</div>
+            <div>-</div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Record voiceover and video directly in-app</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Add physics-based animation to your photos, videos, text, shapes, and icons</div>
+            <div>
+              <p>+</p>
+              <p>Dynamic Animations</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Dynamic Animations</p>
+            </div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Automatically apply motion to your entire design</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Apply animations to individual elements</div>
+            <div>
+              <p>+</p>
+              <p>Customizable settings</p>
+            </div>
+            <div>+</div>
+            <div>
+              <p>+</p>
+              <p>Customizable settings</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Customizable settings</p>
+            </div>
+          </div>
+          <div>
+            <div>Create animated characters using your own audio or recording</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="build-and-launch-campaigns-easily">Build and launch campaigns easily</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Resize for multiple formats - at one time, in the same file</div>
+            <div>-</div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Unlimited resize variations</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Limited to 5 resize variations</p>
+            </div>
+          </div>
+          <div>
+            <div>Turn your documents into presentations in minutes</div>
+            <div>
+              <p>-</p>
+              <p>5 free lifetime uses</p>
+            </div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Apply format-aware Safe Zones to keep important text, visuals, and logos visible</div>
+            <div>
+              <p>+</p>
+              <p>Instagram, TikTok, Facebook &amp; LinkedIn</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via add-on<br /><br />Instagram &amp; Facebook only</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Instagram, TikTok, Facebook &amp; LinkedIn</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via add-on<br /><br />Instagram &amp; Facebook only</p>
+            </div>
+          </div>
+          <div>
+            <div>Plan, publish, and schedule direct to social channels</div>
+            <div>
+              <p>+</p>
+              <p>3 accounts per social network <em>Including</em> TikTok, Instagram Stories and Reels</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>3 accounts per social network <em>Including</em> TikTok, Instagram Stories and Reels</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>1 account per social network <em>Excluding</em> TikTok, Instagram Stories and Reels</p>
+            </div>
+          </div>
+          <div>
+            <div>Get AI-generated social captions tailored to your design. Available in 45 + languages.</div>
+            <div>
+              <p>+</p>
+              <p>via Content Scheduler</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via add-on</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via Content Scheduler</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>via add-on</p>
+            </div>
+          </div>
+          <div>
+            <div>Add social mentions directly in captions when scheduling posts</div>
+            <div>
+              <p>+</p>
+              <p>Facebook, Instagram, LinkedIn, X</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Facebook, Instagram, LinkedIn, X</p>
+            </div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Publish to multiple channels simultaneously</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Publish paid ads directly via add-on</div>
+            <div>
+              <p>+</p>
+              <p>Google, LinkedIn, Amazon and TikTok</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Includes Meta<br />Excludes TikTok</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Google, LinkedIn, Amazon and TikTok</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Includes Meta<br />Excludes TikTok</p>
+            </div>
+          </div>
+          <div>
+            <div>Track key social metrics, competitive insights, and download custom reports</div>
+            <div>
+              <p>+</p>
+              <p>Metricool Add-On</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Limited to single post metrics</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Metricool Add-On</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>Limited to single post metrics</p>
+            </div>
+          </div>
+          <div>
+            <div>Collaborate with your team on shared social calendars</div>
+            <div>
+              <p>+</p>
+              <p>1 shared calendar</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>3 shared calendars</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>1 shared calendar</p>
+            </div>
+          </div>
+          <div>
+            <div>Translate any design in up to 46 languages and bulk translate 20 languages at one time in the same file</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>TikTok Symphony Assistant Add-on: includes 1M+ songs and sounds from TikTok's Commercial Music Library</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="create-on-brand-content-at-scale">Create on-brand content at scale</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Extract brand colors, fonts, logos from image in one-click</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Apply brand logos, fonts, colors and recolor graphics</div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Collaborate in real-time across teams</div>
+            <div>
+              <p>+</p>
+              <p>Share projects with non-team members</p>
+            </div>
+            <div>+</div>
+            <div>
+              <p>+</p>
+              <p>Share projects with non-team members</p>
+            </div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Share templates across teams</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Enforced brand controls with password-protected locked template elements</div>
+            <div>-</div>
+            <div>-</div>
+            <div>-</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Built-in reviews and approval workflows</div>
+            <div>-</div>
+            <div>-</div>
+            <div>-</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Custom Home, with featured branded banner and instant access to approved on-brand templates</div>
+            <div>Available for Enterprise plans</div>
+            <div>-</div>
+            <div>Available for Enterprise plans</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Generate on-brand content with Firefly Custom Models</div>
+            <div>Available for Enterprise plans</div>
+            <div>-</div>
+            <div>Available for Enterprise plans</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="ai-assistant-limited-beta">AI Assistant (Limited Beta)</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Switch between prompting and manual editing</div>
+            <div>In development</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Generate a design</div>
+            <div>In development</div>
+            <div>+</div>
+            <div>In development</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Generate an image</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Make sweeping edits to color schemes, copy and elements across your design</div>
+            <div>In development</div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Directly edits canvas</p>
+            </div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Edit images while maintaining style and character</div>
+            <div>In development</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Get dynamic prompt suggestions that update as your design evolves</div>
+            <div>In development</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Prompt to animate your design</div>
+            <div>In development</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="business-ready-through-adobe-app-integrations">Business-ready through Adobe app integrations</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Seamless integration across Adobe apps like Photoshop, Illustrator, InDesign, Firefly, Acrobat and Lightroom</div>
+            <div>
+              <p>+</p>
+              <p>No download/upload needed</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>No download/upload needed</p>
+            </div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>High-quality import and edit PDF, one-click convert to and from PDF</div>
+            <div>
+              <p>+</p>
+              <p>Powered by Adobe Acrobat</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Powered by Adobe Acrobat</p>
+            </div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Integration with Adobe Experience Manager, Workfront, and GenStudio for performance marketing</div>
+            <div>Available for Enterprise plans</div>
+            <div>-</div>
+            <div>Available for Enterprise plans</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="take-advantage-of-additional-features">Take advantage of additional features</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Draw and paint with 85+ brushes and coloring pages</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+          </div>
+          <div>
+            <div>Interactive, collaborative online whiteboard</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Create mockups of t-shirts, websites and more using images or designs</div>
+            <div>-</div>
+            <div>+</div>
+            <div>-</div>
+            <div>+</div>
+          </div>
+          <div>
+            <div>Protect your brand with IP indemnification for Adobe Firefly generated content</div>
+            <div>Available for Enterprise plans</div>
+            <div>Available for Enterprise plans</div>
+            <div>Available for Enterprise plans</div>
+            <div>Available for Enterprise plans</div>
+          </div>
+          <div>
+            <div>
+              <hr />
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>
+              <h3 id="get-extensive-support-and-storage">Get extensive support and storage</h3>
+            </div>
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
+          <div>
+            <div>Version History: Access, review, and restore earlier versions of your designs</div>
+            <div>
+              <p>+</p>
+              <p>10 day history</p>
+            </div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>30 day history</p>
+            </div>
+            <div>
+              <p>+</p>
+              <p>50 versions</p>
+            </div>
+          </div>
+          <div>
+            <div>Cloud Storage</div>
+            <div>5GB</div>
+            <div>5GB</div>
+            <div>100GB</div>
+            <div>100GB</div>
+          </div>
+          <div>
+            <div>Live customer support</div>
+            <div>-</div>
+            <div>-</div>
+            <div>-</div>
+            <div>
+              <p>+</p>
+              <p>Live chat support</p>
+            </div>
+          </div>
+          <div>
+            <div>Advanced security and protection (data encryption and SSO) with consolidated license management and customer success support</div>
+            <div>Available for Enterprise plans</div>
+            <div>Available for Business and Enterprise plans</div>
+            <div>Available for Enterprise plans</div>
+            <div>Available for Business and Enterprise plans</div>
+          </div>
+          <div>
+            <div>Feature comparisons based on publicly available information as of January 2026. Features are subject to change; please visit <a href="https://www.adobe.com/express">adobe.com/express</a> for the most up to date information on Adobe Express.</div>
+          </div>
+        </div>
+      </div>
+    </main>
+    <script type="module" src="/express/code/scripts/scripts.js"></script>
+    <script type="module" src="/express/code/blocks/comparison-table-v2/comparison-table-v2.js"></script>
+  </body>
+</html>

--- a/express/code/blocks/comparison-table-v2/comparison-table-state.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-state.js
@@ -3,7 +3,6 @@ import { adjustElementPosition } from '../../scripts/widgets/tooltip.js';
 
 let createTag;
 
-// Constants
 const PLAN_DEFAULTS = {
   FIRST_VISIBLE_PLAN: 0,
   SECOND_VISIBLE_PLAN: 1,
@@ -66,12 +65,10 @@ export class ComparisonTableState {
         const currentPlanIndex = parseInt(option.dataset.planIndex, 10);
         const selectorIndex = parseInt(selector.dataset.planIndex, 10);
 
-        // Don't allow selecting the same plan that's currently visible
         if (this.visiblePlans.includes(currentPlanIndex)) {
-          return; // Exit early, don't process the click
+          return;
         }
 
-        // Update aria-selected
         choiceWrapper.querySelectorAll('[role="option"]').forEach((opt) => {
           opt.setAttribute('aria-selected', 'false');
         });
@@ -80,7 +77,6 @@ export class ComparisonTableState {
 
         this.updateVisiblePlan(selectorIndex, currentPlanIndex);
 
-        // Close dropdown and update aria-expanded
         ComparisonTableState.closeDropdown(selector);
         selector.focus();
       });
@@ -127,9 +123,7 @@ export class ComparisonTableState {
             this.constructor.focusOption(visibleOptions, prevIndex);
             break;
           case 'Tab':
-            // Allow normal tab behavior - close dropdown and move to next element
             ComparisonTableState.closeDropdown(selector);
-            // Don't prevent default - let Tab continue normal navigation
             break;
           case 'Escape':
             e.preventDefault();
@@ -158,25 +152,21 @@ export class ComparisonTableState {
           e.preventDefault();
           const currentPlanIndex = parseInt(option.dataset.planIndex, 10);
 
-          // Don't allow selecting the same plan that's currently visible
           if (!this.visiblePlans.includes(currentPlanIndex)) {
             option.click();
           }
           selector.focus();
         } else if (e.key === 'Tab' && isOpen) {
-          // Focus trap - prevent tabbing out of dropdown
           e.preventDefault();
           const visibleOptions = Array.from(choices.querySelectorAll('.plan-selector-choice:not(.invisible-content)'));
           const currentIndex = visibleOptions.indexOf(option);
 
           if (e.shiftKey) {
-            // Shift+Tab - go backwards (higher index -> lower index)
             const nextIndex = currentIndex < visibleOptions.length - 1
               ? currentIndex + 1
               : PLAN_DEFAULTS.FIRST_VISIBLE_PLAN;
             ComparisonTableState.focusOption(visibleOptions, nextIndex);
           } else {
-            // Tab - go forwards (lower index -> higher index)
             const prevIndex = currentIndex > PLAN_DEFAULTS.FIRST_VISIBLE_PLAN
               ? currentIndex - 1
               : visibleOptions.length - 1;
@@ -219,7 +209,6 @@ export class ComparisonTableState {
       }
     }
 
-    // Update table cell visibility
     this.comparisonBlock.querySelectorAll('tr').forEach((row) => {
       const cells = row.querySelectorAll('.feature-cell:not(.feature-cell-header), th[scope="col"]');
       for (let i = 0; i < cells.length; i += 1) {
@@ -240,13 +229,11 @@ export class ComparisonTableState {
     this.planSelectors.forEach((selector, index) => {
       const options = Array.from(selector.querySelector('.plan-selector-choices').children);
 
-      // Setup all event handlers
       this.setupOptionClickHandlers(selector, options);
       this.setupSelectorClickHandler(selector);
       this.setupSelectorKeyboardNavigation(selector);
       this.setupOptionKeyboardNavigation(selector, options);
 
-      // Update visibility state
       this.updateVisibilityState(selector, index);
     });
 
@@ -290,14 +277,11 @@ export class ComparisonTableState {
     dropdown.classList.toggle('invisible-content', isOpen);
 
     if (!isOpen) {
-      // Make options focusable when opening
       dropdown.querySelectorAll('.plan-selector-choice').forEach((opt) => {
         opt.setAttribute('tabindex', '0');
       });
-      // Determine alignment via class (mobile only)
       this.constructor.setDropdownAlignment(dropdown, planCellWrapper);
     } else {
-      // Make options not focusable when closing
       dropdown.querySelectorAll('.plan-selector-choice').forEach((opt) => {
         opt.setAttribute('tabindex', '-1');
       });
@@ -318,7 +302,6 @@ export class ComparisonTableState {
       planCellWrapper.setAttribute('aria-expanded', 'false');
     }
 
-    // Make options not focusable when closed
     dropdown.querySelectorAll('.plan-selector-choice').forEach((opt) => {
       opt.setAttribute('tabindex', '-1');
       opt.classList.remove('focused');
@@ -331,21 +314,17 @@ export class ComparisonTableState {
     const oldHeader = this.planSelectors[selectorIndex].closest('.plan-cell');
     const newHeader = this.planSelectors[newPlanIndex].closest('.plan-cell');
 
-    // Get plan names for announcement
     const oldPlanName = oldHeader.querySelector('.plan-cell-wrapper').textContent.trim();
     const newPlanName = newHeader.querySelector('.plan-cell-wrapper').textContent.trim();
 
     oldHeader.classList.toggle('invisible-content');
     newHeader.classList.toggle('invisible-content');
 
-    // Update positioning classes
     if (visiblePlanIndex === PLAN_DEFAULTS.FIRST_VISIBLE_PLAN) {
-      // First visible position (left)
       oldHeader.classList.remove('left-plan');
       newHeader.classList.add('left-plan');
       newHeader.classList.remove('right-plan');
     } else {
-      // Second visible position (right)
       oldHeader.classList.remove('right-plan');
       newHeader.classList.add('right-plan');
       newHeader.classList.remove('left-plan');
@@ -359,13 +338,11 @@ export class ComparisonTableState {
     this.updatePlanSelectorOptions();
     this.updateTableCells(selectorIndex, newPlanIndex);
 
-    // Announce the plan change to screen readers
     if (this.ariaLiveRegion) {
       const position = visiblePlanIndex === PLAN_DEFAULTS.FIRST_VISIBLE_PLAN ? 'left' : 'right';
       const announcement = `Changed ${position} plan from ${oldPlanName} to ${newPlanName}`;
       this.ariaLiveRegion.textContent = announcement;
 
-      // Clear the announcement after a short delay to prepare for next announcement
       setTimeout(() => {
         this.ariaLiveRegion.textContent = '';
       }, TIMING.ARIA_ANNOUNCEMENT_CLEAR);
@@ -385,7 +362,6 @@ export class ComparisonTableState {
           child.classList.remove('invisible-content');
         }
 
-        // Update selected state and icon
         const planIndex = parseInt(child.dataset.planIndex, 10);
         if (this.visiblePlans.includes(planIndex)) {
           child.classList.add('selected');
@@ -399,13 +375,11 @@ export class ComparisonTableState {
   }
 
   static addSelectedIcon(option) {
-    // Remove existing icon if present
     const existingIcon = option.querySelector('.plan-selector-choice-text').querySelector('.selected-icon');
     if (existingIcon) {
       existingIcon.remove();
     }
 
-    // Add selected icon
     const iconSpan = createTag('span', { class: 'selected-icon icon-selected' });
     option.querySelector('.plan-selector-choice-text').prepend(iconSpan);
     option.setAttribute('aria-selected', 'true');

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -646,14 +646,16 @@ flex-grow: 1;
   display: grid;
   grid-template-rows: 1fr;
   overflow: hidden;
-  transition: grid-template-rows 400ms ease-out;
+  transition: grid-template-rows 400ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.comparison-table-v2.accordion .table-container {
+  overflow-anchor: auto;
 }
 
 .comparison-table-v2.accordion .table-container table.hide-table {
-  display: grid;
   grid-template-rows: 0fr;
   padding: 0;
-  transition: none;
 }
 
 .comparison-table-v2.accordion .table-container table > * {

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -646,13 +646,14 @@ flex-grow: 1;
   display: grid;
   grid-template-rows: 1fr;
   overflow: hidden;
-  transition: grid-template-rows 300ms ease-out;
+  transition: grid-template-rows 400ms ease-out;
 }
 
 .comparison-table-v2.accordion .table-container table.hide-table {
   display: grid;
   grid-template-rows: 0fr;
   padding: 0;
+  transition: none;
 }
 
 .comparison-table-v2.accordion .table-container table > * {
@@ -1269,12 +1270,13 @@ color: var(--color-gray-700-variant);
   .comparison-table-v2.accordion .table-container table {
     display: grid;
     grid-template-rows: 1fr;
-    transition: grid-template-rows 300ms ease-out;
+    transition: grid-template-rows 400ms ease-out;
   }
 
   .comparison-table-v2.accordion .table-container table.hide-table {
     grid-template-rows: 0fr;
     padding: 0;
+    transition: none;
   }
 }
 

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -799,7 +799,7 @@ export default async function decorate(comparisonBlock) {
       }
     });
   } catch (error) {
-    window.lana.log('Failed to initialize comparison table:', error);
+    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', severity: 'error'});
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -451,7 +451,6 @@ function initializeAccordionBehavior(comparisonBlock) {
       toggleButton.querySelector('span').classList.toggle('open');
       toggleButton.setAttribute('aria-expanded', wasExpanded ? 'false' : 'true');
 
-      // Scroll to the top of the expanded accordion content with sticky header offset
       if (!wasExpanded) {
         const firstRow = container.querySelector('.first-row');
         if (firstRow) {
@@ -460,21 +459,16 @@ function initializeAccordionBehavior(comparisonBlock) {
             const stickyHeaderHeight = stickyHeader?.offsetHeight || 0;
             const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
 
-            // gnav offset applies on desktop when sticky header is active
-            // CSS: --gnav-offset-height: 64px
             const gnavOffset = isDesktop ? 64 : 0;
 
-            // spacing-300 = 16px gap between table containers from CSS
             const tableGap = 16;
 
-            // Total offset: sticky header + gnav + gap between tables
             const totalOffset = stickyHeaderHeight + gnavOffset + tableGap;
 
             const currentScrollPosition = window.scrollY;
             const elementTop = firstRow.getBoundingClientRect().top + currentScrollPosition;
             const calculatedTarget = elementTop - totalOffset;
 
-            // Clamp to max scrollable position to prevent overscrolling at bottom of page
             const maxScrollPosition = document.documentElement.scrollHeight - window.innerHeight;
             const targetScrollPosition = Math.min(calculatedTarget, maxScrollPosition);
 
@@ -484,16 +478,13 @@ function initializeAccordionBehavior(comparisonBlock) {
             });
           };
 
-          // Find any table that was just collapsed and wait for its transition to end
           const collapsingTable = Array.from(tableContainers)
             .filter((c) => c !== container)
             .map((c) => c.querySelector('table.hide-table'))
             .find((t) => t);
 
           if (collapsingTable) {
-            // Wait for the collapse transition to finish before calculating scroll position
             const onTransitionEnd = (e) => {
-              // Only react to height/max-height transitions on the table itself
               if (e.target === collapsingTable && ['height', 'max-height', 'grid-template-rows'].includes(e.propertyName)) {
                 collapsingTable.removeEventListener('transitionend', onTransitionEnd);
                 requestAnimationFrame(performScroll);
@@ -501,13 +492,11 @@ function initializeAccordionBehavior(comparisonBlock) {
             };
             collapsingTable.addEventListener('transitionend', onTransitionEnd);
 
-            // Fallback timeout in case transition doesn't fire (e.g., no transition defined)
             setTimeout(() => {
               collapsingTable.removeEventListener('transitionend', onTransitionEnd);
               requestAnimationFrame(performScroll);
             }, 350);
           } else {
-            // No other table was collapsed, use double rAF as before
             requestAnimationFrame(() => {
               requestAnimationFrame(performScroll);
             });

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -450,6 +450,27 @@ function initializeAccordionBehavior(comparisonBlock) {
       table.classList.toggle('hide-table');
       toggleButton.querySelector('span').classList.toggle('open');
       toggleButton.setAttribute('aria-expanded', wasExpanded ? 'false' : 'true');
+
+      // Scroll to the top of the expanded accordion content with sticky header offset
+      if (!wasExpanded) {
+        const firstRow = container.querySelector('.first-row');
+        if (firstRow) {
+          requestAnimationFrame(() => {
+            const stickyHeader = comparisonBlock.querySelector('.sticky-header');
+            const stickyHeaderHeight = stickyHeader?.offsetHeight || 0;
+            const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
+            const gnavOffset = isDesktop ? 64 : 0; // gnav-offset-height from CSS
+            const rowGap = 16; // spacing-300 gap between table containers
+            const totalOffset = stickyHeaderHeight + gnavOffset + rowGap;
+
+            const elementTop = firstRow.getBoundingClientRect().top + window.scrollY;
+            window.scrollTo({
+              top: elementTop - totalOffset,
+              behavior: 'smooth',
+            });
+          });
+        }
+      }
     };
   });
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -564,6 +564,7 @@ function initializeAccordionBehavior(comparisonBlock, stickyReleaseControls = {}
       }
 
       let hasResumed = false;
+      let fallbackResumeTimeout = null;
       const resumeOnce = () => {
         if (hasResumed) return;
         hasResumed = true;
@@ -576,7 +577,6 @@ function initializeAccordionBehavior(comparisonBlock, stickyReleaseControls = {}
         }
       };
 
-      let fallbackResumeTimeout = null;
       if (typeof resumeStickyRelease === 'function') {
         fallbackResumeTimeout = window.setTimeout(() => {
           resumeOnce();

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -86,13 +86,32 @@ const scrollAccordionIntoView = (anchorTarget, comparisonBlock) => {
   });
 
   const isSmoothScroll = initialBehavior === 'smooth';
-  if (!isSmoothScroll || Math.abs(window.scrollY - targetScrollPosition) <= SCROLL_COMPLETION_THRESHOLD) {
+  if (!isSmoothScroll || Math.abs(
+    window.scrollY - targetScrollPosition
+  ) <= SCROLL_COMPLETION_THRESHOLD) {
     return Promise.resolve();
   }
 
   return new Promise((resolve) => {
     let rafId = null;
     let timeoutId = null;
+
+    const finish = () => {
+      /* eslint-disable-next-line no-use-before-define */
+      cleanup();
+      resolve();
+    };
+
+
+    const onScroll = () => {
+      if (Math.abs(window.scrollY - targetScrollPosition) <= SCROLL_COMPLETION_THRESHOLD) {
+        finish();
+      }
+    };
+
+    const onUserInteraction = () => {
+      finish();
+    };
 
     const cleanup = () => {
       if (rafId) {
@@ -107,21 +126,6 @@ const scrollAccordionIntoView = (anchorTarget, comparisonBlock) => {
       window.removeEventListener('wheel', onUserInteraction);
       window.removeEventListener('touchstart', onUserInteraction);
       window.removeEventListener('keydown', onUserInteraction);
-    };
-
-    const finish = () => {
-      cleanup();
-      resolve();
-    };
-
-    const onScroll = () => {
-      if (Math.abs(window.scrollY - targetScrollPosition) <= SCROLL_COMPLETION_THRESHOLD) {
-        finish();
-      }
-    };
-
-    const onUserInteraction = () => {
-      finish();
     };
 
     const monitorScroll = () => {

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -5,7 +5,6 @@ import { createStickyHeader, initStickyBehavior, synchronizePlanCellHeights, set
 
 let createTag;
 
-// Constants
 const BREAKPOINTS = {
   DESKTOP: '(min-width: 1024px)',
   TABLET: '(min-width: 768px)',
@@ -40,7 +39,6 @@ const scrollAccordionIntoView = (anchorTarget, comparisonBlock) => {
   const isStickyActive = stickyHeader?.classList.contains('is-stuck')
     && !stickyHeader.classList.contains('is-retracted');
 
-  // Capture anchor position BEFORE any scrolling to avoid recalculation issues
   const anchorTop = anchorTarget.getBoundingClientRect().top + window.scrollY;
 
   const stickyHeaderHeight = stickyHeader?.offsetHeight || 0;
@@ -57,28 +55,21 @@ const scrollAccordionIntoView = (anchorTarget, comparisonBlock) => {
   };
 
   let initialOffset = tableGap;
-  // Use smooth scrolling for better UX
   const initialBehavior = 'smooth';
 
   if (isStickyActive) {
-    // Header is already stuck, account for it
     initialOffset = stickyHeaderHeight + gnavOffset + tableGap;
   } else if (stickyHeader) {
-    // Header is not stuck - check if scrolling would cause it to become stuck
-    // Find the header sentinel (inserted before comparisonBlock)
     const headerSentinel = comparisonBlock.previousElementSibling;
     if (headerSentinel) {
       const headerSentinelTop = headerSentinel.getBoundingClientRect().top;
       const stickyTriggerOffset = isDesktop ? gnavOffset : 0;
 
-      // Calculate what the scroll position would be with just tableGap
       const targetScrollPosition = clampTarget(tableGap);
       const scrollDelta = targetScrollPosition - window.scrollY;
 
-      // Calculate what the header sentinel's top would be after scrolling
       const headerSentinelTopAfterScroll = headerSentinelTop - scrollDelta;
 
-      // If scrolling would cause the header to become stuck, account for sticky header height
       if (headerSentinelTopAfterScroll < stickyTriggerOffset) {
         initialOffset = stickyHeaderHeight + gnavOffset + tableGap;
       }
@@ -197,7 +188,6 @@ function partitionContentBySeparators(blockChildren) {
 function createToggleButton(isHidden, noAccordion) {
   const button = document.createElement('button');
   button.classList.add('toggle-button');
-  // Removed aria-label - button will get its name from the H3 inside it
   button.setAttribute('aria-expanded', isHidden ? 'false' : 'true');
   if (noAccordion) {
     button.setAttribute('role', 'presentation');
@@ -237,12 +227,10 @@ function createAccessibilityHeaders(sectionTitle, colTitles) {
   const headerRow = document.createElement('tr');
   screenReaderHeaders.classList.add('invisible-headers');
 
-  // Add section title header
   const sectionHeader = document.createElement('th');
   sectionHeader.textContent = sectionTitle;
   headerRow.appendChild(sectionHeader);
 
-  // Add column headers
   colTitles.forEach((columnTitle) => {
     const columnHeader = document.createElement('th');
     columnHeader.setAttribute('scope', 'col');
@@ -311,7 +299,6 @@ function convertToTable(sectionGroup, columnHeaders) {
 
   if (sectionGroup.length === 0) return tableContainer;
 
-  // Process header row
   const sectionHeaderDiv = sectionGroup[0];
   const shouldHideTable = !sectionHeaderDiv.classList.contains('open-separator') && !sectionHeaderDiv.classList.contains('no-accordion');
   if (shouldHideTable) {
@@ -324,7 +311,6 @@ function convertToTable(sectionGroup, columnHeaders) {
 
   const { sectionHeaderContainer, sectionTitle } = createTableHeader(sectionHeaderDiv);
 
-  // Add toggle button
   const toggleButton = createToggleButton(shouldHideTable, noAccordion);
   toggleButton.onclick = () => {
     const wasExpanded = !comparisonTable.classList.contains('hide-table');
@@ -340,11 +326,9 @@ function convertToTable(sectionGroup, columnHeaders) {
   }
   sectionHeaderContainer.appendChild(toggleButton);
   tableContainer.prepend(sectionHeaderContainer);
-  // Add accessibility headers
   const screenReaderHeaders = createAccessibilityHeaders(sectionTitle, columnHeaders);
   comparisonTable.appendChild(screenReaderHeaders);
 
-  // Process data rows
   for (let featureIndex = 1; featureIndex < sectionGroup.length; featureIndex += 1) {
     const featureRow = createTableRow(sectionGroup[featureIndex]);
     tableBody.appendChild(featureRow);
@@ -601,12 +585,10 @@ function synchronizeIconWrapperTextHeights(comparisonBlock) {
     const iconTextElements = Array.from(row.querySelectorAll('.icon-wrapper'));
     if (iconTextElements.length === 0) return;
 
-    // Reset heights to measure natural height
     iconTextElements.forEach((iconText) => {
       iconText.style.height = 'auto';
     });
 
-    // On desktop, synchronize all cells. On mobile/tablet, only synchronize visible cells.
     const visibleIconTextElements = isDesktop
       ? iconTextElements
       : iconTextElements.filter((iconText) => {
@@ -651,13 +633,11 @@ function setupEventListeners(comparisonBlock, updateTabindexOnResize) {
     synchronizeIconWrapperTextHeights(comparisonBlock);
   });
 
-  // Observe all plan cell wrappers for size changes
   const planCellWrappers = comparisonBlock.querySelectorAll('.plan-cell-wrapper');
   planCellWrappers.forEach((wrapper) => {
     resizeObserver.observe(wrapper);
   });
 
-  // Observe the block itself to react to table height changes (plan swap, accordion, etc.)
   resizeObserver.observe(comparisonBlock);
 
   adjustElementPosition();
@@ -669,15 +649,12 @@ function setupEventListeners(comparisonBlock, updateTabindexOnResize) {
  */
 export default async function decorate(comparisonBlock) {
   try {
-    // If this block starts inside a hidden content-toggle panel, defer initialization
-    // until the panel is actually activated. This avoids Safari measuring/layout issues.
     const parentSection = comparisonBlock.closest('section');
     if (parentSection && parentSection.classList.contains('content-toggle-hidden')) {
       const initOnReveal = (e) => {
         const panel = e?.detail?.panel;
         if (panel && panel === parentSection) {
           document.removeEventListener('content-toggle:activated', initOnReveal);
-          // Re-run decoration now that the section is visible
           decorate(comparisonBlock);
         }
       };
@@ -714,18 +691,15 @@ export default async function decorate(comparisonBlock) {
     const updateTabindexOnResize = createTabindexUpdateHandler(comparisonBlock, colTitles);
 
     setupEventListeners(comparisonBlock, updateTabindexOnResize);
-    // Recalculate layout when revealed by content-toggle
     document.addEventListener('content-toggle:activated', (e) => {
       const panel = e?.detail?.panel;
       if (panel && panel.contains(comparisonBlock)) {
         synchronizeIconWrapperTextHeights(comparisonBlock);
         synchronizePlanCellHeights(comparisonBlock);
-        // trigger any sticky header correction
         window.dispatchEvent(new Event('resize'));
       }
     });
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error('Failed to initialize comparison table:', error);
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -477,17 +477,21 @@ function initializeAccordionBehavior(comparisonBlock) {
   tableContainers.forEach((container, index) => {
     const table = container.querySelector('table');
     const toggleButton = container.querySelector('.toggle-button');
-    const iconSpan = toggleButton?.querySelector('span');
+    if (!table || !toggleButton) return;
+
+    const iconSpan = toggleButton.querySelector('span');
+    if (!iconSpan) return;
 
     if (index === 0) {
-      table?.classList.remove('hide-table');
-      iconSpan?.classList.remove('open');
-      toggleButton?.setAttribute('aria-expanded', 'true');
-    } else {
-      table?.classList.add('hide-table');
-      iconSpan?.classList.add('open');
-      toggleButton?.setAttribute('aria-expanded', 'false');
+      table.classList.remove('hide-table');
+      iconSpan.classList.remove('open');
+      toggleButton.setAttribute('aria-expanded', 'true');
+      return;
     }
+
+    table.classList.add('hide-table');
+    iconSpan.classList.add('open');
+    toggleButton.setAttribute('aria-expanded', 'false');
   });
 
   tableContainers.forEach((container) => {
@@ -495,37 +499,46 @@ function initializeAccordionBehavior(comparisonBlock) {
     if (!toggleButton) return;
 
     const table = container.querySelector('table');
+    if (!table) return;
+
+    const iconSpan = toggleButton.querySelector('span');
+    if (!iconSpan) return;
 
     toggleButton.onclick = () => {
       const wasExpanded = !table.classList.contains('hide-table');
       const anchorTarget = container.querySelector('.toggle-button') || container;
 
       table.classList.toggle('hide-table');
-      toggleButton.querySelector('span').classList.toggle('open');
+      iconSpan.classList.toggle('open');
       toggleButton.setAttribute('aria-expanded', wasExpanded ? 'false' : 'true');
 
-      if (!wasExpanded) {
-        tableContainers.forEach((otherContainer) => {
-          if (otherContainer !== container) {
-            const otherTable = otherContainer.querySelector('table');
-            const otherButton = otherContainer.querySelector('.toggle-button');
-            const otherIcon = otherButton?.querySelector('span');
-            if (otherTable && !otherTable.classList.contains('hide-table')) {
-              otherTable.classList.add('hide-table');
-              otherIcon?.classList.add('open');
-              otherButton?.setAttribute('aria-expanded', 'false');
-            }
-          }
-        });
+      if (wasExpanded) return;
 
-        if (anchorTarget) {
-          window.setTimeout(() => {
-            requestAnimationFrame(() => {
-              scrollAccordionIntoView(anchorTarget, comparisonBlock);
-            });
-          }, ACCORDION_TRANSITION_DURATION);
-        }
-      }
+      tableContainers.forEach((otherContainer) => {
+        if (otherContainer === container) return;
+
+        const otherTable = otherContainer.querySelector('table');
+        if (!otherTable) return;
+        if (otherTable.classList.contains('hide-table')) return;
+
+        const otherButton = otherContainer.querySelector('.toggle-button');
+        if (!otherButton) return;
+
+        const otherIcon = otherButton.querySelector('span');
+        if (!otherIcon) return;
+
+        otherTable.classList.add('hide-table');
+        otherIcon.classList.add('open');
+        otherButton.setAttribute('aria-expanded', 'false');
+      });
+
+      if (!anchorTarget) return;
+
+      window.setTimeout(() => {
+        requestAnimationFrame(() => {
+          scrollAccordionIntoView(anchorTarget, comparisonBlock);
+        });
+      }, ACCORDION_TRANSITION_DURATION);
     };
   });
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -87,7 +87,7 @@ const scrollAccordionIntoView = (anchorTarget, comparisonBlock) => {
 
   const isSmoothScroll = initialBehavior === 'smooth';
   if (!isSmoothScroll || Math.abs(
-    window.scrollY - targetScrollPosition
+    window.scrollY - targetScrollPosition,
   ) <= SCROLL_COMPLETION_THRESHOLD) {
     return Promise.resolve();
   }
@@ -101,7 +101,6 @@ const scrollAccordionIntoView = (anchorTarget, comparisonBlock) => {
       cleanup();
       resolve();
     };
-
 
     const onScroll = () => {
       if (Math.abs(window.scrollY - targetScrollPosition) <= SCROLL_COMPLETION_THRESHOLD) {

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -455,20 +455,63 @@ function initializeAccordionBehavior(comparisonBlock) {
       if (!wasExpanded) {
         const firstRow = container.querySelector('.first-row');
         if (firstRow) {
-          requestAnimationFrame(() => {
+          const performScroll = () => {
             const stickyHeader = comparisonBlock.querySelector('.sticky-header');
             const stickyHeaderHeight = stickyHeader?.offsetHeight || 0;
             const isDesktop = window.matchMedia(BREAKPOINTS.DESKTOP).matches;
-            const gnavOffset = isDesktop ? 64 : 0; // gnav-offset-height from CSS
-            const rowGap = 16; // spacing-300 gap between table containers
-            const totalOffset = stickyHeaderHeight + gnavOffset + rowGap;
 
-            const elementTop = firstRow.getBoundingClientRect().top + window.scrollY;
+            // gnav offset applies on desktop when sticky header is active
+            // CSS: --gnav-offset-height: 64px
+            const gnavOffset = isDesktop ? 64 : 0;
+
+            // spacing-300 = 16px gap between table containers from CSS
+            const tableGap = 16;
+
+            // Total offset: sticky header + gnav + gap between tables
+            const totalOffset = stickyHeaderHeight + gnavOffset + tableGap;
+
+            const currentScrollPosition = window.scrollY;
+            const elementTop = firstRow.getBoundingClientRect().top + currentScrollPosition;
+            const calculatedTarget = elementTop - totalOffset;
+
+            // Clamp to max scrollable position to prevent overscrolling at bottom of page
+            const maxScrollPosition = document.documentElement.scrollHeight - window.innerHeight;
+            const targetScrollPosition = Math.min(calculatedTarget, maxScrollPosition);
+
             window.scrollTo({
-              top: elementTop - totalOffset,
+              top: targetScrollPosition,
               behavior: 'smooth',
             });
-          });
+          };
+
+          // Find any table that was just collapsed and wait for its transition to end
+          const collapsingTable = Array.from(tableContainers)
+            .filter((c) => c !== container)
+            .map((c) => c.querySelector('table.hide-table'))
+            .find((t) => t);
+
+          if (collapsingTable) {
+            // Wait for the collapse transition to finish before calculating scroll position
+            const onTransitionEnd = (e) => {
+              // Only react to height/max-height transitions on the table itself
+              if (e.target === collapsingTable && ['height', 'max-height', 'grid-template-rows'].includes(e.propertyName)) {
+                collapsingTable.removeEventListener('transitionend', onTransitionEnd);
+                requestAnimationFrame(performScroll);
+              }
+            };
+            collapsingTable.addEventListener('transitionend', onTransitionEnd);
+
+            // Fallback timeout in case transition doesn't fire (e.g., no transition defined)
+            setTimeout(() => {
+              collapsingTable.removeEventListener('transitionend', onTransitionEnd);
+              requestAnimationFrame(performScroll);
+            }, 350);
+          } else {
+            // No other table was collapsed, use double rAF as before
+            requestAnimationFrame(() => {
+              requestAnimationFrame(performScroll);
+            });
+          }
         }
       }
     };

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -478,29 +478,10 @@ function initializeAccordionBehavior(comparisonBlock) {
             });
           };
 
-          const collapsingTable = Array.from(tableContainers)
-            .filter((c) => c !== container)
-            .map((c) => c.querySelector('table.hide-table'))
-            .find((t) => t);
-
-          if (collapsingTable) {
-            const onTransitionEnd = (e) => {
-              if (e.target === collapsingTable && ['height', 'max-height', 'grid-template-rows'].includes(e.propertyName)) {
-                collapsingTable.removeEventListener('transitionend', onTransitionEnd);
-                requestAnimationFrame(performScroll);
-              }
-            };
-            collapsingTable.addEventListener('transitionend', onTransitionEnd);
-
-            setTimeout(() => {
-              collapsingTable.removeEventListener('transitionend', onTransitionEnd);
-              requestAnimationFrame(performScroll);
-            }, 350);
-          } else {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(performScroll);
-            });
-          }
+          // Collapse is instant (no transition), so just wait for next frame
+          requestAnimationFrame(() => {
+            requestAnimationFrame(performScroll);
+          });
         }
       }
     };

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -799,7 +799,7 @@ export default async function decorate(comparisonBlock) {
       }
     });
   } catch (error) {
-    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', severity: 'error'});
+    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', severity: 'error' });
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -799,7 +799,7 @@ export default async function decorate(comparisonBlock) {
       }
     });
   } catch (error) {
-    console.error('Failed to initialize comparison table:', error);
+    window.lana.log('Failed to initialize comparison table:', error);
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }
 }

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -295,7 +295,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     return getCSSNumericValue('--gnav-offset-height');
   };
 
-  // Sentinel at the top of the block to detect when header should become sticky
   const headerSentinel = document.createElement('div');
   headerSentinel.style.cssText = 'position:absolute;top:0;height:1px;width:100%;pointer-events:none';
   comparisonBlock.style.position = 'relative';
@@ -332,7 +331,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     if (window.matchMedia(BREAKPOINTS.DESKTOP).matches) {
       stickyHeader.classList.add('gnav-offset');
     }
-
     isRetracted = false;
     isSticky = true;
   };
@@ -380,21 +378,17 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     const stickyTriggerOffset = getStickyTriggerOffset();
     const contentBottom = getContentBottom(comparisonBlock);
     const isPastHeader = headerTop < stickyTriggerOffset;
-    // Offset by sticky header height for smoother transition
     const headerOffset = stickyHeight || stickyHeader.offsetHeight;
     const isContentVisible = contentBottom > headerOffset;
 
     if (!isPastHeader) {
-      // Header is in view - remove sticky
       removeStickyState();
     } else if (isPastHeader && !isContentVisible) {
-      // Past header and content is above viewport - retract
       if (!isSticky) {
         applyStickyState();
       }
       retractStickyHeader();
     } else if (isPastHeader && isContentVisible) {
-      // Past header and content is visible - show sticky header
       if (!isSticky) {
         applyStickyState();
       } else if (isRetracted) {
@@ -403,7 +397,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     }
   };
 
-  // Single scroll listener handles all sticky state changes
   let scrollTicking = false;
   window.addEventListener('scroll', () => {
     if (!scrollTicking) {
@@ -415,7 +408,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     }
   }, { passive: true });
 
-  // Observer for initial state and when scrolling back to top
   const headerObserver = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
@@ -423,7 +415,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
           if (isSticky) removeStickyState();
           return;
         }
-        // When sentinel comes back into view, remove sticky
         const stickyTriggerOffset = getStickyTriggerOffset();
         if (entry.isIntersecting
           && entry.boundingClientRect.top >= stickyTriggerOffset
@@ -436,7 +427,6 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
   );
   headerObserver.observe(headerSentinel);
 
-  // Watch for content-toggle visibility changes
   const parentSection = getParentSection();
   if (parentSection) {
     const mutationObserver = new MutationObserver(() => {

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -278,6 +278,7 @@ function getContentBottom(comparisonBlock) {
 export function initStickyBehavior(stickyHeader, comparisonBlock) {
   const placeholder = document.createElement('div');
   placeholder.classList.add('sticky-header-placeholder');
+  placeholder.style.display = 'none';
   comparisonBlock.insertBefore(placeholder, stickyHeader.nextSibling);
 
   let isSticky = false;

--- a/express/code/blocks/comparison-table-v2/sticky-header.js
+++ b/express/code/blocks/comparison-table-v2/sticky-header.js
@@ -284,6 +284,16 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
   let isRetracted = false;
   let stickyHeight = 0;
 
+  const getCSSNumericValue = (property) => {
+    const value = window.getComputedStyle(comparisonBlock).getPropertyValue(property);
+    return Number.parseFloat(value) || 0;
+  };
+
+  const getStickyTriggerOffset = () => {
+    if (!window.matchMedia(BREAKPOINTS.DESKTOP).matches) return 0;
+    return getCSSNumericValue('--gnav-offset-height');
+  };
+
   // Sentinel at the top of the block to detect when header should become sticky
   const headerSentinel = document.createElement('div');
   headerSentinel.style.cssText = 'position:absolute;top:0;height:1px;width:100%;pointer-events:none';
@@ -366,8 +376,9 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
     }
 
     const headerTop = headerSentinel.getBoundingClientRect().top;
+    const stickyTriggerOffset = getStickyTriggerOffset();
     const contentBottom = getContentBottom(comparisonBlock);
-    const isPastHeader = headerTop < 0;
+    const isPastHeader = headerTop < stickyTriggerOffset;
     // Offset by sticky header height for smoother transition
     const headerOffset = stickyHeight || stickyHeader.offsetHeight;
     const isContentVisible = contentBottom > headerOffset;
@@ -412,7 +423,10 @@ export function initStickyBehavior(stickyHeader, comparisonBlock) {
           return;
         }
         // When sentinel comes back into view, remove sticky
-        if (entry.isIntersecting && isSticky) {
+        const stickyTriggerOffset = getStickyTriggerOffset();
+        if (entry.isIntersecting
+          && entry.boundingClientRect.top >= stickyTriggerOffset
+          && isSticky) {
           removeStickyState();
         }
       });

--- a/nala/blocks/comparison-table-v2/comparison-table-v2.page.cjs
+++ b/nala/blocks/comparison-table-v2/comparison-table-v2.page.cjs
@@ -1,0 +1,24 @@
+class ComparisonTableV2Block {
+  constructor(page, selector = '.comparison-table-v2', nth = 0) {
+    this.page = page;
+    this.block = page.locator(selector).nth(nth);
+  }
+
+  get accordionContainers() {
+    return this.block.locator('.table-container:not(.no-accordion)');
+  }
+
+  get noAccordionContainers() {
+    return this.block.locator('.table-container.no-accordion');
+  }
+
+  tableAt(index) {
+    return this.accordionContainers.nth(index).locator('table');
+  }
+
+  toggleAt(index) {
+    return this.accordionContainers.nth(index).locator('.toggle-button');
+  }
+}
+
+module.exports = ComparisonTableV2Block;

--- a/nala/blocks/comparison-table-v2/comparison-table-v2.spec.cjs
+++ b/nala/blocks/comparison-table-v2/comparison-table-v2.spec.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  name: 'Comparison Table V2 Block',
+  features: [
+    {
+      tcid: '0',
+      name: '@comparison-table-v2 accordion interactions',
+      selector: '.comparison-table-v2',
+      path: '/drafts/nala/blocks/comparison-table-v2/accordion',
+      tags: '@comparison-table-v2 @accordion @express',
+    },
+  ],
+};

--- a/nala/blocks/comparison-table-v2/comparison-table-v2.spec.cjs
+++ b/nala/blocks/comparison-table-v2/comparison-table-v2.spec.cjs
@@ -8,5 +8,12 @@ module.exports = {
       path: '/drafts/nala/blocks/comparison-table-v2/accordion',
       tags: '@comparison-table-v2 @accordion @express',
     },
+    {
+      tcid: '1',
+      name: '@comparison-table-v2 default rendering',
+      selector: '.comparison-table-v2',
+      path: '/drafts/nala/blocks/comparison-table-v2/comparison-table-v2',
+      tags: '@comparison-table-v2 @default @express',
+    },
   ],
 };

--- a/nala/blocks/comparison-table-v2/comparison-table-v2.test.cjs
+++ b/nala/blocks/comparison-table-v2/comparison-table-v2.test.cjs
@@ -7,6 +7,7 @@ const miloLibs = process.env.MILO_LIBS || '';
 test.describe('Comparison Table V2 Block Test Suite', () => {
   features.forEach((feature) => {
     test(`[Test Id - ${feature.tcid}] ${feature.name} ${feature.tags}`, async ({ page, baseURL }) => {
+      const isAccordionVariant = feature.tags.includes('@accordion');
       const pagePath = feature.path;
       const isAbsolute = /^https?:\/\//.test(pagePath);
       const testUrl = `${isAbsolute ? pagePath : `${baseURL}${pagePath}`}${miloLibs}`;
@@ -19,20 +20,40 @@ test.describe('Comparison Table V2 Block Test Suite', () => {
         await expect(page).toHaveURL(testUrl);
       });
 
-      await test.step('Verify accordion containers initialize correctly', async () => {
+      const containerCount = await block.accordionContainers.count();
+
+      await test.step('Verify block structure and table initialization', async () => {
         await expect(block.block).toBeVisible();
-        const containerCount = await block.accordionContainers.count();
         expect(containerCount).toBeGreaterThan(1);
+        const stickyHeader = block.block.locator('.sticky-header');
+        await expect(stickyHeader).toBeVisible();
+        const planSelectorCount = await block.block.locator('.plan-selector').count();
+        expect(planSelectorCount).toBeGreaterThan(0);
         await expect(block.tableAt(0)).not.toHaveClass(/hide-table/);
-        await expect(block.tableAt(1)).toHaveClass(/hide-table/);
+        if (containerCount > 1) {
+          await expect(block.tableAt(1)).toHaveClass(/hide-table/);
+        }
       });
 
-      await test.step('Toggle a collapsed section and ensure previous one closes', async () => {
-        await block.toggleAt(1).click();
-        await page.waitForTimeout(500);
-        await expect(block.tableAt(1)).not.toHaveClass(/hide-table/);
-        await expect(block.tableAt(0)).toHaveClass(/hide-table/);
-      });
+      if (isAccordionVariant) {
+        await test.step('Toggle a collapsed section and ensure previous one closes', async () => {
+          await block.toggleAt(1).click();
+          await page.waitForTimeout(500);
+          await expect(block.tableAt(1)).not.toHaveClass(/hide-table/);
+          await expect(block.tableAt(0)).toHaveClass(/hide-table/);
+        });
+      } else {
+        await test.step('Toggle multiple sections independently in default variant', async () => {
+          expect(containerCount).toBeGreaterThan(2);
+          await block.toggleAt(1).click();
+          await page.waitForTimeout(500);
+          await block.toggleAt(2).click();
+          await page.waitForTimeout(500);
+          await expect(block.tableAt(0)).not.toHaveClass(/hide-table/);
+          await expect(block.tableAt(1)).not.toHaveClass(/hide-table/);
+          await expect(block.tableAt(2)).not.toHaveClass(/hide-table/);
+        });
+      }
     });
   });
 });

--- a/nala/blocks/comparison-table-v2/comparison-table-v2.test.cjs
+++ b/nala/blocks/comparison-table-v2/comparison-table-v2.test.cjs
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const { features } = require('./comparison-table-v2.spec.cjs');
+const ComparisonTableV2Block = require('./comparison-table-v2.page.cjs');
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+test.describe('Comparison Table V2 Block Test Suite', () => {
+  features.forEach((feature) => {
+    test(`[Test Id - ${feature.tcid}] ${feature.name} ${feature.tags}`, async ({ page, baseURL }) => {
+      const pagePath = feature.path;
+      const isAbsolute = /^https?:\/\//.test(pagePath);
+      const testUrl = `${isAbsolute ? pagePath : `${baseURL}${pagePath}`}${miloLibs}`;
+      const block = new ComparisonTableV2Block(page, feature.selector);
+      console.info(`[Test Page]: ${testUrl}`);
+
+      await test.step('Navigate to comparison table block example', async () => {
+        await page.goto(testUrl);
+        await page.waitForLoadState('networkidle');
+        await expect(page).toHaveURL(testUrl);
+      });
+
+      await test.step('Verify accordion containers initialize correctly', async () => {
+        await expect(block.block).toBeVisible();
+        const containerCount = await block.accordionContainers.count();
+        expect(containerCount).toBeGreaterThan(1);
+        await expect(block.tableAt(0)).not.toHaveClass(/hide-table/);
+        await expect(block.tableAt(1)).toHaveClass(/hide-table/);
+      });
+
+      await test.step('Toggle a collapsed section and ensure previous one closes', async () => {
+        await block.toggleAt(1).click();
+        await page.waitForTimeout(500);
+        await expect(block.tableAt(1)).not.toHaveClass(/hide-table/);
+        await expect(block.tableAt(0)).toHaveClass(/hide-table/);
+      });
+    });
+  });
+});

--- a/test/blocks/comparison-table-v2/sticky-header.test.js
+++ b/test/blocks/comparison-table-v2/sticky-header.test.js
@@ -493,7 +493,7 @@ describe('Sticky Header', () => {
       window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
-    // Should remove sticky when section is hidden
+      // Should remove sticky when section is hidden
       expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
       expect(placeholder.style.display).to.equal('none');
     });

--- a/test/blocks/comparison-table-v2/sticky-header.test.js
+++ b/test/blocks/comparison-table-v2/sticky-header.test.js
@@ -493,7 +493,74 @@ describe('Sticky Header', () => {
       window.dispatchEvent(new Event('scroll'));
       clock.tick(100);
 
-      // Should remove sticky when section is hidden
+    // Should remove sticky when section is hidden
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
+      expect(placeholder.style.display).to.equal('none');
+    });
+
+    it('should trigger sticky once sentinel enters gnav offset region on desktop', () => {
+      const stickyHeader = document.createElement('div');
+      stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 80, configurable: true });
+
+      const comparisonBlock = document.createElement('div');
+      comparisonBlock.classList.add('comparison-table-v2');
+      comparisonBlock.style.setProperty('--gnav-offset-height', '90px');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
+
+      const section = document.createElement('section');
+      section.appendChild(comparisonBlock);
+      document.body.appendChild(section);
+
+      comparisonBlock.appendChild(stickyHeader);
+      initStickyBehavior(stickyHeader, comparisonBlock);
+
+      const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
+      const headerSentinel = comparisonBlock.previousElementSibling;
+
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: 70 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 400 });
+
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
+      expect(placeholder.style.display).to.equal('flex');
+      expect(stickyHeader.classList.contains('gnav-offset')).to.be.true;
+    });
+
+    it('should not trigger sticky until sentinel reaches gnav offset on desktop', () => {
+      const stickyHeader = document.createElement('div');
+      stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 80, configurable: true });
+
+      const comparisonBlock = document.createElement('div');
+      comparisonBlock.classList.add('comparison-table-v2');
+      comparisonBlock.style.setProperty('--gnav-offset-height', '90px');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
+
+      const section = document.createElement('section');
+      section.appendChild(comparisonBlock);
+      document.body.appendChild(section);
+
+      comparisonBlock.appendChild(stickyHeader);
+      initStickyBehavior(stickyHeader, comparisonBlock);
+
+      const placeholder = comparisonBlock.querySelector('.sticky-header-placeholder');
+      const headerSentinel = comparisonBlock.previousElementSibling;
+
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: 120 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 400 });
+
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
       expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
       expect(placeholder.style.display).to.equal('none');
     });

--- a/test/blocks/comparison-table-v2/sticky-header.test.js
+++ b/test/blocks/comparison-table-v2/sticky-header.test.js
@@ -453,6 +453,51 @@ describe('Sticky Header', () => {
       expect(placeholder.style.display).to.equal('none');
     });
 
+    it('should expose controls to suspend sticky removal', () => {
+      const stickyHeader = document.createElement('div');
+      stickyHeader.classList.add('sticky-header');
+      Object.defineProperty(stickyHeader, 'offsetHeight', { value: 100, configurable: true });
+
+      const comparisonBlock = document.createElement('div');
+      comparisonBlock.classList.add('comparison-table-v2');
+
+      const tableContainer = document.createElement('div');
+      tableContainer.classList.add('table-container');
+      comparisonBlock.appendChild(tableContainer);
+
+      const section = document.createElement('section');
+      section.appendChild(comparisonBlock);
+      document.body.appendChild(section);
+
+      comparisonBlock.appendChild(stickyHeader);
+
+      const controls = initStickyBehavior(stickyHeader, comparisonBlock);
+      expect(controls).to.have.property('suspendStickyRelease');
+      expect(controls).to.have.property('resumeStickyRelease');
+
+      const headerSentinel = comparisonBlock.previousElementSibling;
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: -10 });
+      tableContainer.getBoundingClientRect = sinon.stub().returns({ bottom: 500 });
+
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
+
+      controls.suspendStickyRelease();
+      headerSentinel.getBoundingClientRect = sinon.stub().returns({ top: 20 });
+
+      window.dispatchEvent(new Event('scroll'));
+      clock.tick(100);
+
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.true;
+
+      controls.resumeStickyRelease();
+      clock.tick(100);
+
+      expect(stickyHeader.classList.contains('is-stuck')).to.be.false;
+    });
+
     it('should handle hidden parent section', () => {
       const section = document.createElement('section');
       const stickyHeader = document.createElement('div');


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Fix issue with bad scrolling behavior for the accordion variant of the comparison table. It now scrolls to the top of the page sans the sticky header smoothly, ensuring the user sees the header first.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-186664

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://comparison-accordion-bug-fix--da-express-milo--adobecom.aem.page/drafts/chel/comparison-table-v2-test?tab=2 |
| **After**   | https://comparison-accordion-bug-fix--da-express-milo--adobecom.aem.page/express/why-choose-express /
---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page and tab down to one of the tables at the bottom of the page. 
- Expand it, you should scroll downwards, but still be able to see the header of the table.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
