### PR TITLE
[Color][Service Layer][MWPW-187673] CC Library Service Integration

### DIFF
--- a/express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js
+++ b/express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js
@@ -1,26 +1,30 @@
 import BaseApiService from '../../core/BaseApiService.js';
+import { StorageFullError } from '../../core/Errors.js';
+import { CCLibraryActionGroups } from './topics.js';
+import { LibraryActions, LibraryThemeActions } from './actions/CCLibraryActions.js';
+import { HTTP_STATUS } from './constants.js';
 
+/**
+ * @param {Object} options - Configuration options
+ * @param {Object} options.serviceConfig - CCLibraries service config (melvilleBasePath, endpoints)
+ * @param {Object} options.appConfig - Application config (features, environment)
+ */
 export default class CCLibraryPlugin extends BaseApiService {
   static get serviceName() {
     return 'CCLibrary';
   }
 
-  /**
-   * @param {Object} [options]
-   * @param {Object} [options.serviceConfig]
-   * @param {Object} [options.appConfig]
-   */
   constructor({ serviceConfig = {}, appConfig = {} } = {}) {
     super({ serviceConfig, appConfig });
+    this.registerActionGroups();
   }
 
-  /** @returns {string} */
   get baseUrl() {
-    return this.serviceConfig.melvilleBasePath || this.serviceConfig.baseUrl;
+    return this.serviceConfig.melvilleBasePath;
   }
 
   /**
-   * @param {Object} appConfigParam
+   * @param {Object} appConfigParam - Application config with features
    * @returns {boolean}
    */
   // eslint-disable-next-line class-methods-use-this
@@ -29,50 +33,28 @@ export default class CCLibraryPlugin extends BaseApiService {
   }
 
   /**
-   * @param {string} name
-   * @returns {Promise<Object>}
+   * @param {Response} response - Fetch API response
+   * @returns {Promise<Object>} Parsed response
+   * @throws {StorageFullError} When HTTP 507 is returned
    */
-  async createLibrary(name) {
-    const path = this.endpoints.libraries;
-    const body = { name };
-
-    return this.post(path, body);
+  async handleResponse(response) {
+    if (response.status === HTTP_STATUS.STORAGE_FULL) {
+      const errorBody = await response.text();
+      throw new StorageFullError('CC Libraries storage is full', {
+        serviceName: CCLibraryPlugin.serviceName,
+        responseBody: errorBody,
+      });
+    }
+    return super.handleResponse(response);
   }
 
-  /** @returns {Promise<Object>} */
-  async fetchLibraries() {
-    const path = this.endpoints.libraries;
-    return this.get(path);
+  registerActionGroups() {
+    this.registerActionGroup(CCLibraryActionGroups.LIBRARY, new LibraryActions(this));
+    this.registerActionGroup(CCLibraryActionGroups.THEME, new LibraryThemeActions(this));
   }
 
-  /**
-   * @param {string} libraryId
-   * @param {Object} themeData
-   * @returns {Promise<Object>}
-   */
-  async saveTheme(libraryId, themeData) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}`;
-    return this.post(path, themeData);
-  }
-
-  /**
-   * @param {string} libraryId
-   * @param {string} themeId
-   * @returns {Promise<Object>}
-   */
-  async deleteTheme(libraryId, themeId) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}/${themeId}`;
-    return this.delete(path);
-  }
-
-  /**
-   * @param {string} libraryId
-   * @param {string} themeId
-   * @param {Object} themeData
-   * @returns {Promise<Object>}
-   */
-  async updateTheme(libraryId, themeId, themeData) {
-    const path = `${this.endpoints.libraries}/${libraryId}${this.endpoints.themes}/${themeId}/representations`;
-    return this.post(path, themeData);
+  /** @returns {string[]} */
+  getActionGroupNames() {
+    return Array.from(this.actionGroups.keys());
   }
 }

--- a/express/code/libs/services/plugins/cclibrary/README.md
+++ b/express/code/libs/services/plugins/cclibrary/README.md
@@ -1,0 +1,403 @@
+# CCLibrary Plugin
+
+> Creative Cloud Libraries (Melville API) plugin for creating and managing libraries, themes, gradients, and element metadata.
+
+## Overview
+
+The CCLibrary Plugin provides topic-driven access to Adobe Creative Cloud Libraries through the Melville API.
+It is implemented as a Pattern A plugin with action groups and a provider, enabling both low-level dispatch usage and a consumer-friendly provider API.
+
+## Features
+
+- 📚 **Library Management** - Create libraries and fetch paginated library lists
+- 🧩 **Library Elements** - Fetch elements (themes/gradients) in a specific library
+- 🎨 **Theme Operations** - Save, update, and delete theme elements
+- 🌈 **Gradient Operations** - Save gradient elements with Melville-compliant payload builder
+- 🏷️ **Metadata Updates** - Update element metadata (for example, renaming elements)
+- 🔒 **Writable Library Filtering** - Determine which libraries the user can write to (private, shared-editor, ACL)
+- 🎯 **Swatch Conversion** - Convert internal color swatches to CC Library format (RGB, CMYK, HSB, LAB, Pantone)
+- ⚠️ **Storage Full Detection** - Dedicated `StorageFullError` for HTTP 507 responses
+
+## Configuration
+
+**Feature Flag:** `ENABLE_CCLIBRARY`
+
+**Plugin Manifest Name:** `cclibrary`  
+**Service Config Key:** `cclibrary`
+
+**Service Config:**
+
+```javascript
+cclibrary: {
+  baseUrl: 'https://cc-api-assets.adobe.io',
+  melvilleBasePath: 'https://libraries.adobe.io/api/v1',
+  apiKey: 'API_KEY', // Required — injected as x-api-key header by BaseApiService
+  assetAclDirectoryKey: 'http://ns.adobe.com/adobecloud/rel/directory',
+  endpoints: {
+    libraries: '/libraries',
+    themes: '/elements',
+    metadata: '/metadata',
+  },
+}
+```
+
+> **Note:** The plugin's `baseUrl` resolves to `melvilleBasePath` from service config, falling back to `baseUrl` if not set.
+> The `apiKey` field is required for the `x-api-key` header to be sent with every request.
+
+## Constants
+
+All magic values are centralized in `constants.js`:
+
+```javascript
+import {
+  THEME_ELEMENT_TYPE,        // 'application/vnd.adobe.element.colortheme+dcx'
+  GRADIENT_ELEMENT_TYPE,     // 'application/vnd.adobe.element.gradient+dcx'
+  THEME_REPRESENTATION_TYPE, // 'application/vnd.adobe.colortheme+json'
+  GRADIENT_REPRESENTATION_TYPE, // 'application/vnd.adobe.gradient+json'
+  ALL_COLOR_ELEMENT_TYPES,   // Combined theme + gradient filter string
+  LIBRARIES_PAGE_SIZE,       // 40
+  ELEMENTS_PAGE_SIZE,        // 50
+  MAX_ELEMENTS_PER_LIBRARY,  // 1000
+  LIBRARY_OWNER_SCOPE,      // { ALL, PRIVATE, INCOMING, OUTGOING, TEAM, DISCOVERY, PUBLIC, OTHER }
+  LIBRARY_OWNERSHIP,         // { PRIVATE, SHARED } — response-level ownership field
+  LIBRARY_ROLE,              // { EDITOR, VIEWER }
+  ERROR_CODE,                // { STORAGE_FULL }
+  HTTP_STATUS,               // { STORAGE_FULL: 507 }
+  COLOR_MODE,                // { RGB, CMYK, HSB, LAB } — internal comparison keys
+  CC_LIBRARY_COLOR_MODE,     // { RGB, CMYK, HSB, Lab } — Melville API output strings
+  getClientInfo,             // () => { deviceId, device, app } for gradient payloads
+  COLOR_PROFILE,             // 'sRGB IEC61966-2.1'
+} from './constants.js';
+```
+
+The `assetAclDirectoryKey` (full URI for `asset_acl` directory permissions) is part of the `cclibrary` service config object in `../../config.js` and is accessed via `this.plugin.serviceConfig.assetAclDirectoryKey` in the provider.
+
+> **Note:** `COLOR_MODE` is used for internal comparisons (e.g. switch cases), while `CC_LIBRARY_COLOR_MODE` is used for mode strings sent to the Melville API. The key difference is LAB: internally `'LAB'`, but the API expects `'Lab'` (mixed case).
+
+## Topics
+
+| Topic | Description |
+|-------|-------------|
+| `cclibrary.library.create` | Create a new library |
+| `cclibrary.library.fetch` | Fetch libraries with pagination/filter options |
+| `cclibrary.library.elements` | Fetch elements in a specific library |
+| `cclibrary.theme.save` | Save a theme element into a library |
+| `cclibrary.theme.saveGradient` | Save a gradient element into a library |
+| `cclibrary.theme.delete` | Delete a library element |
+| `cclibrary.theme.update` | Update an element's representation payload |
+| `cclibrary.theme.updateMetadata` | Update element metadata (for example, name) |
+
+## Owner Scope Parameter
+
+The `owner` query parameter for `fetchLibraries` accepts the following Melville API values (defined in `LIBRARY_OWNER_SCOPE`):
+
+| Value | Meaning |
+|-------|---------|
+| `all` | All libraries the user has access to (default) |
+| `private` | User's own libraries |
+| `incoming` | Libraries shared with the user |
+| `outgoing` | Libraries the user has shared out |
+| `team` | Team libraries |
+| `discovery` | Discovery libraries |
+| `public` | Public libraries |
+| `other` | Other libraries |
+
+Values can be comma-separated (e.g. `owner: 'private,incoming'`).
+
+> **Note:** The legacy value `'self'` is **not** accepted by the Melville API. Use `'private'` to fetch user-owned libraries, or use the convenience method `fetchUserLibraries()` on the provider.
+
+## Action Groups
+
+| Group | Actions |
+|-------|---------|
+| `library` | `createLibrary`, `fetchLibraries`, `fetchLibraryElements` |
+| `theme` | `saveTheme`, `saveGradient`, `deleteTheme`, `updateTheme`, `updateElementMetadata` |
+
+## Usage
+
+### Via Provider (Recommended)
+
+```javascript
+import { serviceManager, initApiService } from './services/integration/index.js';
+
+await initApiService();
+
+const ccLibrary = await serviceManager.getProvider('cclibrary');
+
+// Create library
+const created = await ccLibrary.createLibrary('Brand Colors');
+
+// List libraries (with explicit owner scope)
+const libraries = await ccLibrary.fetchLibraries({ owner: 'private', limit: 20 });
+
+// List user's own libraries (convenience shorthand)
+const myLibraries = await ccLibrary.fetchUserLibraries({ limit: 20 });
+
+// Fetch elements in library (defaults to theme + gradient types)
+const elements = await ccLibrary.fetchLibraryElements('lib-123', {
+  start: 0,
+  limit: 50,
+  selector: 'representations',
+});
+
+// Save theme
+await ccLibrary.saveTheme('lib-123', {
+  name: 'Warm Sunset',
+  type: 'colortheme',
+  representations: [],
+});
+
+// Save gradient
+await ccLibrary.saveGradient('lib-123', {
+  name: 'Ocean Fade',
+  type: 'gradient',
+  representations: [],
+});
+
+// Update element representations
+await ccLibrary.updateTheme('lib-123', 'elem-456', {
+  client: 'express',
+  type: 'colortheme',
+  representations: [],
+});
+
+// Update metadata
+await ccLibrary.updateElementMetadata('lib-123', [
+  { id: 'elem-456', name: 'Renamed Theme' },
+]);
+
+// Delete element
+await ccLibrary.deleteTheme('lib-123', 'elem-456');
+```
+
+### Via Plugin Dispatch
+
+```javascript
+import { CCLibraryTopics } from './services/integration/plugins/cclibrary/topics.js';
+
+const plugin = serviceManager.getPlugin('cclibrary');
+
+const libraries = await plugin.dispatch(CCLibraryTopics.LIBRARY.FETCH, {
+  owner: 'all',
+  start: 0,
+  limit: 40,
+});
+
+const created = await plugin.dispatch(CCLibraryTopics.LIBRARY.CREATE, 'My Library');
+```
+
+### Writable Library Filtering
+
+A library is considered writable when any of these conditions is true:
+1. It is a **private** library (owned by the user).
+2. It is **shared** and the user's bookmark role is `"editor"`.
+3. It is **shared** and the `asset_acl` grants `"write"` access on the directory key (`serviceConfig.assetAclDirectoryKey`).
+
+> **Note:** The `asset_acl` property uses the full URI configured in `assetAclDirectoryKey` as the JSON key for directory-level permissions, not a short key like `directory_access`.
+
+```javascript
+const ccLibrary = await serviceManager.getProvider('cclibrary');
+
+// Fetch all libraries
+const result = await ccLibrary.fetchLibraries({ owner: 'all' });
+
+// Filter to only those the user can save into
+const writableLibs = ccLibrary.filterWritableLibraries(result.libraries);
+
+// Or check a single library
+if (ccLibrary.isLibraryWritable(someLibrary)) {
+  await ccLibrary.saveTheme(someLibrary.library_urn, themePayload);
+}
+```
+
+### Gradient Payload Builder
+
+Build Melville-compliant gradient payloads for saving to CC Libraries:
+
+```javascript
+const ccLibrary = await serviceManager.getProvider('cclibrary');
+
+const payload = ccLibrary.buildGradientPayload({
+  name: 'Sunset Fade',
+  angle: 135,
+  type: 'linear',           // 'linear' | 'radial' (default: 'linear')
+  interpolation: 'linear',  // color interpolation (default: 'linear')
+  aspectRatio: 1,            // gradient aspect ratio (default: 1)
+  stops: [
+    { color: '#FF5733', position: 0 },
+    { color: '#FFC300', position: 0.5 },
+    { color: '#DAF7A6', position: 1 },
+  ],
+});
+
+// Save the gradient to a library
+await ccLibrary.saveGradient('lib-123', payload);
+```
+
+The builder accepts CSS color strings (hex `#RGB`/`#RRGGBB`, `rgb()`, `rgba()`) and automatically parses them to the `{ r, g, b }` format expected by the Melville API. Invalid or missing colors default to black `{ r: 0, g: 0, b: 0 }`.
+
+### Swatch Format Conversion
+
+Each swatch in a CC Library theme is an **array** of mode objects.
+When the primary `colorMode` is not RGB, an entry for that mode is added first, followed by the mandatory RGB entry.
+Pantone / spot-color metadata is attached to **both** the non-RGB mode entry and the RGB entry when present.
+
+The color mode comparison is case-insensitive, and output mode strings use the `CC_LIBRARY_COLOR_MODE` constants (notably `'Lab'` for LAB, not `'LAB'`).
+
+The HSB case also accepts `'HSV'` as a backward-compatible alias, reading from `swatch.hsv` or `swatch.hsb`.
+
+```javascript
+const ccLibrary = await serviceManager.getProvider('cclibrary');
+
+// Convert a single swatch (RGB values are 0-1 floats internally)
+const ccSwatch = ccLibrary.convertSwatchToCCFormat(
+  { rgb: { r: 0.9, g: 0.4, b: 0.2 } },
+  'RGB'
+);
+// → [{ mode: 'RGB', value: { r: 230, g: 102, b: 51 } }]
+
+// With Pantone data
+const pantoneSwatch = ccLibrary.convertSwatchToCCFormat(
+  { rgb: { r: 0.9, g: 0.4, b: 0.2 }, pantone: '185 C', isSpotColor: true },
+  'RGB'
+);
+// → [{ mode: 'RGB', value: { r: 230, g: 102, b: 51 }, type: 'spot', spotColorName: 'PANTONE 185 C' }]
+
+// Convert all swatches for a CMYK theme
+const ccSwatches = ccLibrary.convertSwatchesToCCFormat(theme.swatches, 'CMYK');
+// → Each swatch array contains [cmykEntry, rgbEntry] (both with Pantone data if present)
+```
+
+### Storage Full Error Handling
+
+```javascript
+import { StorageFullError } from './services/core/Errors.js';
+
+try {
+  await ccLibrary.createLibrary('New Library');
+} catch (error) {
+  if (error instanceof StorageFullError) {
+    // Show user-facing message that cloud storage is full
+  }
+}
+```
+
+> **Note:** When using the provider's `safeExecute` wrapper, errors are caught and logged automatically.
+> To handle `StorageFullError` explicitly, use `plugin.dispatch()` directly or catch within the action call.
+
+## Response Structure
+
+### `fetchLibraries(params)`
+
+```javascript
+{
+  total_count: number,
+  libraries: [
+    {
+      id: string,
+      name: string,
+      // ... API fields
+    }
+  ],
+  _links: object
+}
+```
+
+### `fetchLibraryElements(libraryId, params)`
+
+```javascript
+{
+  total_count: number,
+  elements: [
+    {
+      id: string,
+      name: string,
+      type: string, // e.g. 'colortheme' or 'gradient'
+      // ... API fields
+    }
+  ]
+}
+```
+
+### `saveTheme(...)` / `saveGradient(...)`
+
+```javascript
+{
+  elements: [
+    {
+      id: string,
+      name: string,
+      type: string
+    }
+  ]
+}
+```
+
+### `deleteTheme(...)` / `updateElementMetadata(...)`
+
+```javascript
+{}
+```
+
+### `updateTheme(...)`
+
+```javascript
+{
+  id: string,
+  representations: []
+  // ... API fields
+}
+```
+
+## Validation
+
+All action methods validate required inputs before making API calls. Invalid inputs throw a `ValidationError` (from `../../core/Errors.js`) with contextual metadata:
+
+```javascript
+{
+  field: 'libraryId',             // the invalid field
+  serviceName: 'CCLibrary',       // plugin service name
+  topic: 'cclibrary.theme.save'   // the dispatched topic
+}
+```
+
+| Method | Required Fields |
+|--------|----------------|
+| `createLibrary` | `name` (non-empty string) |
+| `fetchLibraryElements` | `libraryId` |
+| `saveTheme` | `libraryId`, `themeData` (object) |
+| `saveGradient` | `libraryId`, `gradientData` (object) |
+| `deleteTheme` | `libraryId`, `elementId` |
+| `updateTheme` | `libraryId`, `elementId`, `payload` (object) |
+| `updateElementMetadata` | `libraryId`, `elements` (non-empty array) |
+
+## Error Handling
+
+| Error Type | Code | When |
+|------------|------|------|
+| `ValidationError` | `VALIDATION_ERROR` | Missing or invalid input parameters |
+| `ApiError` | HTTP status code | Generic HTTP failures (400, 401, 403, 404, etc.) |
+| `StorageFullError` | `STORAGE_FULL` | HTTP 507 — user's CC cloud storage is full |
+
+## Authentication
+
+Bearer authentication is expected for CCLibrary operations.
+Auth headers are provided through the shared service-layer auth flow (Adobe IMS token resolution in `BaseApiService`).
+
+The `x-api-key` header is injected automatically when `apiKey` is set in the service config.
+
+## Related Files
+
+- `CCLibraryPlugin.js` - Main plugin class (with 507 handleResponse override)
+- `topics.js` - Topic and action-group identifiers
+- `constants.js` - MIME types, pagination defaults, ownership constants, API mode strings
+- `../../config.js` - Shared service config (includes `assetAclDirectoryKey` in cclibrary service entry)
+- `actions/CCLibraryActions.js` - Action group implementations
+- `../../providers/CCLibraryProvider.js` - Consumer-facing provider (with utility helpers)
+- `../../core/Errors.js` - Error types including `StorageFullError`
+- `index.js` - Plugin manifest
+
+---
+
+**Version:** 1.3  
+**Last Updated:** February 2026

--- a/express/code/libs/services/plugins/cclibrary/actions/CCLibraryActions.js
+++ b/express/code/libs/services/plugins/cclibrary/actions/CCLibraryActions.js
@@ -1,0 +1,238 @@
+/* eslint-disable max-classes-per-file */
+import BaseActionGroup from '../../../core/BaseActionGroup.js';
+import { ValidationError } from '../../../core/Errors.js';
+import { CCLibraryTopics } from '../topics.js';
+import {
+  LIBRARIES_PAGE_SIZE,
+  ELEMENTS_PAGE_SIZE,
+  ALL_COLOR_ELEMENT_TYPES,
+  LIBRARY_OWNER_SCOPE,
+} from '../constants.js';
+
+export class LibraryActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [CCLibraryTopics.LIBRARY.CREATE]: this.createLibrary.bind(this),
+      [CCLibraryTopics.LIBRARY.FETCH]: this.fetchLibraries.bind(this),
+      [CCLibraryTopics.LIBRARY.ELEMENTS]: this.fetchLibraryElements.bind(this),
+    };
+  }
+
+  /**
+   * @param {string} name - Library name
+   * @returns {Promise<Object>} Created library
+   * @throws {ValidationError} If name is missing
+   */
+  async createLibrary(name) {
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      throw new ValidationError('Library name is required', {
+        field: 'name',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.LIBRARY.CREATE,
+      });
+    }
+    const path = this.plugin.endpoints.libraries;
+    return this.plugin.post(path, { name });
+  }
+
+  /**
+   * @param {Object} [params] - Query parameters
+   * @param {string} [params.owner='all'] - Owner scope filter.
+   *   Valid: 'all', 'private', 'incoming', 'outgoing', 'team', 'discovery', 'public', 'other'.
+   *   Can be comma-separated (e.g. 'private,incoming').
+   * @param {number} [params.start=0] - Pagination start index
+   * @param {number} [params.limit=LIBRARIES_PAGE_SIZE] - Results per page
+   * @param {string} [params.selector='details'] - Data detail level
+   * @param {string} [params.orderBy='-modified_date'] -
+   * Sort order ('name', 'created_date', 'modified_date'; prefix with - for descending)
+   * @param {string} [params.toolkit='none'] - Exclude toolkit data
+   * @returns {Promise<Object>} { total_count, libraries, _links }
+   */
+  async fetchLibraries(params = {}) {
+    const path = this.plugin.endpoints.libraries;
+    const queryParams = {
+      owner: params.owner ?? LIBRARY_OWNER_SCOPE.ALL,
+      start: params.start ?? 0,
+      limit: params.limit ?? LIBRARIES_PAGE_SIZE,
+      selector: params.selector ?? 'details',
+      orderBy: params.orderBy ?? '-modified_date',
+      toolkit: params.toolkit ?? 'none',
+    };
+    return this.plugin.get(path, { params: queryParams });
+  }
+
+  /**
+   * @param {string} libraryId - Library ID (library_urn or id)
+   * @param {Object} [params] - Query parameters
+   * @param {number} [params.start=0] - Pagination start index
+   * @param {number} [params.limit=ELEMENTS_PAGE_SIZE] - Results per page
+   * @param {string} [params.selector='representations'] - Data detail level
+   * @param {string} [params.type] - Filter by element type (MIME types, comma-separated).
+   *   Defaults to ALL_COLOR_ELEMENT_TYPES (themes + gradients).
+   * @returns {Promise<Object>} { total_count, elements }
+   * @throws {ValidationError} If libraryId is missing
+   */
+  async fetchLibraryElements(libraryId, params = {}) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.LIBRARY.ELEMENTS,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}`;
+    const queryParams = {
+      start: params.start ?? 0,
+      limit: params.limit ?? ELEMENTS_PAGE_SIZE,
+      selector: params.selector ?? 'representations',
+      type: params.type ?? ALL_COLOR_ELEMENT_TYPES,
+    };
+    return this.plugin.get(path, { params: queryParams });
+  }
+}
+
+export class LibraryThemeActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [CCLibraryTopics.THEME.SAVE]: this.saveTheme.bind(this),
+      [CCLibraryTopics.THEME.SAVE_GRADIENT]: this.saveGradient.bind(this),
+      [CCLibraryTopics.THEME.DELETE]: this.deleteTheme.bind(this),
+      [CCLibraryTopics.THEME.UPDATE]: this.updateTheme.bind(this),
+      [CCLibraryTopics.THEME.UPDATE_METADATA]: this.updateElementMetadata.bind(this),
+    };
+  }
+
+  /**
+   * @param {string} libraryId - Library ID
+   * @param {Object} themeData - Theme data (name, type, client, representations per API)
+   * @returns {Promise<Object>} { elements: [{ id, name, type, ... }] }
+   * @throws {ValidationError} If libraryId or themeData is missing
+   */
+  async saveTheme(libraryId, themeData) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE,
+      });
+    }
+    if (!themeData || typeof themeData !== 'object') {
+      throw new ValidationError('Theme data is required', {
+        field: 'themeData',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}`;
+    return this.plugin.post(path, themeData);
+  }
+
+  /**
+   * @param {string} libraryId - Library ID
+   * @param {Object} gradientData - Gradient data (name, type, client, representations per API)
+   * @returns {Promise<Object>} { elements: [{ id, name, type, ... }] }
+   * @throws {ValidationError} If libraryId or gradientData is missing
+   */
+  async saveGradient(libraryId, gradientData) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE_GRADIENT,
+      });
+    }
+    if (!gradientData || typeof gradientData !== 'object') {
+      throw new ValidationError('Gradient data is required', {
+        field: 'gradientData',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.SAVE_GRADIENT,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}`;
+    return this.plugin.post(path, gradientData);
+  }
+
+  /**
+   * @param {string} libraryId - Library ID
+   * @param {string} elementId - Element ID
+   * @returns {Promise<Object>} Empty object (204 No Content)
+   * @throws {ValidationError} If libraryId or elementId is missing
+   */
+  async deleteTheme(libraryId, elementId) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.DELETE,
+      });
+    }
+    if (!elementId) {
+      throw new ValidationError('Element ID is required', {
+        field: 'elementId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.DELETE,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}/${elementId}`;
+    return this.plugin.delete(path);
+  }
+
+  /**
+   * @param {string} libraryId - Library ID
+   * @param {string} elementId - Element ID
+   * @param {Object} payload - Update payload (client, type, representations per API)
+   * @returns {Promise<Object>} { id, representations }
+   * @throws {ValidationError} If required params are missing
+   */
+  async updateTheme(libraryId, elementId, payload) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE,
+      });
+    }
+    if (!elementId) {
+      throw new ValidationError('Element ID is required', {
+        field: 'elementId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE,
+      });
+    }
+    if (!payload || typeof payload !== 'object') {
+      throw new ValidationError('Update payload is required', {
+        field: 'payload',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}/${elementId}/representations`;
+    return this.plugin.put(path, payload);
+  }
+
+  /**
+   * @param {string} libraryId - Library ID
+   * @param {Array<{id: string, name?: string}>} elements
+   *   Elements to update (id and fields to set)
+   * @returns {Promise<Object>} Empty object (204 No Content)
+   * @throws {ValidationError} If libraryId or elements is missing/invalid
+   */
+  async updateElementMetadata(libraryId, elements) {
+    if (!libraryId) {
+      throw new ValidationError('Library ID is required', {
+        field: 'libraryId',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE_METADATA,
+      });
+    }
+    if (!Array.isArray(elements) || elements.length === 0) {
+      throw new ValidationError('Elements array is required and must not be empty', {
+        field: 'elements',
+        serviceName: 'CCLibrary',
+        topic: CCLibraryTopics.THEME.UPDATE_METADATA,
+      });
+    }
+    const path = `${this.plugin.endpoints.libraries}/${libraryId}${this.plugin.endpoints.themes}${this.plugin.endpoints.metadata}`;
+    return this.plugin.put(path, { elements });
+  }
+}

--- a/express/code/libs/services/plugins/cclibrary/constants.js
+++ b/express/code/libs/services/plugins/cclibrary/constants.js
@@ -1,0 +1,88 @@
+export const THEME_ELEMENT_TYPE = 'application/vnd.adobe.element.colortheme+dcx';
+
+export const GRADIENT_ELEMENT_TYPE = 'application/vnd.adobe.element.gradient+dcx';
+
+export const THEME_REPRESENTATION_TYPE = 'application/vnd.adobe.colortheme+json';
+
+export const GRADIENT_REPRESENTATION_TYPE = 'application/vnd.adobe.gradient+json';
+
+export const ALL_COLOR_ELEMENT_TYPES = `${THEME_ELEMENT_TYPE},${GRADIENT_ELEMENT_TYPE}`;
+
+export const LIBRARIES_PAGE_SIZE = 40;
+
+export const ELEMENTS_PAGE_SIZE = 50;
+
+export const MAX_ELEMENTS_PER_LIBRARY = 1000;
+
+export const LIBRARY_OWNER_SCOPE = {
+  ALL: 'all',
+  PRIVATE: 'private',
+  INCOMING: 'incoming',
+  OUTGOING: 'outgoing',
+  TEAM: 'team',
+  DISCOVERY: 'discovery',
+  PUBLIC: 'public',
+  OTHER: 'other',
+};
+
+export const LIBRARY_OWNERSHIP = {
+  PRIVATE: 'private',
+  SHARED: 'shared',
+};
+
+export const LIBRARY_ROLE = {
+  EDITOR: 'editor',
+  VIEWER: 'viewer',
+};
+
+export const ERROR_CODE = {
+  STORAGE_FULL: 'STORAGE_FULL',
+};
+
+export const HTTP_STATUS = {
+  STORAGE_FULL: 507,
+};
+
+export const COLOR_MODE = {
+  RGB: 'RGB',
+  CMYK: 'CMYK',
+  HSB: 'HSB',
+  LAB: 'LAB',
+};
+
+/**
+ * CC Library mode strings as expected by the Melville API.
+ * Note: LAB must be 'Lab' (mixed case), not 'LAB'.
+ */
+export const CC_LIBRARY_COLOR_MODE = {
+  RGB: 'RGB',
+  CMYK: 'CMYK',
+  HSB: 'HSB',
+  LAB: 'Lab',
+};
+
+export const CLIENT_APP = 'AdobeExpress';
+
+/**
+ * Build the CC Libraries API client object at runtime.
+ * - `deviceId` is user-specific (derived from IMS userId)
+ * - `device`   describes the platform / OS
+ * - `app`      identifies the calling application
+ *
+ * @returns {{ deviceId: string, device: string, app: string }}
+ */
+export function getClientInfo() {
+  const userId = window.adobeUserProfile?.userId?.split('@')[0] || 'unknown';
+  const platform = window.navigator?.userAgentData?.platform
+    || window.navigator?.platform
+    || 'unknown';
+  const osVersion = window.navigator?.userAgent?.match(/OS (\d+[._]\d+)/)?.[1]?.replace('_', '.') || 'unknown';
+
+  return {
+    deviceId: userId,
+    device: `${platform}_${osVersion}`,
+    app: CLIENT_APP,
+  };
+}
+
+export const COLOR_PROFILE = 'sRGB IEC61966-2.1';

--- a/express/code/libs/services/plugins/cclibrary/index.js
+++ b/express/code/libs/services/plugins/cclibrary/index.js
@@ -2,4 +2,5 @@ export default {
   name: 'cclibrary',
   featureFlag: 'ENABLE_CCLIBRARY',
   loader: () => import('./CCLibraryPlugin.js'),
+  providerLoader: () => import('../../providers/CCLibraryProvider.js'),
 };

--- a/express/code/libs/services/plugins/cclibrary/topics.js
+++ b/express/code/libs/services/plugins/cclibrary/topics.js
@@ -1,3 +1,19 @@
-export const CCLibraryTopics = {};
+export const CCLibraryTopics = {
+  LIBRARY: {
+    CREATE: 'cclibrary.library.create',
+    FETCH: 'cclibrary.library.fetch',
+    ELEMENTS: 'cclibrary.library.elements',
+  },
+  THEME: {
+    SAVE: 'cclibrary.theme.save',
+    SAVE_GRADIENT: 'cclibrary.theme.saveGradient',
+    DELETE: 'cclibrary.theme.delete',
+    UPDATE: 'cclibrary.theme.update',
+    UPDATE_METADATA: 'cclibrary.theme.updateMetadata',
+  },
+};
 
-export const CCLibraryActionGroups = {};
+export const CCLibraryActionGroups = {
+  LIBRARY: 'library',
+  THEME: 'theme',
+};

--- a/express/code/libs/services/providers/CCLibraryProvider.js
+++ b/express/code/libs/services/providers/CCLibraryProvider.js
@@ -1,0 +1,309 @@
+import BaseProvider from './BaseProvider.js';
+import { CCLibraryTopics, CCLibraryActionGroups } from '../plugins/cclibrary/topics.js';
+import {
+  LIBRARY_OWNERSHIP,
+  LIBRARY_OWNER_SCOPE,
+  LIBRARY_ROLE,
+  COLOR_MODE,
+  GRADIENT_ELEMENT_TYPE,
+  GRADIENT_REPRESENTATION_TYPE,
+  getClientInfo,
+  COLOR_PROFILE,
+  CC_LIBRARY_COLOR_MODE,
+} from '../plugins/cclibrary/constants.js';
+
+export default class CCLibraryProvider extends BaseProvider {
+  #actions = {};
+
+  constructor(plugin) {
+    super(plugin);
+    this.#initActions();
+  }
+
+  #initActions() {
+    const { LIBRARY, THEME } = CCLibraryActionGroups;
+
+    this.#actions = {
+      createLibrary: this.plugin.useAction(LIBRARY, CCLibraryTopics.LIBRARY.CREATE),
+      fetchLibraries: this.plugin.useAction(LIBRARY, CCLibraryTopics.LIBRARY.FETCH),
+      fetchLibraryElements: this.plugin.useAction(LIBRARY, CCLibraryTopics.LIBRARY.ELEMENTS),
+      saveTheme: this.plugin.useAction(THEME, CCLibraryTopics.THEME.SAVE),
+      saveGradient: this.plugin.useAction(THEME, CCLibraryTopics.THEME.SAVE_GRADIENT),
+      deleteTheme: this.plugin.useAction(THEME, CCLibraryTopics.THEME.DELETE),
+      updateTheme: this.plugin.useAction(THEME, CCLibraryTopics.THEME.UPDATE),
+      updateElementMetadata: this.plugin.useAction(THEME, CCLibraryTopics.THEME.UPDATE_METADATA),
+    };
+  }
+
+  async createLibrary(name) {
+    return this.safeExecute(() => this.#actions.createLibrary(name));
+  }
+
+  async fetchLibraries(params) {
+    return this.safeExecute(() => this.#actions.fetchLibraries(params));
+  }
+
+  async fetchUserLibraries(params = {}) {
+    return this.fetchLibraries({ ...params, owner: LIBRARY_OWNER_SCOPE.PRIVATE });
+  }
+
+  async fetchLibraryElements(libraryId, params) {
+    return this.safeExecute(() => this.#actions.fetchLibraryElements(libraryId, params));
+  }
+
+  async saveTheme(libraryId, themeData) {
+    return this.safeExecute(() => this.#actions.saveTheme(libraryId, themeData));
+  }
+
+  async saveGradient(libraryId, gradientData) {
+    return this.safeExecute(() => this.#actions.saveGradient(libraryId, gradientData));
+  }
+
+  async deleteTheme(libraryId, themeId) {
+    return this.safeExecute(() => this.#actions.deleteTheme(libraryId, themeId));
+  }
+
+  async updateTheme(libraryId, elementId, payload) {
+    return this.safeExecute(() => this.#actions.updateTheme(libraryId, elementId, payload));
+  }
+
+  async updateElementMetadata(libraryId, elements) {
+    return this.safeExecute(() => this.#actions.updateElementMetadata(libraryId, elements));
+  }
+
+  /**
+   * @param {Object} library - Library object from the API
+   * @returns {boolean}
+   */
+  isLibraryWritable(library) {
+    if (!library) return false;
+    if (library.ownership === LIBRARY_OWNERSHIP.PRIVATE) return true;
+    if (library.bookmark?.role === LIBRARY_ROLE.EDITOR) return true;
+    const aclKey = this.plugin.serviceConfig.assetAclDirectoryKey;
+    const directoryAccess = library.asset_acl?.[aclKey];
+    if (directoryAccess?.includes('write')) return true;
+    return false;
+  }
+
+  /**
+   * @param {Array<Object>} libraries - Array of library objects from the API
+   * @returns {Array<Object>} Writable libraries only
+   */
+  filterWritableLibraries(libraries) {
+    if (!Array.isArray(libraries)) return [];
+    return libraries.filter((lib) => this.isLibraryWritable(lib));
+  }
+
+  /**
+   * Build a Melville-compliant gradient payload for POST /libraries/{id}/elements.
+   *
+   * @param {Object} options
+   * @param {string}  options.name  - Gradient display name
+   * @param {number}  [options.angle=90] - Gradient angle in degrees
+   * @param {number}  [options.aspectRatio=1] - Gradient aspect ratio
+   * @param {string}  [options.interpolation='linear'] - Color interpolation
+   * @param {string}  [options.type='linear'] - Gradient type
+   * @param {Array<{color: string, position: number}>} options.stops
+   *   Each stop has a CSS color string (hex or rgb/rgba) and a position (0-1 float).
+   * @returns {Object} Melville-ready element payload
+   */
+  // eslint-disable-next-line class-methods-use-this
+  buildGradientPayload({
+    name,
+    angle = 90,
+    aspectRatio = 1,
+    interpolation = 'linear',
+    type = 'linear',
+    stops = [],
+  }) {
+    return {
+      name: name || 'Untitled gradient',
+      type: GRADIENT_ELEMENT_TYPE,
+      client: getClientInfo(),
+      representations: [
+        {
+          rel: 'primary',
+          type: GRADIENT_REPRESENTATION_TYPE,
+          'gradient#data': {
+            interpolation,
+            angle,
+            aspectRatio,
+            type,
+            stops: stops.map((stop) => ({
+              color: [
+                {
+                  mode: CC_LIBRARY_COLOR_MODE.RGB,
+                  value: CCLibraryProvider.#parseColorToRgb(stop.color),
+                  profileName: COLOR_PROFILE,
+                },
+              ],
+              offset: stop.position,
+              opacity: 1,
+            })),
+            opacityStops: [],
+          },
+        },
+      ],
+    };
+  }
+
+  /**
+   * Parse a CSS color string (hex or rgb/rgba) into an { r, g, b } object (0-255 integers).
+   *
+   * @param {string} color - CSS color string, e.g. "#FF5733" or "rgb(255, 87, 51)"
+   * @returns {{ r: number, g: number, b: number }}
+   */
+  static #parseColorToRgb(color) {
+    if (!color || typeof color !== 'string') return { r: 0, g: 0, b: 0 };
+
+    if (color.startsWith('#')) {
+      let hex = color.slice(1);
+      if (hex.length === 3) {
+        hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+      }
+      return {
+        r: Number.parseInt(hex.substring(0, 2), 16),
+        g: Number.parseInt(hex.substring(2, 4), 16),
+        b: Number.parseInt(hex.substring(4, 6), 16),
+      };
+    }
+
+    const match = color.match(/rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)/);
+    if (match) {
+      return {
+        r: Number.parseInt(match[1], 10),
+        g: Number.parseInt(match[2], 10),
+        b: Number.parseInt(match[3], 10),
+      };
+    }
+
+    return { r: 0, g: 0, b: 0 };
+  }
+
+  /**
+   * Extract Pantone metadata from a swatch if present.
+   *
+   * @param {Object} swatch
+   * @returns {Object} Pantone fields to merge, or empty object
+   */
+  static #getPantoneData(swatch) {
+    if (!swatch.pantone) return {};
+    return {
+      type: swatch.isSpotColor ? 'spot' : 'process',
+      spotColorName: `PANTONE ${swatch.pantone}`,
+    };
+  }
+
+  /**
+   * @param {Object} swatch - Internal swatch object
+   * @param {Object} swatch.rgb - RGB values (each 0-1 float)
+   * @param {number} swatch.rgb.r - Red channel 0-1
+   * @param {number} swatch.rgb.g - Green channel 0-1
+   * @param {number} swatch.rgb.b - Blue channel 0-1
+   * @param {Object} [swatch.cmyk] - CMYK values (each 0-100)
+   * @param {Object} [swatch.hsb] - HSB values (h 0-360, s/b 0-100)
+   * @param {Object} [swatch.lab] - LAB values (l 0-100, a/b -128..127)
+   * @param {string} [swatch.pantone] - Pantone identifier (e.g. "185 C")
+   * @param {boolean} [swatch.isSpotColor] - Whether the swatch is a spot color
+   * @param {string} colorMode - Primary color mode ('RGB', 'CMYK', 'HSB', 'LAB')
+   * @returns {Array<Object>} CC Library swatch array
+   */
+  // eslint-disable-next-line class-methods-use-this
+  convertSwatchToCCFormat(swatch, colorMode) {
+    const result = [];
+
+    if (colorMode.toUpperCase() !== COLOR_MODE.RGB) {
+      const modeEntry = CCLibraryProvider.#buildModeEntry(swatch, colorMode);
+      if (modeEntry) result.push(modeEntry);
+    }
+
+    const rgbEntry = {
+      mode: CC_LIBRARY_COLOR_MODE.RGB,
+      value: {
+        r: Math.round(swatch.rgb.r * 255),
+        g: Math.round(swatch.rgb.g * 255),
+        b: Math.round(swatch.rgb.b * 255),
+      },
+    };
+
+    Object.assign(rgbEntry, CCLibraryProvider.#getPantoneData(swatch));
+
+    result.push(rgbEntry);
+    return result;
+  }
+
+  /**
+   * @param {Array<Object>} swatches - Array of internal swatch objects
+   * @param {string} colorMode - Primary color mode
+   * @returns {Array<Array<Object>>} Array of CC Library swatch arrays
+   */
+  convertSwatchesToCCFormat(swatches, colorMode) {
+    if (!Array.isArray(swatches)) return [];
+    return swatches.map((swatch) => this.convertSwatchToCCFormat(swatch, colorMode));
+  }
+
+  /**
+   * @param {Object} swatch - Internal swatch object
+   * @param {string} mode - Color mode key
+   * @returns {Object|null} Mode entry or null if data is missing
+   */
+  static #buildModeEntry(swatch, mode) {
+    let entry = null;
+
+    switch (mode) {
+      case COLOR_MODE.CMYK: {
+        if (!swatch.cmyk) return null;
+        entry = {
+          mode: CC_LIBRARY_COLOR_MODE.CMYK,
+          value: {
+            c: Math.round(swatch.cmyk.c),
+            m: Math.round(swatch.cmyk.m),
+            y: Math.round(swatch.cmyk.y),
+            k: Math.round(swatch.cmyk.k),
+          },
+        };
+        break;
+      }
+      case 'HSV':
+      case COLOR_MODE.HSB: {
+        const hsData = swatch.hsv || swatch.hsb;
+        if (!hsData) return null;
+        entry = {
+          mode: CC_LIBRARY_COLOR_MODE.HSB,
+          value: {
+            h: Math.round(hsData.h),
+            s: Math.round(hsData.s),
+            b: Math.round((hsData.v ?? hsData.b)),
+          },
+        };
+        break;
+      }
+      case COLOR_MODE.LAB: {
+        if (!swatch.lab) return null;
+        entry = {
+          mode: CC_LIBRARY_COLOR_MODE.LAB,
+          value: {
+            l: Math.round(swatch.lab.l),
+            a: Math.round(swatch.lab.a),
+            b: Math.round(swatch.lab.b),
+          },
+        };
+        break;
+      }
+      default:
+        return null;
+    }
+
+    Object.assign(entry, CCLibraryProvider.#getPantoneData(swatch));
+
+    return entry;
+  }
+}
+
+/**
+ * @param {Object} plugin - Plugin instance
+ * @returns {CCLibraryProvider} New provider instance
+ */
+export function createCCLibraryProvider(plugin) {
+  return new CCLibraryProvider(plugin);
+}

--- a/express/code/libs/services/providers/index.js
+++ b/express/code/libs/services/providers/index.js
@@ -1,1 +1,2 @@
 export { default as BaseProvider } from './BaseProvider.js';
+export { default as CCLibraryProvider, createCCLibraryProvider } from './CCLibraryProvider.js';

--- a/test/services/plugins/cclibrary/CCLibraryPlugin.test.js
+++ b/test/services/plugins/cclibrary/CCLibraryPlugin.test.js
@@ -1,0 +1,180 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import CCLibraryPlugin from '../../../../express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js';
+import { CCLibraryActionGroups } from '../../../../express/code/libs/services/plugins/cclibrary/topics.js';
+import { StorageFullError, ApiError } from '../../../../express/code/libs/services/core/Errors.js';
+import { HTTP_STATUS } from '../../../../express/code/libs/services/plugins/cclibrary/constants.js';
+
+function createTestPlugin(PluginClass, overrides = {}) {
+  return new PluginClass({
+    serviceConfig: {
+      baseUrl: 'https://test.com',
+      melvilleBasePath: 'https://libraries.test.io/api/v1',
+      apiKey: 'test-key',
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('CCLibraryPlugin', () => {
+  let plugin;
+
+  beforeEach(() => {
+    plugin = createTestPlugin(CCLibraryPlugin);
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('serviceName', () => {
+    it('should return "CCLibrary"', () => {
+      expect(CCLibraryPlugin.serviceName).to.equal('CCLibrary');
+    });
+  });
+
+  describe('isActivated (feature flag)', () => {
+    [
+      { label: 'ENABLE_CCLIBRARY not set', config: { features: {} }, expected: true },
+      { label: 'ENABLE_CCLIBRARY is true', config: { features: { ENABLE_CCLIBRARY: true } }, expected: true },
+      { label: 'ENABLE_CCLIBRARY is explicitly false', config: { features: { ENABLE_CCLIBRARY: false } }, expected: false },
+      { label: 'no features key', config: {}, expected: true },
+      { label: 'null config', config: null, expected: true },
+      { label: 'undefined config', config: undefined, expected: true },
+    ].forEach(({ label, config, expected }) => {
+      it(`should return ${expected} when ${label}`, () => {
+        expect(plugin.isActivated(config)).to.equal(expected);
+      });
+    });
+  });
+
+  describe('baseUrl resolution', () => {
+    it('should resolve baseUrl from melvilleBasePath', () => {
+      expect(plugin.baseUrl).to.equal('https://libraries.test.io/api/v1');
+    });
+
+    it('should fall back to serviceConfig.baseUrl when melvilleBasePath is missing', () => {
+      const fallbackPlugin = createTestPlugin(CCLibraryPlugin, {
+        serviceConfig: {
+          baseUrl: 'https://fallback.com',
+          melvilleBasePath: undefined,
+          endpoints: { libraries: '/libraries', themes: '/elements', metadata: '/metadata' },
+        },
+      });
+      expect(fallbackPlugin.baseUrl).to.equal('https://fallback.com');
+    });
+  });
+
+  describe('handler registration', () => {
+    it('should register handlers on construction', () => {
+      expect(plugin.topicRegistry.size).to.be.greaterThan(0);
+    });
+
+    it('should register action groups on construction', () => {
+      expect(plugin.getActionGroupNames()).to.have.length.greaterThan(0);
+    });
+
+    it('should register the "library" action group', () => {
+      expect(plugin.getActionGroupNames()).to.include(CCLibraryActionGroups.LIBRARY);
+    });
+
+    it('should register the "theme" action group', () => {
+      expect(plugin.getActionGroupNames()).to.include(CCLibraryActionGroups.THEME);
+    });
+
+    it('should register exactly 2 action groups', () => {
+      expect(plugin.getActionGroupNames()).to.have.lengthOf(2);
+    });
+
+    it('should register 8 topic handlers total (3 library + 5 theme)', () => {
+      expect(plugin.topicRegistry.size).to.equal(8);
+    });
+  });
+
+  describe('handleResponse', () => {
+    it('should throw StorageFullError when status is 507', async () => {
+      const response = {
+        ok: false,
+        status: HTTP_STATUS.STORAGE_FULL,
+        statusText: 'Insufficient Storage',
+        text: () => Promise.resolve('Storage quota exceeded'),
+      };
+
+      try {
+        await plugin.handleResponse(response);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(StorageFullError);
+        expect(err.message).to.equal('CC Libraries storage is full');
+        expect(err.statusCode).to.equal(507);
+        expect(err.name).to.equal('StorageFullError');
+        expect(err.serviceName).to.equal('CCLibrary');
+      }
+    });
+
+    it('should include the response body in StorageFullError', async () => {
+      const errorBody = '{"error":"quota_exceeded","message":"Storage limit reached"}';
+      const response = {
+        ok: false,
+        status: 507,
+        statusText: 'Insufficient Storage',
+        text: () => Promise.resolve(errorBody),
+      };
+
+      try {
+        await plugin.handleResponse(response);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(StorageFullError);
+        expect(err.responseBody).to.equal(errorBody);
+      }
+    });
+
+    it('should throw ApiError for non-507 error responses (delegates to super)', async () => {
+      const response = {
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('Server error'),
+      };
+
+      try {
+        await plugin.handleResponse(response);
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(ApiError);
+        expect(err).to.not.be.instanceOf(StorageFullError);
+        expect(err.statusCode).to.equal(500);
+      }
+    });
+
+    it('should return parsed JSON for 200 OK responses (delegates to super)', async () => {
+      const responseData = { total_count: 1, libraries: [{ id: 'lib-1' }] };
+      const response = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(responseData),
+      };
+
+      const result = await plugin.handleResponse(response);
+      expect(result).to.deep.equal(responseData);
+    });
+
+    it('should return empty object for 204 No Content (delegates to super)', async () => {
+      const response = {
+        ok: true,
+        status: 204,
+      };
+
+      const result = await plugin.handleResponse(response);
+      expect(result).to.deep.equal({});
+    });
+  });
+});

--- a/test/services/plugins/cclibrary/CHECKLIST.md
+++ b/test/services/plugins/cclibrary/CHECKLIST.md
@@ -1,0 +1,263 @@
+# CCLibrary — Test Coverage Checklist
+
+> Comprehensive list of all test cases covered for the `CCLibrary` plugin
+> and its children (action groups, provider). Update this file whenever tests
+> are added, modified, or removed.
+
+---
+
+## Plugin: `CCLibraryPlugin`
+
+**Test file:** `CCLibraryPlugin.test.js`
+
+### Service Name
+
+- [x] Returns `"CCLibrary"`
+
+### Feature Flag Gating (`isActivated`)
+
+- [x] Returns `true` when feature flag is not set
+- [x] Returns `true` when feature flag is explicitly `true`
+- [x] Returns `false` when feature flag is explicitly `false`
+- [x] Returns `true` when `features` key is missing entirely
+- [x] Returns `true` for `null` and `undefined` config inputs
+
+### Handler Registration
+
+- [x] Registers handlers on construction (`topicRegistry.size > 0`)
+- [x] Registers action groups on construction
+- [x] Registers `library` action group
+- [x] Registers `theme` action group
+- [x] Registers exactly 2 action groups
+- [x] Registers expected handler count (`8` topics total)
+
+### Config Resolution
+
+- [x] Resolves `baseUrl` from `melvilleBasePath`
+- [x] Falls back to `serviceConfig.baseUrl` when `melvilleBasePath` is missing
+
+### Response Handling (`handleResponse`)
+
+- [x] Throws `StorageFullError` when status is `507`
+- [x] Includes response body in `StorageFullError`
+- [x] Throws `ApiError` for non-507 error responses (delegates to super)
+- [x] Returns parsed JSON for `200 OK` responses (delegates to super)
+- [x] Returns empty object for `204 No Content` (delegates to super)
+
+---
+
+## Action Group: `LibraryActions`
+
+**Test file:** `actions/LibraryActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Returns a handler for every expected `CCLibraryTopics.LIBRARY` topic
+- [x] Contains no unexpected topic keys
+
+### Delegation Wiring
+
+| Action Method | Delegates to Plugin | Passes Args Correctly | Returns Result |
+|---------------|:---:|:---:|:---:|
+| `createLibrary(name)` | [x] | [x] | [x] |
+| `fetchLibraries(params)` | [x] | [x] | [x] |
+| `fetchLibraryElements(libraryId, params)` | [x] | [x] | [x] |
+
+### Validation
+
+| Action Method | Invalid Inputs | Error Metadata | Valid Inputs |
+|---------------|:---:|:---:|:---:|
+| `createLibrary(name)` | [x] | [x] | [x] |
+| `fetchLibraryElements(libraryId, params)` | [x] | [x] | [x] |
+
+### Default Parameter Behavior
+
+- [x] `fetchLibraries()` uses documented defaults (including `LIBRARY_OWNER_SCOPE.ALL`)
+- [x] `fetchLibraries(params)` preserves non-overridden defaults
+- [x] `fetchLibraries(params)` accepts comma-separated owner scopes (e.g. `'private,incoming'`)
+- [x] `fetchLibraryElements()` uses documented defaults (including `ALL_COLOR_ELEMENT_TYPES`)
+- [x] `fetchLibraryElements(params)` allows overriding `type` param
+- [x] `fetchLibraryElements(params)` allows overriding `start`, `limit`, `selector`
+
+---
+
+## Action Group: `LibraryThemeActions`
+
+**Test file:** `actions/LibraryThemeActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Returns a handler for every expected `CCLibraryTopics.THEME` topic
+- [x] Contains no unexpected topic keys
+
+### Delegation Wiring
+
+| Action Method | Delegates to Plugin | Passes Args Correctly | Returns Result |
+|---------------|:---:|:---:|:---:|
+| `saveTheme(libraryId, themeData)` | [x] | [x] | [x] |
+| `saveGradient(libraryId, gradientData)` | [x] | [x] | [x] |
+| `deleteTheme(libraryId, elementId)` | [x] | [x] | [x] |
+| `updateTheme(libraryId, elementId, payload)` | [x] | [x] | [x] |
+| `updateElementMetadata(libraryId, elements)` | [x] | [x] | [x] |
+
+### Validation
+
+| Action Method | Invalid Inputs | Error Metadata | Valid Inputs |
+|---------------|:---:|:---:|:---:|
+| `saveTheme(...)` | [x] | [x] | [x] |
+| `saveGradient(...)` | [x] | [x] | [x] |
+| `deleteTheme(...)` | [x] | [x] | [x] |
+| `updateTheme(...)` | [x] | [x] | [x] |
+| `updateElementMetadata(...)` | [x] | [x] | [x] |
+
+---
+
+## Provider: `CCLibraryProvider`
+
+### Delegation & Errors
+
+**Test file:** `providers/CCLibraryProvider.delegation.test.js`
+
+#### Delegation Wiring
+
+| Provider Method | Returns Data | Passes Args Correctly |
+|-----------------|:---:|:---:|
+| `createLibrary(name)` | [x] | [x] |
+| `fetchLibraries(params)` | [x] | [x] |
+| `fetchUserLibraries(params)` | [x] | [x] |
+| `fetchLibraryElements(libraryId, params)` | [x] | [x] |
+| `saveTheme(libraryId, themeData)` | [x] | [x] |
+| `saveGradient(libraryId, gradientData)` | [x] | [x] |
+| `deleteTheme(libraryId, themeId)` | [x] | [x] |
+| `updateTheme(libraryId, elementId, payload)` | [x] | [x] |
+| `updateElementMetadata(libraryId, elements)` | [x] | [x] |
+
+#### `fetchUserLibraries` Specifics
+
+- [x] Delegates with `owner=private` to Melville API
+- [x] Overrides `owner` even if caller passes a different value
+
+#### Error Boundary (`safeExecute`)
+
+| Provider Method | Returns `null` on Fetch Error | Returns `null` on API Error |
+|-----------------|:---:|:---:|
+| `createLibrary(...)` | [x] | [x] |
+| `fetchLibraries(...)` | [x] | [x] |
+| `fetchUserLibraries(...)` | [x] | [x] |
+| `fetchLibraryElements(...)` | [x] | [x] |
+| `saveTheme(...)` | [x] | [x] |
+| `saveGradient(...)` | [x] | [x] |
+| `deleteTheme(...)` | [x] | [x] |
+| `updateTheme(...)` | [x] | [x] |
+| `updateElementMetadata(...)` | [x] | [x] |
+
+- [x] Returns `null` for validation errors (e.g. missing `libraryId`)
+- [x] Returns `null` when API returns non-OK response (e.g. `500`)
+
+#### StorageFullError through `safeExecute`
+
+- [x] Returns `null` when API returns `507` (storage full)
+- [x] Logs `StorageFullError` with correct `errorType`
+
+#### Factory Functions
+
+- [x] `createCCLibraryProvider()` returns correct instance
+
+#### Availability
+
+- [x] `isAvailable` is `true` when plugin instance exists
+
+---
+
+### Color Conversion
+
+**Test file:** `providers/CCLibraryProvider.colorConversion.test.js`
+
+#### `convertSwatchToCCFormat`
+
+- [x] Returns a single RGB entry for RGB color mode
+- [x] Scales RGB 0–1 floats to 0–255 integers
+- [x] Returns CMYK entry + RGB entry for CMYK color mode
+- [x] Returns HSB entry + RGB entry for HSB color mode
+- [x] Returns LAB entry + RGB entry for LAB color mode
+- [x] Rounds CMYK values to integers
+- [x] Falls back to only RGB entry when CMYK mode but `cmyk` data is missing
+- [x] Falls back to only RGB entry when HSB mode but `hsb` data is missing
+- [x] Falls back to only RGB entry when LAB mode but `lab` data is missing
+- [x] Adds Pantone spot color info to RGB entry
+- [x] Adds Pantone process color info to RGB entry
+- [x] Does not add Pantone info when pantone is absent
+- [x] Includes Pantone info on both entries in non-RGB color modes
+- [x] Handles HSV swatch data for backward compatibility
+- [x] Handles case-insensitive color mode comparison
+- [x] Outputs `Lab` (mixed case) for LAB mode in API payloads
+
+#### `convertSwatchesToCCFormat`
+
+- [x] Returns empty array for `null` input
+- [x] Returns empty array for `undefined` input
+- [x] Returns empty array for non-array input
+- [x] Handles empty array
+- [x] Converts an array of swatches
+- [x] Produces multi-entry arrays for non-RGB color mode
+
+---
+
+### Permissions
+
+**Test file:** `providers/CCLibraryProvider.permissions.test.js`
+
+#### `isLibraryWritable`
+
+- [x] Returns `false` for `null`
+- [x] Returns `false` for `undefined`
+- [x] Returns `true` for private ownership
+- [x] Returns `true` when bookmark role is editor
+- [x] Returns `true` when `asset_acl` directory access (via `ASSET_ACL_DIRECTORY_KEY`) includes `write`
+- [x] Returns `false` for shared ownership with viewer role
+- [x] Returns `false` for shared ownership with no bookmark or ACL
+- [x] Returns `false` when `asset_acl` directory access (via `ASSET_ACL_DIRECTORY_KEY`) has only `read`
+- [x] Returns `false` for an empty object
+
+#### `filterWritableLibraries`
+
+- [x] Returns empty array for `null` input
+- [x] Returns empty array for `undefined` input
+- [x] Returns empty array for non-array input
+- [x] Returns empty array when no libraries are writable
+- [x] Returns only writable libraries
+- [x] Returns all libraries when all are writable
+- [x] Handles empty array
+
+---
+
+### Gradient Payload Builder
+
+**Test file:** `providers/CCLibraryProvider.gradient.test.js`
+
+#### `buildGradientPayload`
+
+- [x] Builds a basic gradient payload with defaults
+- [x] Uses `rel` field (not `relationship`) on representations
+- [x] Sets correct representation type
+- [x] Applies default gradient data values (angle, aspectRatio, interpolation, type, opacityStops)
+- [x] Accepts custom angle, aspectRatio, interpolation, and type
+- [x] Defaults name to `"Untitled gradient"` when empty
+- [x] Parses hex color stops correctly
+- [x] Parses 3-digit hex color stops
+- [x] Parses `rgb()` color stops
+- [x] Parses `rgba()` color stops
+- [x] Falls back to black for invalid color strings
+- [x] Falls back to black for null color
+- [x] Handles multiple stops
+- [x] Handles empty stops array
+
+---
+
+## Coverage Gaps
+
+- [ ] Add middleware coverage if plugin-specific middleware is introduced later
+
+---
+
+**Last Updated:** February 2026

--- a/test/services/plugins/cclibrary/actions/LibraryActions.test.js
+++ b/test/services/plugins/cclibrary/actions/LibraryActions.test.js
@@ -1,0 +1,259 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import {
+  LibraryActions,
+} from '../../../../../express/code/libs/services/plugins/cclibrary/actions/CCLibraryActions.js';
+import { CCLibraryTopics } from '../../../../../express/code/libs/services/plugins/cclibrary/topics.js';
+import { ValidationError } from '../../../../../express/code/libs/services/core/Errors.js';
+import {
+  ALL_COLOR_ELEMENT_TYPES,
+  LIBRARIES_PAGE_SIZE,
+  ELEMENTS_PAGE_SIZE,
+  LIBRARY_OWNER_SCOPE,
+} from '../../../../../express/code/libs/services/plugins/cclibrary/constants.js';
+
+async function expectValidationError(fn, extraAssertions = () => {}) {
+  try {
+    await fn();
+    expect.fail('Should have thrown');
+  } catch (err) {
+    expect(err).to.be.instanceOf(ValidationError);
+    extraAssertions(err);
+  }
+}
+
+describe('LibraryActions', () => {
+  let actions;
+  let mockPlugin;
+
+  const mockLibrariesResponse = {
+    total_count: 2,
+    libraries: [
+      { id: 'lib-1', name: 'My Library' },
+      { id: 'lib-2', name: 'Another Library' },
+    ],
+    _links: {},
+  };
+
+  const mockElementsResponse = {
+    total_count: 2,
+    elements: [
+      { id: 'elem-1', name: 'Theme A', type: 'colortheme' },
+      { id: 'elem-2', name: 'Gradient B', type: 'gradient' },
+    ],
+  };
+
+  const mockCreatedLibrary = { id: 'lib-new', name: 'New Library' };
+
+  beforeEach(() => {
+    mockPlugin = {
+      get: sinon.stub().resolves(mockLibrariesResponse),
+      post: sinon.stub().resolves(mockCreatedLibrary),
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+    };
+    actions = new LibraryActions(mockPlugin);
+  });
+
+  afterEach(() => sinon.restore());
+
+  // 1. Structural Correctness
+  describe('getHandlers - action routing', () => {
+    it('should return a handler for every CCLibraryTopics.LIBRARY topic', () => {
+      const handlers = actions.getHandlers();
+      const expectedTopics = Object.values(CCLibraryTopics.LIBRARY);
+
+      expectedTopics.forEach((topic) => {
+        expect(handlers).to.have.property(topic).that.is.a('function');
+      });
+    });
+
+    it('should not contain any unexpected topic keys', () => {
+      const handlers = actions.getHandlers();
+      const handlerKeys = Object.keys(handlers);
+      const expectedTopics = Object.values(CCLibraryTopics.LIBRARY);
+
+      expect(handlerKeys).to.have.lengthOf(expectedTopics.length);
+      handlerKeys.forEach((key) => {
+        expect(expectedTopics).to.include(key);
+      });
+    });
+  });
+
+  // 2. Delegation Wiring — createLibrary
+  describe('createLibrary', () => {
+    it('should call plugin.post with the correct path and body', async () => {
+      await actions.createLibrary('My Library');
+
+      expect(mockPlugin.post.calledOnce).to.be.true;
+      const [path, body] = mockPlugin.post.firstCall.args;
+      expect(path).to.equal('/libraries');
+      expect(body).to.deep.equal({ name: 'My Library' });
+    });
+
+    it('should return the created library data', async () => {
+      const result = await actions.createLibrary('New Library');
+      expect(result).to.deep.equal(mockCreatedLibrary);
+    });
+  });
+
+  // 3. Validation — createLibrary
+  describe('createLibrary - validation', () => {
+    [
+      { label: 'null', input: null },
+      { label: 'undefined', input: undefined },
+      { label: 'empty string', input: '' },
+      { label: 'whitespace only', input: '   ' },
+      { label: 'number', input: 123 },
+      { label: 'boolean', input: true },
+    ].forEach(({ label, input }) => {
+      it(`should throw ValidationError for ${label}`, async () => {
+        await expectValidationError(() => actions.createLibrary(input));
+      });
+    });
+
+    it('should set correct error metadata on ValidationError', async () => {
+      await expectValidationError(
+        () => actions.createLibrary(''),
+        (err) => {
+          expect(err.field).to.equal('name');
+          expect(err.serviceName).to.equal('CCLibrary');
+          expect(err.topic).to.equal(CCLibraryTopics.LIBRARY.CREATE);
+        },
+      );
+    });
+
+    it('should NOT throw for a valid name', async () => {
+      const result = await actions.createLibrary('Valid Name');
+      expect(result).to.deep.equal(mockCreatedLibrary);
+    });
+  });
+
+  // 2. Delegation Wiring — fetchLibraries
+  describe('fetchLibraries', () => {
+    it('should call plugin.get with default query params', async () => {
+      await actions.fetchLibraries();
+
+      expect(mockPlugin.get.calledOnce).to.be.true;
+      const [path, options] = mockPlugin.get.firstCall.args;
+      expect(path).to.equal('/libraries');
+      expect(options.params).to.deep.equal({
+        owner: LIBRARY_OWNER_SCOPE.ALL,
+        start: 0,
+        limit: LIBRARIES_PAGE_SIZE,
+        selector: 'details',
+        orderBy: '-modified_date',
+        toolkit: 'none',
+      });
+    });
+
+    it('should allow overriding default query params', async () => {
+      await actions.fetchLibraries({ owner: 'private', limit: 10, start: 20 });
+
+      const [, options] = mockPlugin.get.firstCall.args;
+      expect(options.params.owner).to.equal('private');
+      expect(options.params.limit).to.equal(10);
+      expect(options.params.start).to.equal(20);
+    });
+
+    it('should accept comma-separated owner scopes', async () => {
+      await actions.fetchLibraries({ owner: 'private,incoming' });
+
+      const [, options] = mockPlugin.get.firstCall.args;
+      expect(options.params.owner).to.equal('private,incoming');
+    });
+
+    it('should preserve non-overridden defaults when some params are provided', async () => {
+      await actions.fetchLibraries({ owner: 'incoming' });
+
+      const [, options] = mockPlugin.get.firstCall.args;
+      expect(options.params.owner).to.equal('incoming');
+      expect(options.params.start).to.equal(0);
+      expect(options.params.limit).to.equal(40);
+      expect(options.params.selector).to.equal('details');
+      expect(options.params.orderBy).to.equal('-modified_date');
+      expect(options.params.toolkit).to.equal('none');
+    });
+
+    it('should return libraries data from plugin', async () => {
+      const result = await actions.fetchLibraries();
+      expect(result).to.deep.equal(mockLibrariesResponse);
+    });
+  });
+
+  // 2. Delegation Wiring — fetchLibraryElements
+  describe('fetchLibraryElements', () => {
+    beforeEach(() => {
+      mockPlugin.get.resolves(mockElementsResponse);
+    });
+
+    it('should call plugin.get with the correct path and default params', async () => {
+      await actions.fetchLibraryElements('lib-123');
+
+      expect(mockPlugin.get.calledOnce).to.be.true;
+      const [path, options] = mockPlugin.get.firstCall.args;
+      expect(path).to.equal('/libraries/lib-123/elements');
+      expect(options.params).to.deep.equal({
+        start: 0,
+        limit: ELEMENTS_PAGE_SIZE,
+        selector: 'representations',
+        type: ALL_COLOR_ELEMENT_TYPES,
+      });
+    });
+
+    it('should default type to ALL_COLOR_ELEMENT_TYPES when not provided', async () => {
+      await actions.fetchLibraryElements('lib-123');
+
+      const [, options] = mockPlugin.get.firstCall.args;
+      expect(options.params.type).to.equal(ALL_COLOR_ELEMENT_TYPES);
+    });
+
+    it('should allow overriding type param', async () => {
+      await actions.fetchLibraryElements('lib-123', { type: 'application/vnd.adobe.element.colortheme+dcx' });
+
+      const [, options] = mockPlugin.get.firstCall.args;
+      expect(options.params.type).to.equal('application/vnd.adobe.element.colortheme+dcx');
+    });
+
+    it('should allow overriding default params', async () => {
+      await actions.fetchLibraryElements('lib-123', { start: 10, limit: 25, selector: 'full' });
+
+      const [, options] = mockPlugin.get.firstCall.args;
+      expect(options.params.start).to.equal(10);
+      expect(options.params.limit).to.equal(25);
+      expect(options.params.selector).to.equal('full');
+    });
+
+    it('should return elements data from plugin', async () => {
+      const result = await actions.fetchLibraryElements('lib-123');
+      expect(result).to.deep.equal(mockElementsResponse);
+    });
+  });
+
+  // 3. Validation — fetchLibraryElements
+  describe('fetchLibraryElements - validation', () => {
+    [
+      { label: 'null', input: null },
+      { label: 'undefined', input: undefined },
+      { label: 'empty string', input: '' },
+    ].forEach(({ label, input }) => {
+      it(`should throw ValidationError for libraryId = ${label}`, async () => {
+        await expectValidationError(() => actions.fetchLibraryElements(input));
+      });
+    });
+
+    it('should set correct error metadata on ValidationError', async () => {
+      await expectValidationError(
+        () => actions.fetchLibraryElements(null),
+        (err) => {
+          expect(err.field).to.equal('libraryId');
+          expect(err.serviceName).to.equal('CCLibrary');
+          expect(err.topic).to.equal(CCLibraryTopics.LIBRARY.ELEMENTS);
+        },
+      );
+    });
+  });
+});

--- a/test/services/plugins/cclibrary/actions/LibraryThemeActions.test.js
+++ b/test/services/plugins/cclibrary/actions/LibraryThemeActions.test.js
@@ -1,0 +1,268 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import {
+  LibraryThemeActions,
+} from '../../../../../express/code/libs/services/plugins/cclibrary/actions/CCLibraryActions.js';
+import { CCLibraryTopics } from '../../../../../express/code/libs/services/plugins/cclibrary/topics.js';
+import { ValidationError } from '../../../../../express/code/libs/services/core/Errors.js';
+
+async function expectValidationError(fn, extraAssertions = () => {}) {
+  try {
+    await fn();
+    expect.fail('Should have thrown');
+  } catch (err) {
+    expect(err).to.be.instanceOf(ValidationError);
+    extraAssertions(err);
+  }
+}
+
+describe('LibraryThemeActions', () => {
+  let actions;
+  let mockPlugin;
+
+  const mockSaveResponse = { elements: [{ id: 'elem-1', name: 'New Theme', type: 'colortheme' }] };
+  const mockEmptyResponse = {};
+
+  beforeEach(() => {
+    mockPlugin = {
+      get: sinon.stub().resolves({}),
+      post: sinon.stub().resolves(mockSaveResponse),
+      put: sinon.stub().resolves(mockEmptyResponse),
+      delete: sinon.stub().resolves(mockEmptyResponse),
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+    };
+    actions = new LibraryThemeActions(mockPlugin);
+  });
+
+  afterEach(() => sinon.restore());
+
+  // 1. Structural Correctness
+  describe('getHandlers - action routing', () => {
+    it('should return a handler for every CCLibraryTopics.THEME topic', () => {
+      const handlers = actions.getHandlers();
+      const expectedTopics = Object.values(CCLibraryTopics.THEME);
+
+      expectedTopics.forEach((topic) => {
+        expect(handlers).to.have.property(topic).that.is.a('function');
+      });
+    });
+
+    it('should not contain any unexpected topic keys', () => {
+      const handlers = actions.getHandlers();
+      const handlerKeys = Object.keys(handlers);
+      const expectedTopics = Object.values(CCLibraryTopics.THEME);
+
+      expect(handlerKeys).to.have.lengthOf(expectedTopics.length);
+      handlerKeys.forEach((key) => {
+        expect(expectedTopics).to.include(key);
+      });
+    });
+  });
+
+  // --- saveTheme ---
+  describe('saveTheme', () => {
+    const themeData = { name: 'My Theme', type: 'colortheme', representations: [] };
+
+    it('should call plugin.post with the correct path and body', async () => {
+      await actions.saveTheme('lib-123', themeData);
+
+      expect(mockPlugin.post.calledOnce).to.be.true;
+      const [path, body] = mockPlugin.post.firstCall.args;
+      expect(path).to.equal('/libraries/lib-123/elements');
+      expect(body).to.deep.equal(themeData);
+    });
+
+    it('should return saved theme data from plugin', async () => {
+      const result = await actions.saveTheme('lib-123', themeData);
+      expect(result).to.deep.equal(mockSaveResponse);
+    });
+  });
+
+  describe('saveTheme - validation', () => {
+    [
+      { label: 'null libraryId', args: [null, { name: 'theme' }], field: 'libraryId' },
+      { label: 'empty libraryId', args: ['', { name: 'theme' }], field: 'libraryId' },
+      { label: 'undefined libraryId', args: [undefined, { name: 'theme' }], field: 'libraryId' },
+      { label: 'null themeData', args: ['lib-1', null], field: 'themeData' },
+      { label: 'undefined themeData', args: ['lib-1', undefined], field: 'themeData' },
+      { label: 'string themeData', args: ['lib-1', 'not-an-object'], field: 'themeData' },
+      { label: 'number themeData', args: ['lib-1', 42], field: 'themeData' },
+    ].forEach(({ label, args, field }) => {
+      it(`should throw ValidationError for ${label}`, async () => {
+        await expectValidationError(
+          () => actions.saveTheme(...args),
+          (err) => {
+            expect(err.field).to.equal(field);
+            expect(err.serviceName).to.equal('CCLibrary');
+            expect(err.topic).to.equal(CCLibraryTopics.THEME.SAVE);
+          },
+        );
+      });
+    });
+  });
+
+  // --- saveGradient ---
+  describe('saveGradient', () => {
+    const gradientData = { name: 'My Gradient', type: 'gradient', representations: [] };
+
+    it('should call plugin.post with the correct path and body', async () => {
+      await actions.saveGradient('lib-123', gradientData);
+
+      expect(mockPlugin.post.calledOnce).to.be.true;
+      const [path, body] = mockPlugin.post.firstCall.args;
+      expect(path).to.equal('/libraries/lib-123/elements');
+      expect(body).to.deep.equal(gradientData);
+    });
+
+    it('should return saved gradient data from plugin', async () => {
+      const result = await actions.saveGradient('lib-123', gradientData);
+      expect(result).to.deep.equal(mockSaveResponse);
+    });
+  });
+
+  describe('saveGradient - validation', () => {
+    [
+      { label: 'null libraryId', args: [null, { name: 'grad' }], field: 'libraryId' },
+      { label: 'empty libraryId', args: ['', { name: 'grad' }], field: 'libraryId' },
+      { label: 'null gradientData', args: ['lib-1', null], field: 'gradientData' },
+      { label: 'undefined gradientData', args: ['lib-1', undefined], field: 'gradientData' },
+      { label: 'string gradientData', args: ['lib-1', 'not-an-object'], field: 'gradientData' },
+    ].forEach(({ label, args, field }) => {
+      it(`should throw ValidationError for ${label}`, async () => {
+        await expectValidationError(
+          () => actions.saveGradient(...args),
+          (err) => {
+            expect(err.field).to.equal(field);
+            expect(err.serviceName).to.equal('CCLibrary');
+            expect(err.topic).to.equal(CCLibraryTopics.THEME.SAVE_GRADIENT);
+          },
+        );
+      });
+    });
+  });
+
+  // --- deleteTheme ---
+  describe('deleteTheme', () => {
+    it('should call plugin.delete with the correct path', async () => {
+      await actions.deleteTheme('lib-123', 'elem-456');
+
+      expect(mockPlugin.delete.calledOnce).to.be.true;
+      const [path] = mockPlugin.delete.firstCall.args;
+      expect(path).to.equal('/libraries/lib-123/elements/elem-456');
+    });
+
+    it('should return empty object from plugin', async () => {
+      const result = await actions.deleteTheme('lib-123', 'elem-456');
+      expect(result).to.deep.equal(mockEmptyResponse);
+    });
+  });
+
+  describe('deleteTheme - validation', () => {
+    [
+      { label: 'null libraryId', args: [null, 'elem-1'], field: 'libraryId' },
+      { label: 'empty libraryId', args: ['', 'elem-1'], field: 'libraryId' },
+      { label: 'null elementId', args: ['lib-1', null], field: 'elementId' },
+      { label: 'empty elementId', args: ['lib-1', ''], field: 'elementId' },
+      { label: 'undefined elementId', args: ['lib-1', undefined], field: 'elementId' },
+    ].forEach(({ label, args, field }) => {
+      it(`should throw ValidationError for ${label}`, async () => {
+        await expectValidationError(
+          () => actions.deleteTheme(...args),
+          (err) => {
+            expect(err.field).to.equal(field);
+            expect(err.serviceName).to.equal('CCLibrary');
+            expect(err.topic).to.equal(CCLibraryTopics.THEME.DELETE);
+          },
+        );
+      });
+    });
+  });
+
+  // --- updateTheme ---
+  describe('updateTheme', () => {
+    const updatePayload = { client: 'express', type: 'colortheme', representations: [] };
+
+    it('should call plugin.put with the correct path and body', async () => {
+      await actions.updateTheme('lib-123', 'elem-456', updatePayload);
+
+      expect(mockPlugin.put.calledOnce).to.be.true;
+      const [path, body] = mockPlugin.put.firstCall.args;
+      expect(path).to.equal('/libraries/lib-123/elements/elem-456/representations');
+      expect(body).to.deep.equal(updatePayload);
+    });
+
+    it('should return update response from plugin', async () => {
+      const result = await actions.updateTheme('lib-123', 'elem-456', updatePayload);
+      expect(result).to.deep.equal(mockEmptyResponse);
+    });
+  });
+
+  describe('updateTheme - validation', () => {
+    [
+      { label: 'null libraryId', args: [null, 'elem-1', { data: true }], field: 'libraryId' },
+      { label: 'empty libraryId', args: ['', 'elem-1', { data: true }], field: 'libraryId' },
+      { label: 'null elementId', args: ['lib-1', null, { data: true }], field: 'elementId' },
+      { label: 'empty elementId', args: ['lib-1', '', { data: true }], field: 'elementId' },
+      { label: 'null payload', args: ['lib-1', 'elem-1', null], field: 'payload' },
+      { label: 'undefined payload', args: ['lib-1', 'elem-1', undefined], field: 'payload' },
+      { label: 'string payload', args: ['lib-1', 'elem-1', 'not-object'], field: 'payload' },
+    ].forEach(({ label, args, field }) => {
+      it(`should throw ValidationError for ${label}`, async () => {
+        await expectValidationError(
+          () => actions.updateTheme(...args),
+          (err) => {
+            expect(err.field).to.equal(field);
+            expect(err.serviceName).to.equal('CCLibrary');
+            expect(err.topic).to.equal(CCLibraryTopics.THEME.UPDATE);
+          },
+        );
+      });
+    });
+  });
+
+  // --- updateElementMetadata ---
+  describe('updateElementMetadata', () => {
+    const elements = [{ id: 'elem-1', name: 'Renamed Theme' }];
+
+    it('should call plugin.put with the correct path and body', async () => {
+      await actions.updateElementMetadata('lib-123', elements);
+
+      expect(mockPlugin.put.calledOnce).to.be.true;
+      const [path, body] = mockPlugin.put.firstCall.args;
+      expect(path).to.equal('/libraries/lib-123/elements/metadata');
+      expect(body).to.deep.equal({ elements });
+    });
+
+    it('should return response from plugin', async () => {
+      const result = await actions.updateElementMetadata('lib-123', elements);
+      expect(result).to.deep.equal(mockEmptyResponse);
+    });
+  });
+
+  describe('updateElementMetadata - validation', () => {
+    [
+      { label: 'null libraryId', args: [null, [{ id: 'e1' }]], field: 'libraryId' },
+      { label: 'empty libraryId', args: ['', [{ id: 'e1' }]], field: 'libraryId' },
+      { label: 'null elements', args: ['lib-1', null], field: 'elements' },
+      { label: 'undefined elements', args: ['lib-1', undefined], field: 'elements' },
+      { label: 'empty array elements', args: ['lib-1', []], field: 'elements' },
+      { label: 'non-array elements (string)', args: ['lib-1', 'not-array'], field: 'elements' },
+      { label: 'non-array elements (object)', args: ['lib-1', { id: 'e1' }], field: 'elements' },
+    ].forEach(({ label, args, field }) => {
+      it(`should throw ValidationError for ${label}`, async () => {
+        await expectValidationError(
+          () => actions.updateElementMetadata(...args),
+          (err) => {
+            expect(err.field).to.equal(field);
+            expect(err.serviceName).to.equal('CCLibrary');
+            expect(err.topic).to.equal(CCLibraryTopics.THEME.UPDATE_METADATA);
+          },
+        );
+      });
+    });
+  });
+});

--- a/test/services/plugins/cclibrary/providers/CCLibraryProvider.colorConversion.test.js
+++ b/test/services/plugins/cclibrary/providers/CCLibraryProvider.colorConversion.test.js
@@ -1,0 +1,277 @@
+/* global globalThis */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import CCLibraryProvider from '../../../../../express/code/libs/services/providers/CCLibraryProvider.js';
+import CCLibraryPlugin from '../../../../../express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js';
+import {
+  COLOR_MODE,
+  CC_LIBRARY_COLOR_MODE,
+} from '../../../../../express/code/libs/services/plugins/cclibrary/constants.js';
+
+function createTestPlugin(PluginClass, overrides = {}) {
+  return new PluginClass({
+    serviceConfig: {
+      baseUrl: 'https://test.com',
+      melvilleBasePath: 'https://libraries.test.io/api/v1',
+      apiKey: 'test-key',
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('CCLibraryProvider - color conversion', () => {
+  let plugin;
+  let provider;
+
+  beforeEach(() => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    globalThis.adobeIMS = {
+      isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'mock-token' }),
+    };
+
+    globalThis.lana = { log: sinon.stub() };
+
+    plugin = createTestPlugin(CCLibraryPlugin);
+    provider = new CCLibraryProvider(plugin);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete globalThis.adobeIMS;
+    delete globalThis.lana;
+  });
+
+  // convertSwatchToCCFormat
+  describe('convertSwatchToCCFormat', () => {
+    it('should return a single RGB entry for RGB color mode', () => {
+      const swatch = { rgb: { r: 0.5, g: 0.25, b: 0.75 } };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.RGB);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+      expect(result[0].value).to.deep.equal({ r: 128, g: 64, b: 191 });
+    });
+
+    it('should scale RGB 0-1 floats to 0-255 integers', () => {
+      const swatch = { rgb: { r: 0, g: 1, b: 0.5 } };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.RGB);
+
+      expect(result[0].value).to.deep.equal({ r: 0, g: 255, b: 128 });
+    });
+
+    it('should return CMYK entry + RGB entry for CMYK color mode', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        cmyk: { c: 10, m: 20, y: 30, k: 40 },
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.CMYK);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.CMYK);
+      expect(result[0].value).to.deep.equal({ c: 10, m: 20, y: 30, k: 40 });
+      expect(result[1].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should return HSB entry + RGB entry for HSB color mode', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        hsb: { h: 180, s: 50, b: 75 },
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.HSB);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.HSB);
+      expect(result[0].value).to.deep.equal({ h: 180, s: 50, b: 75 });
+      expect(result[1].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should return LAB entry + RGB entry for LAB color mode', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        lab: { l: 50, a: -10, b: 20 },
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.LAB);
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.LAB);
+      expect(result[0].value).to.deep.equal({ l: 50, a: -10, b: 20 });
+      expect(result[1].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should round CMYK values to integers', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        cmyk: { c: 10.6, m: 20.3, y: 30.9, k: 40.1 },
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.CMYK);
+
+      expect(result[0].value).to.deep.equal({ c: 11, m: 20, y: 31, k: 40 });
+    });
+
+    it('should return only RGB entry when CMYK mode but cmyk data is missing', () => {
+      const swatch = { rgb: { r: 0.5, g: 0.5, b: 0.5 } };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.CMYK);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should return only RGB entry when HSB mode but hsb data is missing', () => {
+      const swatch = { rgb: { r: 0.5, g: 0.5, b: 0.5 } };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.HSB);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should return only RGB entry when LAB mode but lab data is missing', () => {
+      const swatch = { rgb: { r: 0.5, g: 0.5, b: 0.5 } };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.LAB);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should add pantone spot color info to RGB entry', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        pantone: '185 C',
+        isSpotColor: true,
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.RGB);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].type).to.equal('spot');
+      expect(result[0].spotColorName).to.equal('PANTONE 185 C');
+    });
+
+    it('should add pantone process color info to RGB entry', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        pantone: '300 C',
+        isSpotColor: false,
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.RGB);
+
+      expect(result[0].type).to.equal('process');
+      expect(result[0].spotColorName).to.equal('PANTONE 300 C');
+    });
+
+    it('should not add pantone info when pantone is absent', () => {
+      const swatch = { rgb: { r: 0.5, g: 0.5, b: 0.5 } };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.RGB);
+
+      expect(result[0]).to.not.have.property('type');
+      expect(result[0]).to.not.have.property('spotColorName');
+    });
+
+    it('should include pantone info on both entries in non-RGB color modes', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        cmyk: { c: 10, m: 20, y: 30, k: 40 },
+        pantone: '185 C',
+        isSpotColor: true,
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.CMYK);
+
+      expect(result).to.have.lengthOf(2);
+      // CMYK entry should have pantone info
+      expect(result[0].type).to.equal('spot');
+      expect(result[0].spotColorName).to.equal('PANTONE 185 C');
+      // RGB entry should have pantone info
+      expect(result[1].type).to.equal('spot');
+      expect(result[1].spotColorName).to.equal('PANTONE 185 C');
+    });
+
+    it('should handle HSV swatch data for backward compatibility', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        hsv: { h: 200, s: 60, v: 80 },
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, 'HSV');
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.HSB);
+      expect(result[0].value).to.deep.equal({ h: 200, s: 60, b: 80 });
+      expect(result[1].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should handle case-insensitive color mode comparison', () => {
+      const swatch = { rgb: { r: 0.5, g: 0.5, b: 0.5 } };
+      const result = provider.convertSwatchToCCFormat(swatch, 'rgb');
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+
+    it('should output Lab (mixed case) for LAB mode in API payloads', () => {
+      const swatch = {
+        rgb: { r: 0.5, g: 0.5, b: 0.5 },
+        lab: { l: 50, a: -10, b: 20 },
+      };
+      const result = provider.convertSwatchToCCFormat(swatch, COLOR_MODE.LAB);
+
+      expect(result[0].mode).to.equal('Lab');
+    });
+  });
+
+  // convertSwatchesToCCFormat
+  describe('convertSwatchesToCCFormat', () => {
+    it('should return empty array for null input', () => {
+      expect(provider.convertSwatchesToCCFormat(null, COLOR_MODE.RGB)).to.deep.equal([]);
+    });
+
+    it('should return empty array for undefined input', () => {
+      expect(provider.convertSwatchesToCCFormat(undefined, COLOR_MODE.RGB)).to.deep.equal([]);
+    });
+
+    it('should return empty array for non-array input', () => {
+      expect(provider.convertSwatchesToCCFormat('not-array', COLOR_MODE.RGB)).to.deep.equal([]);
+    });
+
+    it('should handle empty array', () => {
+      expect(provider.convertSwatchesToCCFormat([], COLOR_MODE.RGB)).to.deep.equal([]);
+    });
+
+    it('should convert an array of swatches', () => {
+      const swatches = [
+        { rgb: { r: 1, g: 0, b: 0 } },
+        { rgb: { r: 0, g: 1, b: 0 } },
+        { rgb: { r: 0, g: 0, b: 1 } },
+      ];
+      const result = provider.convertSwatchesToCCFormat(swatches, COLOR_MODE.RGB);
+
+      expect(result).to.have.lengthOf(3);
+      expect(result[0][0].value).to.deep.equal({ r: 255, g: 0, b: 0 });
+      expect(result[1][0].value).to.deep.equal({ r: 0, g: 255, b: 0 });
+      expect(result[2][0].value).to.deep.equal({ r: 0, g: 0, b: 255 });
+    });
+
+    it('should produce multi-entry arrays for non-RGB color mode', () => {
+      const swatches = [
+        { rgb: { r: 0.5, g: 0.5, b: 0.5 }, cmyk: { c: 0, m: 0, y: 0, k: 50 } },
+      ];
+      const result = provider.convertSwatchesToCCFormat(swatches, COLOR_MODE.CMYK);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.have.lengthOf(2);
+      expect(result[0][0].mode).to.equal(CC_LIBRARY_COLOR_MODE.CMYK);
+      expect(result[0][1].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+    });
+  });
+});

--- a/test/services/plugins/cclibrary/providers/CCLibraryProvider.delegation.test.js
+++ b/test/services/plugins/cclibrary/providers/CCLibraryProvider.delegation.test.js
@@ -1,0 +1,338 @@
+/* global globalThis */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import CCLibraryProvider, {
+  createCCLibraryProvider,
+} from '../../../../../express/code/libs/services/providers/CCLibraryProvider.js';
+import CCLibraryPlugin from '../../../../../express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js';
+
+function createTestPlugin(PluginClass, overrides = {}) {
+  return new PluginClass({
+    serviceConfig: {
+      baseUrl: 'https://test.com',
+      melvilleBasePath: 'https://libraries.test.io/api/v1',
+      apiKey: 'test-key',
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('CCLibraryProvider - delegation & errors', () => {
+  let plugin;
+  let provider;
+  let fetchStub;
+
+  const mockLibraries = { total_count: 1, libraries: [{ id: 'lib-1', name: 'Lib' }] };
+  const mockElements = { total_count: 1, elements: [{ id: 'elem-1' }] };
+  const mockCreated = { id: 'lib-new', name: 'New' };
+  const mockSaved = { elements: [{ id: 'elem-new' }] };
+  const mockEmpty = {};
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockLibraries),
+    });
+
+    globalThis.adobeIMS = {
+      isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'mock-token' }),
+    };
+
+    globalThis.lana = { log: sinon.stub() };
+
+    plugin = createTestPlugin(CCLibraryPlugin);
+    provider = new CCLibraryProvider(plugin);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete globalThis.adobeIMS;
+    delete globalThis.lana;
+  });
+
+  // 1. Delegation Wiring
+  describe('delegation wiring', () => {
+    it('createLibrary delegates to plugin and returns result', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockCreated),
+      });
+
+      const result = await provider.createLibrary('New Library');
+
+      expect(result).to.deep.equal(mockCreated);
+      expect(fetchStub.calledOnce).to.be.true;
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries');
+      expect(opts.method).to.equal('POST');
+      expect(JSON.parse(opts.body)).to.deep.equal({ name: 'New Library' });
+    });
+
+    it('fetchLibraries delegates to plugin and returns result', async () => {
+      const result = await provider.fetchLibraries();
+
+      expect(result).to.deep.equal(mockLibraries);
+      expect(fetchStub.calledOnce).to.be.true;
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('fetchLibraries passes params correctly', async () => {
+      await provider.fetchLibraries({ owner: 'private', limit: 10 });
+
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('owner=private');
+      expect(url).to.include('limit=10');
+    });
+
+    it('fetchUserLibraries delegates with owner=private', async () => {
+      await provider.fetchUserLibraries({ limit: 20 });
+
+      expect(fetchStub.calledOnce).to.be.true;
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries');
+      expect(url).to.include('owner=private');
+      expect(url).to.include('limit=20');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('fetchUserLibraries returns data from plugin', async () => {
+      const result = await provider.fetchUserLibraries();
+
+      expect(result).to.deep.equal(mockLibraries);
+    });
+
+    it('fetchUserLibraries overrides owner even if caller passes one', async () => {
+      await provider.fetchUserLibraries({ owner: 'all', limit: 5 });
+
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('owner=private');
+      expect(url).to.include('limit=5');
+    });
+
+    it('fetchLibraryElements delegates to plugin with libraryId', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockElements),
+      });
+
+      const result = await provider.fetchLibraryElements('lib-123');
+
+      expect(result).to.deep.equal(mockElements);
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries/lib-123/elements');
+    });
+
+    it('saveTheme delegates to plugin with libraryId and themeData', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockSaved),
+      });
+
+      const themeData = { name: 'Theme', type: 'colortheme' };
+      const result = await provider.saveTheme('lib-123', themeData);
+
+      expect(result).to.deep.equal(mockSaved);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries/lib-123/elements');
+      expect(opts.method).to.equal('POST');
+    });
+
+    it('saveGradient delegates to plugin with libraryId and gradientData', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockSaved),
+      });
+
+      const gradientData = { name: 'Gradient', type: 'gradient' };
+      const result = await provider.saveGradient('lib-123', gradientData);
+
+      expect(result).to.deep.equal(mockSaved);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries/lib-123/elements');
+      expect(opts.method).to.equal('POST');
+    });
+
+    it('deleteTheme delegates to plugin with libraryId and themeId', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 204,
+      });
+
+      const result = await provider.deleteTheme('lib-123', 'elem-456');
+
+      expect(result).to.deep.equal(mockEmpty);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries/lib-123/elements/elem-456');
+      expect(opts.method).to.equal('DELETE');
+    });
+
+    it('updateTheme delegates to plugin with libraryId, elementId, and payload', async () => {
+      const updateResponse = { id: 'elem-456', representations: [] };
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(updateResponse),
+      });
+
+      const payload = { client: 'express', type: 'colortheme' };
+      const result = await provider.updateTheme('lib-123', 'elem-456', payload);
+
+      expect(result).to.deep.equal(updateResponse);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries/lib-123/elements/elem-456/representations');
+      expect(opts.method).to.equal('PUT');
+    });
+
+    it('updateElementMetadata delegates to plugin with libraryId and elements', async () => {
+      fetchStub.resolves({
+        ok: true,
+        status: 204,
+      });
+
+      const elements = [{ id: 'elem-1', name: 'Renamed' }];
+      const result = await provider.updateElementMetadata('lib-123', elements);
+
+      expect(result).to.deep.equal(mockEmpty);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/libraries/lib-123/elements/metadata');
+      expect(opts.method).to.equal('PUT');
+    });
+  });
+
+  // 2. Error Boundary (safeExecute)
+  describe('error boundary (safeExecute)', () => {
+    it('createLibrary returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.createLibrary('Test');
+      expect(result).to.be.null;
+    });
+
+    it('fetchLibraries returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.fetchLibraries();
+      expect(result).to.be.null;
+    });
+
+    it('fetchLibraryElements returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.fetchLibraryElements('lib-1');
+      expect(result).to.be.null;
+    });
+
+    it('saveTheme returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.saveTheme('lib-1', { name: 't' });
+      expect(result).to.be.null;
+    });
+
+    it('saveGradient returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.saveGradient('lib-1', { name: 'g' });
+      expect(result).to.be.null;
+    });
+
+    it('deleteTheme returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.deleteTheme('lib-1', 'elem-1');
+      expect(result).to.be.null;
+    });
+
+    it('updateTheme returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.updateTheme('lib-1', 'elem-1', { data: true });
+      expect(result).to.be.null;
+    });
+
+    it('updateElementMetadata returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.updateElementMetadata('lib-1', [{ id: 'e1' }]);
+      expect(result).to.be.null;
+    });
+
+    it('fetchUserLibraries returns null when fetch throws', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.fetchUserLibraries();
+      expect(result).to.be.null;
+    });
+
+    it('returns null for validation errors (e.g. missing libraryId)', async () => {
+      const result = await provider.fetchLibraryElements(null);
+      expect(result).to.be.null;
+    });
+
+    it('returns null when API returns non-OK response', async () => {
+      fetchStub.resolves({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('Server error'),
+      });
+
+      const result = await provider.fetchLibraries();
+      expect(result).to.be.null;
+    });
+  });
+
+  // 3. Factory Function
+  describe('createCCLibraryProvider factory', () => {
+    it('should return a CCLibraryProvider instance', () => {
+      const instance = createCCLibraryProvider(plugin);
+      expect(instance).to.be.instanceOf(CCLibraryProvider);
+    });
+  });
+
+  // 4. isAvailable
+  describe('isAvailable', () => {
+    it('should return true when plugin is provided', () => {
+      expect(provider.isAvailable).to.be.true;
+    });
+  });
+
+  // 5. StorageFullError through safeExecute
+  describe('StorageFullError through safeExecute', () => {
+    it('should return null when API returns 507 (storage full)', async () => {
+      fetchStub.resolves({
+        ok: false,
+        status: 507,
+        statusText: 'Insufficient Storage',
+        text: () => Promise.resolve('Storage quota exceeded'),
+      });
+
+      const result = await provider.saveTheme('lib-1', { name: 'theme' });
+      expect(result).to.be.null;
+    });
+
+    it('should log StorageFullError with correct error type', async () => {
+      fetchStub.resolves({
+        ok: false,
+        status: 507,
+        statusText: 'Insufficient Storage',
+        text: () => Promise.resolve('Storage quota exceeded'),
+      });
+
+      await provider.saveTheme('lib-1', { name: 'theme' });
+
+      expect(globalThis.lana.log.calledOnce).to.be.true;
+      const [message, opts] = globalThis.lana.log.firstCall.args;
+      expect(message).to.include('error');
+      expect(opts.errorType).to.equal('StorageFullError');
+    });
+  });
+});

--- a/test/services/plugins/cclibrary/providers/CCLibraryProvider.gradient.test.js
+++ b/test/services/plugins/cclibrary/providers/CCLibraryProvider.gradient.test.js
@@ -1,0 +1,229 @@
+/* global globalThis */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import CCLibraryProvider from '../../../../../express/code/libs/services/providers/CCLibraryProvider.js';
+import CCLibraryPlugin from '../../../../../express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js';
+import {
+  GRADIENT_ELEMENT_TYPE,
+  GRADIENT_REPRESENTATION_TYPE,
+  CC_LIBRARY_COLOR_MODE,
+  getClientInfo,
+  COLOR_PROFILE,
+} from '../../../../../express/code/libs/services/plugins/cclibrary/constants.js';
+
+function createTestPlugin(PluginClass, overrides = {}) {
+  return new PluginClass({
+    serviceConfig: {
+      baseUrl: 'https://test.com',
+      melvilleBasePath: 'https://libraries.test.io/api/v1',
+      apiKey: 'test-key',
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('CCLibraryProvider - gradient payload', () => {
+  let plugin;
+  let provider;
+
+  beforeEach(() => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    globalThis.adobeIMS = {
+      isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'mock-token' }),
+    };
+
+    globalThis.lana = { log: sinon.stub() };
+
+    globalThis.adobeUserProfile = { userId: 'testuser123@AdobeID' };
+
+    plugin = createTestPlugin(CCLibraryPlugin);
+    provider = new CCLibraryProvider(plugin);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete globalThis.adobeIMS;
+    delete globalThis.adobeUserProfile;
+    delete globalThis.lana;
+  });
+
+  describe('buildGradientPayload', () => {
+    it('should build a basic gradient payload with defaults', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Test Gradient',
+        stops: [
+          { color: '#FF0000', position: 0 },
+          { color: '#0000FF', position: 1 },
+        ],
+      });
+
+      expect(result.name).to.equal('Test Gradient');
+      expect(result.type).to.equal(GRADIENT_ELEMENT_TYPE);
+      expect(result.client).to.deep.equal(getClientInfo());
+      expect(result.representations).to.have.lengthOf(1);
+    });
+
+    it('should use "rel" field (not "relationship") on representations', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Test',
+        stops: [],
+      });
+
+      const rep = result.representations[0];
+      expect(rep.rel).to.equal('primary');
+      expect(rep).to.not.have.property('relationship');
+    });
+
+    it('should set correct representation type', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Test',
+        stops: [],
+      });
+
+      expect(result.representations[0].type).to.equal(GRADIENT_REPRESENTATION_TYPE);
+    });
+
+    it('should apply default gradient data values', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Test',
+        stops: [],
+      });
+
+      const gradientData = result.representations[0]['gradient#data'];
+      expect(gradientData.angle).to.equal(90);
+      expect(gradientData.aspectRatio).to.equal(1);
+      expect(gradientData.interpolation).to.equal('linear');
+      expect(gradientData.type).to.equal('linear');
+      expect(gradientData.opacityStops).to.deep.equal([]);
+    });
+
+    it('should accept custom angle, aspectRatio, interpolation, and type', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Custom',
+        angle: 45,
+        aspectRatio: 2,
+        interpolation: 'ease',
+        type: 'radial',
+        stops: [],
+      });
+
+      const gradientData = result.representations[0]['gradient#data'];
+      expect(gradientData.angle).to.equal(45);
+      expect(gradientData.aspectRatio).to.equal(2);
+      expect(gradientData.interpolation).to.equal('ease');
+      expect(gradientData.type).to.equal('radial');
+    });
+
+    it('should default name to "Untitled gradient" when empty', () => {
+      const result = provider.buildGradientPayload({ stops: [] });
+      expect(result.name).to.equal('Untitled gradient');
+    });
+
+    it('should parse hex color stops correctly', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Hex Test',
+        stops: [{ color: '#FF5733', position: 0.5 }],
+      });
+
+      const stop = result.representations[0]['gradient#data'].stops[0];
+      expect(stop.color).to.have.lengthOf(1);
+      expect(stop.color[0].mode).to.equal(CC_LIBRARY_COLOR_MODE.RGB);
+      expect(stop.color[0].value).to.deep.equal({ r: 255, g: 87, b: 51 });
+      expect(stop.color[0].profileName).to.equal(COLOR_PROFILE);
+      expect(stop.offset).to.equal(0.5);
+      expect(stop.opacity).to.equal(1);
+    });
+
+    it('should parse 3-digit hex color stops', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Short Hex',
+        stops: [{ color: '#F00', position: 0 }],
+      });
+
+      const stop = result.representations[0]['gradient#data'].stops[0];
+      expect(stop.color[0].value).to.deep.equal({ r: 255, g: 0, b: 0 });
+    });
+
+    it('should parse rgb() color stops', () => {
+      const result = provider.buildGradientPayload({
+        name: 'RGB Test',
+        stops: [{ color: 'rgb(100, 200, 50)', position: 1 }],
+      });
+
+      const stop = result.representations[0]['gradient#data'].stops[0];
+      expect(stop.color[0].value).to.deep.equal({ r: 100, g: 200, b: 50 });
+    });
+
+    it('should parse rgba() color stops', () => {
+      const result = provider.buildGradientPayload({
+        name: 'RGBA Test',
+        stops: [{ color: 'rgba(10, 20, 30, 0.5)', position: 0 }],
+      });
+
+      const stop = result.representations[0]['gradient#data'].stops[0];
+      expect(stop.color[0].value).to.deep.equal({ r: 10, g: 20, b: 30 });
+    });
+
+    it('should fallback to black for invalid color strings', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Invalid',
+        stops: [{ color: 'not-a-color', position: 0 }],
+      });
+
+      const stop = result.representations[0]['gradient#data'].stops[0];
+      expect(stop.color[0].value).to.deep.equal({ r: 0, g: 0, b: 0 });
+    });
+
+    it('should fallback to black for null color', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Null',
+        stops: [{ color: null, position: 0 }],
+      });
+
+      const stop = result.representations[0]['gradient#data'].stops[0];
+      expect(stop.color[0].value).to.deep.equal({ r: 0, g: 0, b: 0 });
+    });
+
+    it('should handle multiple stops', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Multi',
+        stops: [
+          { color: '#FF0000', position: 0 },
+          { color: '#00FF00', position: 0.5 },
+          { color: '#0000FF', position: 1 },
+        ],
+      });
+
+      const stops = result.representations[0]['gradient#data'].stops;
+      expect(stops).to.have.lengthOf(3);
+      expect(stops[0].offset).to.equal(0);
+      expect(stops[1].offset).to.equal(0.5);
+      expect(stops[2].offset).to.equal(1);
+    });
+
+    it('should handle empty stops array', () => {
+      const result = provider.buildGradientPayload({
+        name: 'Empty',
+        stops: [],
+      });
+
+      const stops = result.representations[0]['gradient#data'].stops;
+      expect(stops).to.deep.equal([]);
+    });
+  });
+});

--- a/test/services/plugins/cclibrary/providers/CCLibraryProvider.permissions.test.js
+++ b/test/services/plugins/cclibrary/providers/CCLibraryProvider.permissions.test.js
@@ -1,0 +1,158 @@
+/* global globalThis */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import CCLibraryProvider from '../../../../../express/code/libs/services/providers/CCLibraryProvider.js';
+import CCLibraryPlugin from '../../../../../express/code/libs/services/plugins/cclibrary/CCLibraryPlugin.js';
+import {
+  LIBRARY_OWNERSHIP,
+  LIBRARY_ROLE,
+} from '../../../../../express/code/libs/services/plugins/cclibrary/constants.js';
+
+const ACL_DIR_KEY = 'http://ns.adobe.com/adobecloud/rel/directory';
+
+function createTestPlugin(PluginClass, overrides = {}) {
+  return new PluginClass({
+    serviceConfig: {
+      baseUrl: 'https://test.com',
+      melvilleBasePath: 'https://libraries.test.io/api/v1',
+      apiKey: 'test-key',
+      assetAclDirectoryKey: ACL_DIR_KEY,
+      endpoints: {
+        libraries: '/libraries',
+        themes: '/elements',
+        metadata: '/metadata',
+      },
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('CCLibraryProvider - permissions', () => {
+  let plugin;
+  let provider;
+
+  beforeEach(() => {
+    sinon.stub(globalThis, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    globalThis.adobeIMS = {
+      isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'mock-token' }),
+    };
+
+    globalThis.lana = { log: sinon.stub() };
+
+    plugin = createTestPlugin(CCLibraryPlugin);
+    provider = new CCLibraryProvider(plugin);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete globalThis.adobeIMS;
+    delete globalThis.lana;
+  });
+
+  // isLibraryWritable
+  describe('isLibraryWritable', () => {
+    it('should return false for null', () => {
+      expect(provider.isLibraryWritable(null)).to.be.false;
+    });
+
+    it('should return false for undefined', () => {
+      expect(provider.isLibraryWritable(undefined)).to.be.false;
+    });
+
+    it('should return true for private ownership', () => {
+      const lib = { ownership: LIBRARY_OWNERSHIP.PRIVATE };
+      expect(provider.isLibraryWritable(lib)).to.be.true;
+    });
+
+    it('should return true when bookmark role is editor', () => {
+      const lib = { ownership: LIBRARY_OWNERSHIP.SHARED, bookmark: { role: LIBRARY_ROLE.EDITOR } };
+      expect(provider.isLibraryWritable(lib)).to.be.true;
+    });
+
+    it('should return true when asset_acl directory access includes write', () => {
+      const lib = {
+        ownership: LIBRARY_OWNERSHIP.SHARED,
+        asset_acl: { [ACL_DIR_KEY]: ['read', 'write'] },
+      };
+      expect(provider.isLibraryWritable(lib)).to.be.true;
+    });
+
+    it('should return false for shared ownership with viewer role', () => {
+      const lib = { ownership: LIBRARY_OWNERSHIP.SHARED, bookmark: { role: LIBRARY_ROLE.VIEWER } };
+      expect(provider.isLibraryWritable(lib)).to.be.false;
+    });
+
+    it('should return false for shared ownership with no bookmark or acl', () => {
+      const lib = { ownership: LIBRARY_OWNERSHIP.SHARED };
+      expect(provider.isLibraryWritable(lib)).to.be.false;
+    });
+
+    it('should return false when asset_acl directory access has only read', () => {
+      const lib = {
+        ownership: LIBRARY_OWNERSHIP.SHARED,
+        asset_acl: { [ACL_DIR_KEY]: ['read'] },
+      };
+      expect(provider.isLibraryWritable(lib)).to.be.false;
+    });
+
+    it('should return false for an empty object', () => {
+      expect(provider.isLibraryWritable({})).to.be.false;
+    });
+  });
+
+  // filterWritableLibraries
+  describe('filterWritableLibraries', () => {
+    it('should return empty array for null input', () => {
+      expect(provider.filterWritableLibraries(null)).to.deep.equal([]);
+    });
+
+    it('should return empty array for undefined input', () => {
+      expect(provider.filterWritableLibraries(undefined)).to.deep.equal([]);
+    });
+
+    it('should return empty array for non-array input', () => {
+      expect(provider.filterWritableLibraries('not-an-array')).to.deep.equal([]);
+    });
+
+    it('should return empty array when no libraries are writable', () => {
+      const libraries = [
+        { id: 'lib-1', ownership: LIBRARY_OWNERSHIP.SHARED, bookmark: { role: LIBRARY_ROLE.VIEWER } },
+        { id: 'lib-2', ownership: LIBRARY_OWNERSHIP.SHARED },
+      ];
+      expect(provider.filterWritableLibraries(libraries)).to.deep.equal([]);
+    });
+
+    it('should return only writable libraries', () => {
+      const writable = { id: 'lib-1', ownership: LIBRARY_OWNERSHIP.PRIVATE };
+      const readOnly = { id: 'lib-2', ownership: LIBRARY_OWNERSHIP.SHARED, bookmark: { role: LIBRARY_ROLE.VIEWER } };
+      const editable = { id: 'lib-3', ownership: LIBRARY_OWNERSHIP.SHARED, bookmark: { role: LIBRARY_ROLE.EDITOR } };
+
+      const result = provider.filterWritableLibraries([writable, readOnly, editable]);
+      expect(result).to.have.lengthOf(2);
+      expect(result[0].id).to.equal('lib-1');
+      expect(result[1].id).to.equal('lib-3');
+    });
+
+    it('should return all libraries when all are writable', () => {
+      const libraries = [
+        { id: 'lib-1', ownership: LIBRARY_OWNERSHIP.PRIVATE },
+        { id: 'lib-2', ownership: LIBRARY_OWNERSHIP.PRIVATE },
+      ];
+      expect(provider.filterWritableLibraries(libraries)).to.have.lengthOf(2);
+    });
+
+    it('should handle empty array', () => {
+      expect(provider.filterWritableLibraries([])).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Creative Cloud Libraries (Melville API) service layer integration for saving, managing, and syncing color themes and gradients to a user's private CC Libraries. Implements a plugin-based architecture with **two** action groups (Library, Theme) backed by the Melville API. Uses Adobe IMS Bearer authentication for all operations; theme write operations enforce auth via middleware.

- **API Endpoints:**
  - `libraries.adobe.io/api/v1` — Production (Melville API)
  - `ccx-melville-stage.adobe.io/api/v1` — Stage
- **Feature Flag:** `ENABLE_CCLIBRARY` (defaults to `true`; set to `false` to disable)
- **Auth:** Adobe IMS (`window.adobeIMS`) — Bearer token required for all operations; `x-api-key` header injected automatically
- **Pages Using This:** Service layer only — Color Explorer Hybrid integration is a follow-up

---

## Jira Ticket

Resolves: [MWPW-187673](https://jira.corp.adobe.com/browse/MWPW-187673)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://vvineett-color-service-layer-cc-libraries--da-express-milo--adobecom.aem.page/drafts/dhananjay/color-poc/?martech=off |

---

## Verification Steps

- **Feature flag off:** Override `ENABLE_CCLIBRARY` to `false` during `init()` and confirm the CCLibrary plugin does not activate (`isActivated` returns `false`, provider returns `null`).
- **Feature flag on (default):** Confirm `await serviceManager.getProvider('cclibrary')` returns a valid `CCLibraryProvider` instance.
- **Authenticated operations:** Log in via IMS, then call `ccLibrary.createLibrary('Test')` — verify Bearer token and `x-api-key` are attached in request headers.
- **Fetch libraries:** Call `ccLibrary.fetchUserLibraries()` — verify it delegates with `owner=private` and returns paginated results.
- **Save theme/gradient:** Call `ccLibrary.saveTheme(libraryId, themeData)` and `ccLibrary.saveGradient(libraryId, gradientPayload)` — verify elements are created.
- **Writable filtering:** Call `ccLibrary.filterWritableLibraries(libraries)` — confirm private, editor-role, and ACL-write libraries pass; viewer-role libraries are excluded.
- **Storage full:** Simulate a 507 response — confirm `StorageFullError` is thrown.
- **Stage environment:** Confirm stage URLs (`ccx-melville-stage.adobe.io`, `cc-api-assets-stage.adobe.io`) are used when Milo env is `'stage'`.

---

## Potential Regressions

- https://vvineett-color-service-layer-cc-libraries--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

- **Architecture:** Follows plugin/provider pattern — `CCLibraryPlugin` (extends `BaseApiService`) registers two action groups, and `CCLibraryProvider` (extends `BaseProvider`) exposes a safe public API with `safeExecute` error handling and `window.lana` logging.
- **Action groups:** LibraryActions (3 topics: create, fetch, elements), LibraryThemeActions (5 topics: save, saveGradient, delete, update, updateMetadata) — **8 topics total**.
- **Auth middleware:** Configured on `cclibrary.theme.*` topics for write operations.
- **Provider utilities:** `isLibraryWritable` / `filterWritableLibraries` for permission checks, `buildGradientPayload` for Melville-compliant gradient payloads, `convertSwatchToCCFormat` / `convertSwatchesToCCFormat` for multi-mode color conversion (RGB, CMYK, HSB, LAB, Pantone).
- **Error handling:** `StorageFullError` (HTTP 507), `ValidationError` (missing/invalid params), `ApiError` (generic HTTP failures) — all with contextual metadata.
- **Comprehensive tests:** Plugin (`CCLibraryPlugin.test.js`), both action groups (`LibraryActions.test.js`, `LibraryThemeActions.test.js`), and provider split across 4 test files (delegation, permissions, color conversion, gradient builder) — see `test/services/plugins/cclibrary/CHECKLIST.md` for full coverage matrix.
- **Documentation:** Plugin README and config docs updated to reflect the CCLibrary implementation.