### PR TITLE
[MWPW-187673] CC Library Service Integration

### DIFF
--- a/express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js
+++ b/express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js
@@ -1,33 +1,33 @@
 import BaseApiService from '../../core/BaseApiService.js';
+import { CCLibraryActionGroups } from './topics.js';
+import LibraryActions from './actions/LibraryActions.js';
+import LibraryThemeActions from './actions/LibraryThemeActions.js';
 
 /**
- * CCLibraryPlugin - Plugin for Creative Cloud Libraries API
+ * CCLibraryPlugin - Plugin for Creative Cloud Libraries (Melville) API
  *
- * Provides access to Creative Cloud Libraries for saving and managing themes.
+ * Uses action group architecture. Related actions are organized into:
+ * - LibraryActions: createLibrary, fetchLibraries, fetchLibraryElements
+ * - LibraryThemeActions: saveTheme, saveGradient, deleteTheme, updateTheme, updateElementMetadata
+ *
+ * All operations require Bearer authentication (enforced by BaseApiService getHeaders).
  *
  * @param {Object} options - Configuration options
- * @param {Object} options.serviceConfig - CCLibraries service config (baseUrl, endpoints)
+ * @param {Object} options.serviceConfig - CCLibraries service config (melvilleBasePath, endpoints)
  * @param {Object} options.appConfig - Application config (features, environment)
  */
 export default class CCLibraryPlugin extends BaseApiService {
-  /**
-   * Service name identifier
-   */
   static get serviceName() {
     return 'CCLibrary';
   }
 
-  /**
-   * @param {Object} [options] - Configuration options
-   * @param {Object} [options.serviceConfig] - Service-specific config
-   * @param {Object} [options.appConfig] - Application-level config
-   */
   constructor({ serviceConfig = {}, appConfig = {} } = {}) {
     super({ serviceConfig, appConfig });
+    this.registerActionGroups();
   }
 
   /**
-   * Override baseUrl to use melvilleBasePath
+   * Override baseUrl to use melvilleBasePath (Melville API base).
    */
   get baseUrl() {
     return this.serviceConfig.melvilleBasePath || this.serviceConfig.baseUrl;
@@ -44,124 +44,18 @@ export default class CCLibraryPlugin extends BaseApiService {
   }
 
   /**
-   * Create a new library
-   *
-   * @param {string} name - Library name
-   * @returns {Promise<Object>} Promise resolving to created library
+   * Register all action groups for this plugin.
    */
-  async createLibrary(name) {
-    const path = this.endpoints.libraries;
-    const body = { name };
-
-    return this.post(path, body);
+  registerActionGroups() {
+    this.registerActionGroup(CCLibraryActionGroups.LIBRARY, new LibraryActions(this));
+    this.registerActionGroup(CCLibraryActionGroups.THEME, new LibraryThemeActions(this));
   }
 
   /**
-   * Fetch all libraries
-   *
-   * @param {Object} [params] - Query parameters
-   * @param {string} [params.owner='all'] - Owner filter: 'self', 'shared', or 'all'
-   * @param {number} [params.start=0] - Pagination start index
-   * @param {number} [params.limit=40] - Results per page
-   * @param {string} [params.selector='details'] - Data detail level: 'details', 'summary'
-   * @param {string} [params.orderBy='-modified'] - Sort: '-modified' (newest), 'name' (alphabetical)
-   * @param {string} [params.toolkit='none'] - Set to 'none' to exclude toolkit data
-   * @returns {Promise<Object>} Promise resolving to { total_count, libraries, _links }
+   * Get all registered action group names
+   * @returns {string[]}
    */
-  async fetchLibraries(params = {}) {
-    const path = this.endpoints.libraries;
-    const queryParams = {
-      owner: params.owner ?? 'all',
-      start: params.start ?? 0,
-      limit: params.limit ?? 40,
-      selector: params.selector ?? 'details',
-      orderBy: params.orderBy ?? '-modified',
-      toolkit: params.toolkit ?? 'none',
-    };
-    return this.get(path, { params: queryParams });
-  }
-
-  /**
-   * List elements (themes/gradients) in a library
-   *
-   * @param {string} libraryId - Library ID (library_urn or id)
-   * @param {Object} [params] - Query parameters
-   * @param {number} [params.start=0] - Pagination start index
-   * @param {number} [params.limit=50] - Results per page
-   * @param {string} [params.selector='representations'] - Data detail level
-   * @param {string} [params.type] - Filter by element type (theme and/or gradient MIME types, comma-separated)
-   * @returns {Promise<Object>} Promise resolving to { total_count, elements }
-   */
-  async fetchLibraryElements(libraryId, params = {}) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}`;
-    const queryParams = {
-      start: params.start ?? 0,
-      limit: params.limit ?? 50,
-      selector: params.selector ?? 'representations',
-      ...(params.type != null && { type: params.type }),
-    };
-    return this.get(path, { params: queryParams });
-  }
-
-  /**
-   * Save a theme to a library (create element type colortheme)
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Object} themeData - Theme data (name, type, client, representations per API)
-   * @returns {Promise<Object>} Promise resolving to { elements: [{ id, name, type, ... }] }
-   */
-  async saveTheme(libraryId, themeData) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}`;
-    return this.post(path, themeData);
-  }
-
-  /**
-   * Save a gradient to a library (create element type gradient)
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Object} gradientData - Gradient data (name, type, client, representations per API)
-   * @returns {Promise<Object>} Promise resolving to { elements: [{ id, name, type, ... }] }
-   */
-  async saveGradient(libraryId, gradientData) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}`;
-    return this.post(path, gradientData);
-  }
-
-  /**
-   * Delete a theme from a library
-   *
-   * @param {string} libraryId - Library ID
-   * @param {string} themeId - Theme ID
-   * @returns {Promise<Object>} Promise resolving to delete response
-   */
-  async deleteTheme(libraryId, themeId) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}/${themeId}`;
-    return this.delete(path);
-  }
-
-  /**
-   * Update an element's representation data (theme or gradient)
-   *
-   * @param {string} libraryId - Library ID
-   * @param {string} elementId - Element ID
-   * @param {Object} payload - Update payload (client, type, representations per API)
-   * @returns {Promise<Object>} Promise resolving to { id, representations }
-   */
-  async updateTheme(libraryId, elementId, payload) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}/${elementId}/representations`;
-    return this.put(path, payload);
-  }
-
-  /**
-   * Update element metadata (e.g. name) without changing representations
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Array<{id: string, name?: string}>} elements - Elements to update (id and fields to set)
-   * @returns {Promise<Object>} Promise resolving to empty object (204 No Content)
-   */
-  async updateElementMetadata(libraryId, elements) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}${this.endpoints.metadata}`;
-    return this.put(path, { elements });
+  getActionGroupNames() {
+    return Array.from(this.actionGroups.keys());
   }
 }
-

--- a/express/code/libs/services/plugins/cclibrary/actions/LibraryActions.js
+++ b/express/code/libs/services/plugins/cclibrary/actions/LibraryActions.js
@@ -1,0 +1,98 @@
+import BaseActionGroup from '../../../core/BaseActionGroup.js';
+import { ValidationError } from '../../../core/Errors.js';
+import { CCLibraryTopics } from '../topics.js';
+
+/**
+ * LibraryActions - Handles library-level operations for CC Libraries (Melville API)
+ *
+ * Actions:
+ * - createLibrary - Create a new library
+ * - fetchLibraries - List libraries with optional query params
+ * - fetchLibraryElements - List elements (themes/gradients) in a library
+ *
+ * Uses ValidationError for input validation failures.
+ * All operations require Bearer authentication (enforced by BaseApiService).
+ */
+export default class LibraryActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [CCLibraryTopics.LIBRARY.CREATE]: this.createLibrary.bind(this),
+      [CCLibraryTopics.LIBRARY.FETCH]: this.fetchLibraries.bind(this),
+      [CCLibraryTopics.LIBRARY.ELEMENTS]: this.fetchLibraryElements.bind(this),
+    };
+  }
+
+  /**
+   * Create a new library
+   *
+   * @param {string} name - Library name
+   * @returns {Promise<Object>} Created library
+   * @throws {ValidationError} If name is missing
+   */
+  async createLibrary(name) {
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      throw new ValidationError('Library name is required', {
+        field: 'name',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.LIBRARY.CREATE,
+      });
+    }
+    const path = this.plugin.endpoints.libraries;
+    return this.plugin.post(path, { name });
+  }
+
+  /**
+   * Fetch all libraries
+   *
+   * @param {Object} [params] - Query parameters
+   * @param {string} [params.owner='all'] - Owner filter: 'self', 'shared', 'all'
+   * @param {number} [params.start=0] - Pagination start index
+   * @param {number} [params.limit=40] - Results per page
+   * @param {string} [params.selector='details'] - Data detail level
+   * @param {string} [params.orderBy='-modified'] - Sort order
+   * @param {string} [params.toolkit='none'] - Exclude toolkit data
+   * @returns {Promise<Object>} { total_count, libraries, _links }
+   */
+  async fetchLibraries(params = {}) {
+    const path = this.plugin.endpoints.libraries;
+    const queryParams = {
+      owner: params.owner ?? 'all',
+      start: params.start ?? 0,
+      limit: params.limit ?? 40,
+      selector: params.selector ?? 'details',
+      orderBy: params.orderBy ?? '-modified',
+      toolkit: params.toolkit ?? 'none',
+    };
+    return this.plugin.get(path, { params: queryParams });
+  }
+
+  /**
+   * List elements (themes/gradients) in a library
+   *
+   * @param {string} libraryId - Library ID (library_urn or id)
+   * @param {Object} [params] - Query parameters
+   * @param {number} [params.start=0] - Pagination start index
+   * @param {number} [params.limit=50] - Results per page
+   * @param {string} [params.selector='representations'] - Data detail level
+   * @param {string} [params.type] - Filter by element type (MIME types, comma-separated)
+   * @returns {Promise<Object>} { total_count, elements }
+   * @throws {ValidationError} If libraryId is missing
+   */
+  async fetchLibraryElements(libraryId, params = {}) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.LIBRARY.ELEMENTS,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}`;
+    const queryParams = {
+      start: params.start ?? 0,
+      limit: params.limit ?? 50,
+      selector: params.selector ?? 'representations',
+      ...(params.type != null && { type: params.type }),
+    };
+    return this.plugin.get(path, { params: queryParams });
+  }
+}

--- a/express/code/libs/services/plugins/cclibrary/actions/LibraryThemeActions.js
+++ b/express/code/libs/services/plugins/cclibrary/actions/LibraryThemeActions.js
@@ -1,0 +1,171 @@
+import BaseActionGroup from '../../../core/BaseActionGroup.js';
+import { ValidationError } from '../../../core/Errors.js';
+import { CCLibraryTopics } from '../topics.js';
+
+/**
+ * LibraryThemeActions - Handles theme/element operations within CC Libraries
+ *
+ * Actions:
+ * - saveTheme - Create a theme element in a library
+ * - saveGradient - Create a gradient element in a library
+ * - deleteTheme - Delete an element from a library
+ * - updateTheme - Update an element's representation data (PUT)
+ * - updateElementMetadata - Update element metadata (e.g. name) only
+ *
+ * Uses ValidationError for input validation failures.
+ * All operations require Bearer authentication (enforced by BaseApiService).
+ */
+export default class LibraryThemeActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [CCLibraryTopics.THEME.SAVE]: this.saveTheme.bind(this),
+      [CCLibraryTopics.THEME.SAVE_GRADIENT]: this.saveGradient.bind(this),
+      [CCLibraryTopics.THEME.DELETE]: this.deleteTheme.bind(this),
+      [CCLibraryTopics.THEME.UPDATE]: this.updateTheme.bind(this),
+      [CCLibraryTopics.THEME.UPDATE_METADATA]: this.updateElementMetadata.bind(this),
+    };
+  }
+
+  /**
+   * Save a theme to a library (create element type colortheme)
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Object} themeData - Theme data (name, type, client, representations per API)
+   * @returns {Promise<Object>} { elements: [{ id, name, type, ... }] }
+   * @throws {ValidationError} If libraryId or themeData is missing
+   */
+  async saveTheme(libraryId, themeData) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE,
+      });
+    }
+    if (!themeData || typeof themeData !== 'object') {
+      throw new ValidationError('Theme data is required', {
+        field: 'themeData',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}`;
+    return this.plugin.post(path, themeData);
+  }
+
+  /**
+   * Save a gradient to a library (create element type gradient)
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Object} gradientData - Gradient data (name, type, client, representations per API)
+   * @returns {Promise<Object>} { elements: [{ id, name, type, ... }] }
+   * @throws {ValidationError} If libraryId or gradientData is missing
+   */
+  async saveGradient(libraryId, gradientData) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE_GRADIENT,
+      });
+    }
+    if (!gradientData || typeof gradientData !== 'object') {
+      throw new ValidationError('Gradient data is required', {
+        field: 'gradientData',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE_GRADIENT,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}`;
+    return this.plugin.post(path, gradientData);
+  }
+
+  /**
+   * Delete an element from a library
+   *
+   * @param {string} libraryId - Library ID
+   * @param {string} elementId - Element ID
+   * @returns {Promise<Object>} Empty object (204 No Content)
+   * @throws {ValidationError} If libraryId or elementId is missing
+   */
+  async deleteTheme(libraryId, elementId) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.DELETE,
+      });
+    }
+    if (!elementId) {
+      throw new ValidationError('Element ID is required', {
+        field: 'elementId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.DELETE,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}/${elementId}`;
+    return this.plugin.delete(path);
+  }
+
+  /**
+   * Update an element's representation data (theme or gradient)
+   *
+   * @param {string} libraryId - Library ID
+   * @param {string} elementId - Element ID
+   * @param {Object} payload - Update payload (client, type, representations per API)
+   * @returns {Promise<Object>} { id, representations }
+   * @throws {ValidationError} If required params are missing
+   */
+  async updateTheme(libraryId, elementId, payload) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE,
+      });
+    }
+    if (!elementId) {
+      throw new ValidationError('Element ID is required', {
+        field: 'elementId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE,
+      });
+    }
+    if (!payload || typeof payload !== 'object') {
+      throw new ValidationError('Update payload is required', {
+        field: 'payload',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}/${elementId}/representations`;
+    return this.plugin.put(path, payload);
+  }
+
+  /**
+   * Update element metadata (e.g. name) without changing representations
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Array<{id: string, name?: string}>} elements - Elements to update (id and fields to set)
+   * @returns {Promise<Object>} Empty object (204 No Content)
+   * @throws {ValidationError} If libraryId or elements is missing/invalid
+   */
+  async updateElementMetadata(libraryId, elements) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE_METADATA,
+      });
+    }
+    if (!Array.isArray(elements) || elements.length === 0) {
+      throw new ValidationError('Elements array is required and must not be empty', {
+        field: 'elements',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE_METADATA,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}${this.plugin.endpoints.metadata}`;
+    return this.plugin.put(path, { elements });
+  }
+}

--- a/express/code/libs/services/plugins/cclibrary/index.js
+++ b/express/code/libs/services/plugins/cclibrary/index.js
@@ -2,5 +2,6 @@ export default {
   name: 'cclibrary',
   featureFlag: 'ENABLE_CCLIBRARY',
   loader: () => import('./CCLibraryPlugin.js'),
+  providerLoader: () => import('../../providers/CCLibraryProvider.js'),
 };
 

--- a/express/code/libs/services/plugins/cclibrary/topics.js
+++ b/express/code/libs/services/plugins/cclibrary/topics.js
@@ -1,9 +1,29 @@
 /**
  * CC Library Plugin Topics
  *
- * Topics to be defined in future implementation.
+ * Topics define the available actions for the CC Libraries (Melville) service.
+ * Use these with plugin.dispatch() for direct API access,
+ * or use the CCLibraryProvider for a friendlier interface.
  */
-export const CCLibraryTopics = {};
+export const CCLibraryTopics = {
+  LIBRARY: {
+    CREATE: 'cclibrary.library.create',
+    FETCH: 'cclibrary.library.fetch',
+    ELEMENTS: 'cclibrary.library.elements',
+  },
+  THEME: {
+    SAVE: 'cclibrary.theme.save',
+    SAVE_GRADIENT: 'cclibrary.theme.saveGradient',
+    DELETE: 'cclibrary.theme.delete',
+    UPDATE: 'cclibrary.theme.update',
+    UPDATE_METADATA: 'cclibrary.theme.updateMetadata',
+  },
+};
 
-export const CCLibraryActionGroups = {};
-
+/**
+ * Action group identifiers
+ */
+export const CCLibraryActionGroups = {
+  LIBRARY: 'library',
+  THEME: 'theme',
+};

--- a/express/code/libs/services/providers/CCLibraryProvider.js
+++ b/express/code/libs/services/providers/CCLibraryProvider.js
@@ -32,10 +32,22 @@ export default class CCLibraryProvider extends BaseProvider {
   /**
    * Fetch all libraries
    *
-   * @returns {Promise<Object|null>} Libraries list or null on failure
+   * @param {Object} [params] - Query parameters (owner, start, limit, selector, orderBy, toolkit)
+   * @returns {Promise<Object|null>} { total_count, libraries, _links } or null on failure
    */
-  async fetchLibraries() {
-    return this.safeExecute(() => this.plugin.fetchLibraries());
+  async fetchLibraries(params) {
+    return this.safeExecute(() => this.plugin.fetchLibraries(params));
+  }
+
+  /**
+   * List elements (themes/gradients) in a library
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Object} [params] - Query parameters (start, limit, selector, type)
+   * @returns {Promise<Object|null>} { total_count, elements } or null on failure
+   */
+  async fetchLibraryElements(libraryId, params) {
+    return this.safeExecute(() => this.plugin.fetchLibraryElements(libraryId, params));
   }
 
   /**
@@ -43,10 +55,21 @@ export default class CCLibraryProvider extends BaseProvider {
    *
    * @param {string} libraryId - Library ID
    * @param {Object} themeData - Theme data to save
-   * @returns {Promise<Object|null>} Saved theme or null on failure
+   * @returns {Promise<Object|null>} { elements } or null on failure
    */
   async saveTheme(libraryId, themeData) {
     return this.safeExecute(() => this.plugin.saveTheme(libraryId, themeData));
+  }
+
+  /**
+   * Save a gradient to a library
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Object} gradientData - Gradient data to save
+   * @returns {Promise<Object|null>} { elements } or null on failure
+   */
+  async saveGradient(libraryId, gradientData) {
+    return this.safeExecute(() => this.plugin.saveGradient(libraryId, gradientData));
   }
 
   /**
@@ -61,15 +84,26 @@ export default class CCLibraryProvider extends BaseProvider {
   }
 
   /**
-   * Update a theme in a library
+   * Update an element's representation data (theme or gradient)
    *
    * @param {string} libraryId - Library ID
-   * @param {string} themeId - Theme ID
-   * @param {Object} themeData - Updated theme data
-   * @returns {Promise<Object|null>} Updated theme or null on failure
+   * @param {string} elementId - Element ID
+   * @param {Object} payload - Update payload (client, type, representations)
+   * @returns {Promise<Object|null>} { id, representations } or null on failure
    */
-  async updateTheme(libraryId, themeId, themeData) {
-    return this.safeExecute(() => this.plugin.updateTheme(libraryId, themeId, themeData));
+  async updateTheme(libraryId, elementId, payload) {
+    return this.safeExecute(() => this.plugin.updateTheme(libraryId, elementId, payload));
+  }
+
+  /**
+   * Update element metadata (e.g. name) without changing representations
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Array<{id: string, name?: string}>} elements - Elements to update
+   * @returns {Promise<Object|null>} Empty object or null on failure
+   */
+  async updateElementMetadata(libraryId, elements) {
+    return this.safeExecute(() => this.plugin.updateElementMetadata(libraryId, elements));
   }
 }
 

--- a/express/code/libs/services/providers/CCLibraryProvider.js
+++ b/express/code/libs/services/providers/CCLibraryProvider.js
@@ -1,0 +1,85 @@
+import BaseProvider from './BaseProvider.js';
+
+/**
+ * CC Library Provider
+ *
+ * Provides a clean API for managing Creative Cloud Libraries.
+ * Wraps CCLibraryPlugin methods with error-safe execution.
+ *
+ * @example
+ * const ccLibrary = await serviceManager.getProvider('cclibrary');
+ * const libraries = await ccLibrary.fetchLibraries();
+ * await ccLibrary.createLibrary('My Library');
+ */
+export default class CCLibraryProvider extends BaseProvider {
+  /**
+   * @param {Object} plugin - Plugin instance
+   */
+  constructor(plugin) {
+    super(plugin);
+  }
+
+  /**
+   * Create a new library
+   *
+   * @param {string} name - Library name
+   * @returns {Promise<Object|null>} Created library or null on failure
+   */
+  async createLibrary(name) {
+    return this.safeExecute(() => this.plugin.createLibrary(name));
+  }
+
+  /**
+   * Fetch all libraries
+   *
+   * @returns {Promise<Object|null>} Libraries list or null on failure
+   */
+  async fetchLibraries() {
+    return this.safeExecute(() => this.plugin.fetchLibraries());
+  }
+
+  /**
+   * Save a theme to a library
+   *
+   * @param {string} libraryId - Library ID
+   * @param {Object} themeData - Theme data to save
+   * @returns {Promise<Object|null>} Saved theme or null on failure
+   */
+  async saveTheme(libraryId, themeData) {
+    return this.safeExecute(() => this.plugin.saveTheme(libraryId, themeData));
+  }
+
+  /**
+   * Delete a theme from a library
+   *
+   * @param {string} libraryId - Library ID
+   * @param {string} themeId - Theme ID
+   * @returns {Promise<Object|null>} Delete response or null on failure
+   */
+  async deleteTheme(libraryId, themeId) {
+    return this.safeExecute(() => this.plugin.deleteTheme(libraryId, themeId));
+  }
+
+  /**
+   * Update a theme in a library
+   *
+   * @param {string} libraryId - Library ID
+   * @param {string} themeId - Theme ID
+   * @param {Object} themeData - Updated theme data
+   * @returns {Promise<Object|null>} Updated theme or null on failure
+   */
+  async updateTheme(libraryId, themeId, themeData) {
+    return this.safeExecute(() => this.plugin.updateTheme(libraryId, themeId, themeData));
+  }
+}
+
+/**
+ * Factory function to create a new CC Library provider instance.
+ * Useful for testing or when isolated instances are needed.
+ *
+ * @param {Object} plugin - Plugin instance
+ * @returns {CCLibraryProvider} New provider instance
+ */
+export function createCCLibraryProvider(plugin) {
+  return new CCLibraryProvider(plugin);
+}

--- a/express/code/libs/services/providers/CCLibraryProvider.js
+++ b/express/code/libs/services/providers/CCLibraryProvider.js
@@ -1,10 +1,11 @@
 import BaseProvider from './BaseProvider.js';
+import { CCLibraryTopics, CCLibraryActionGroups } from '../plugins/cclibrary/topics.js';
 
 /**
  * CC Library Provider
  *
  * Provides a clean API for managing Creative Cloud Libraries.
- * Wraps CCLibraryPlugin methods with error-safe execution.
+ * Wraps all topic actions with safeExecute() and uses the useAction pattern.
  *
  * @example
  * const ccLibrary = await serviceManager.getProvider('cclibrary');
@@ -12,104 +13,63 @@ import BaseProvider from './BaseProvider.js';
  * await ccLibrary.createLibrary('My Library');
  */
 export default class CCLibraryProvider extends BaseProvider {
-  /**
-   * @param {Object} plugin - Plugin instance
-   */
+  #actions = {};
+
   constructor(plugin) {
     super(plugin);
+    this.#initActions();
   }
 
-  /**
-   * Create a new library
-   *
-   * @param {string} name - Library name
-   * @returns {Promise<Object|null>} Created library or null on failure
-   */
+  #initActions() {
+    const { LIBRARY, THEME } = CCLibraryActionGroups;
+
+    this.#actions = {
+      createLibrary: this.plugin.useAction(LIBRARY, CCLibraryTopics.LIBRARY.CREATE),
+      fetchLibraries: this.plugin.useAction(LIBRARY, CCLibraryTopics.LIBRARY.FETCH),
+      fetchLibraryElements: this.plugin.useAction(LIBRARY, CCLibraryTopics.LIBRARY.ELEMENTS),
+      saveTheme: this.plugin.useAction(THEME, CCLibraryTopics.THEME.SAVE),
+      saveGradient: this.plugin.useAction(THEME, CCLibraryTopics.THEME.SAVE_GRADIENT),
+      deleteTheme: this.plugin.useAction(THEME, CCLibraryTopics.THEME.DELETE),
+      updateTheme: this.plugin.useAction(THEME, CCLibraryTopics.THEME.UPDATE),
+      updateElementMetadata: this.plugin.useAction(THEME, CCLibraryTopics.THEME.UPDATE_METADATA),
+    };
+  }
+
   async createLibrary(name) {
-    return this.safeExecute(() => this.plugin.createLibrary(name));
+    return this.safeExecute(() => this.#actions.createLibrary(name));
   }
 
-  /**
-   * Fetch all libraries
-   *
-   * @param {Object} [params] - Query parameters (owner, start, limit, selector, orderBy, toolkit)
-   * @returns {Promise<Object|null>} { total_count, libraries, _links } or null on failure
-   */
   async fetchLibraries(params) {
-    return this.safeExecute(() => this.plugin.fetchLibraries(params));
+    return this.safeExecute(() => this.#actions.fetchLibraries(params));
   }
 
-  /**
-   * List elements (themes/gradients) in a library
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Object} [params] - Query parameters (start, limit, selector, type)
-   * @returns {Promise<Object|null>} { total_count, elements } or null on failure
-   */
   async fetchLibraryElements(libraryId, params) {
-    return this.safeExecute(() => this.plugin.fetchLibraryElements(libraryId, params));
+    return this.safeExecute(() => this.#actions.fetchLibraryElements(libraryId, params));
   }
 
-  /**
-   * Save a theme to a library
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Object} themeData - Theme data to save
-   * @returns {Promise<Object|null>} { elements } or null on failure
-   */
   async saveTheme(libraryId, themeData) {
-    return this.safeExecute(() => this.plugin.saveTheme(libraryId, themeData));
+    return this.safeExecute(() => this.#actions.saveTheme(libraryId, themeData));
   }
 
-  /**
-   * Save a gradient to a library
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Object} gradientData - Gradient data to save
-   * @returns {Promise<Object|null>} { elements } or null on failure
-   */
   async saveGradient(libraryId, gradientData) {
-    return this.safeExecute(() => this.plugin.saveGradient(libraryId, gradientData));
+    return this.safeExecute(() => this.#actions.saveGradient(libraryId, gradientData));
   }
 
-  /**
-   * Delete a theme from a library
-   *
-   * @param {string} libraryId - Library ID
-   * @param {string} themeId - Theme ID
-   * @returns {Promise<Object|null>} Delete response or null on failure
-   */
   async deleteTheme(libraryId, themeId) {
-    return this.safeExecute(() => this.plugin.deleteTheme(libraryId, themeId));
+    return this.safeExecute(() => this.#actions.deleteTheme(libraryId, themeId));
   }
 
-  /**
-   * Update an element's representation data (theme or gradient)
-   *
-   * @param {string} libraryId - Library ID
-   * @param {string} elementId - Element ID
-   * @param {Object} payload - Update payload (client, type, representations)
-   * @returns {Promise<Object|null>} { id, representations } or null on failure
-   */
   async updateTheme(libraryId, elementId, payload) {
-    return this.safeExecute(() => this.plugin.updateTheme(libraryId, elementId, payload));
+    return this.safeExecute(() => this.#actions.updateTheme(libraryId, elementId, payload));
   }
 
-  /**
-   * Update element metadata (e.g. name) without changing representations
-   *
-   * @param {string} libraryId - Library ID
-   * @param {Array<{id: string, name?: string}>} elements - Elements to update
-   * @returns {Promise<Object|null>} Empty object or null on failure
-   */
   async updateElementMetadata(libraryId, elements) {
-    return this.safeExecute(() => this.plugin.updateElementMetadata(libraryId, elements));
+    return this.safeExecute(() => this.#actions.updateElementMetadata(libraryId, elements));
   }
 }
 
 /**
  * Factory function to create a new CC Library provider instance.
- * Useful for testing or when isolated instances are needed.
  *
  * @param {Object} plugin - Plugin instance
  * @returns {CCLibraryProvider} New provider instance

--- a/express/code/libs/services/providers/index.js
+++ b/express/code/libs/services/providers/index.js
@@ -7,4 +7,5 @@
 export { default as BaseProvider } from './BaseProvider.js';
 export { default as KulerProvider, createKulerProvider } from './KulerProvider.js';
 export { default as StockProvider, createStockProvider } from './StockProvider.js';
+export { default as CCLibraryProvider, createCCLibraryProvider } from './CCLibraryProvider.js';
 


### PR DESCRIPTION
## Summary

Creative Cloud Libraries integration for saving, managing, and syncing color themes and gradients to a user’s private CC Libraries. Uses Bearer authentication for all operations.

-  API Base: libraries.adobe.io
-  Feature Flag: ENABLE_CCLIBRARY
-  Auth Required: Yes (Bearer token for all operations)
-  Pages Using This: Explore, Color Wheel, Extract


---

## Jira Ticket

Resolves: [MWPW-187673](https://jira.corp.adobe.com/browse/MWPW-187673)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://vvineett-color-service-layer-cc-libraries--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
