### PR TITLE
fixed odd space between pricing cards icons

### DIFF
--- a/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
+++ b/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
@@ -386,6 +386,10 @@ function processTooltips(el) {
       const images = p.querySelectorAll('img');
       if (images.length > 0) {
         p.classList.add('plan-icon-list');
+        const brs = p.querySelectorAll('br');
+        if (brs.length > 0) {
+          brs.forEach((br) => br.remove());
+        }
         images.forEach((img) => {
           handleImageTooltip(img);
         });
@@ -459,7 +463,7 @@ function setupDOMAndEvents(el, cards, rows, defaultOpenIndex, cardWrapper) {
 
       mutations.forEach((mutation) => {
         if (mutation.type === 'attributes'
-            && (mutation.attributeName === 'style' || mutation.attributeName === 'class')) {
+          && (mutation.attributeName === 'style' || mutation.attributeName === 'class')) {
           const computedStyle = window.getComputedStyle(parentSection);
           const currentDisplay = computedStyle.display;
 


### PR DESCRIPTION
## Summary

Fixed odd space between pricing cards icons.

---

## Jira Ticket

Resolves: [MWPW-186719](https://jira.corp.adobe.com/browse/MWPW-186719)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-186719--da-express-milo--adobecom.aem.page/express/ |

---

## Verification Steps

- Navigate to the Before link and observe the icon in the pricing cards have an odd space inbetween them.
- Navigate to the After link and notice that the spacing between the icons appears correct.

---

## Potential Regressions

- Should be none, since the simplified-pricing-cards-v2 seems to only be being used on the homepage and the /pricing/ page, and the /pricing/ page does not include the product icons.

---

## Additional Notes

It turns out that the odd space in the pricing card icons is caused by the import process between sharepoint and DA. It would seem like this process introduced `<br>` tags between certain sets of inline images, depending on how they were added / included into the document. 

Synced with Ernest who informed me that authoring a fix for each instance of the simplified-pricing-cards-v2 block would be a large effort on author sides, since this block is localized and many instances exist. 

Identified quick fix would be to simply remove the `<br>` tags that occur inbetween inline sets of images that appear in this particular element, within this block. 

