### PR TITLE
added fix for frictionless ax issue

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -312,3 +312,17 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     color: var(--color-white);
     padding: 4px;
 }
+
+/* Keep video and play/pause button within viewport down to 320px (accessibility) */
+@media (max-width: 480px) {
+  .frictionless-quick-action {
+      --frictionless-quick-action-video-width: min(444px, calc(100vw - 40px));
+  }
+
+  .frictionless-quick-action .fqa-container .button-container.hero-animation-overlay {
+      width: 100%;
+      max-width: var(--frictionless-quick-action-video-width);
+      min-height: unset;
+      right: 0;
+  }
+}

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -1,7 +1,7 @@
 @import '../../scripts/widgets/frictionless-locale-dropdown.css';
 
 :root {
-    --frictionless-quick-action-video-width: 444px;
+    --frictionless-quick-action-video-width: min(444px, calc(100vw - 40px));
     --frictionless-quick-action-video-height: 455px;
 }
 
@@ -62,7 +62,6 @@
     position: relative;
     right: 5px;
     width: var(--frictionless-quick-action-video-width);
-    min-height: var(--frictionless-quick-action-video-height);
 }
 
 .frictionless-quick-action .fqa-container > div:nth-child(2) {
@@ -238,6 +237,9 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     .frictionless-quick-action video {
         width: 95%;
     }
+    .frictionless-quick-action .fqa-container .button-container.hero-animation-overlay {
+      min-height: var(--frictionless-quick-action-video-height);
+    }
 
 }
 
@@ -311,18 +313,4 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     background: var(--color-info-accent);
     color: var(--color-white);
     padding: 4px;
-}
-
-/* Keep video and play/pause button within viewport down to 320px (accessibility) */
-@media (max-width: 480px) {
-  .frictionless-quick-action {
-      --frictionless-quick-action-video-width: min(444px, calc(100vw - 40px));
-  }
-
-  .frictionless-quick-action .fqa-container .button-container.hero-animation-overlay {
-      width: 100%;
-      max-width: var(--frictionless-quick-action-video-width);
-      min-height: unset;
-      right: 0;
-  }
 }


### PR DESCRIPTION
## Summary

Stops play/pause button from getting cut off the edge of the viewport when the viewport width is <=320px. 

---

## Jira Ticket

Resolves: [MWPW-177915](https://jira.corp.adobe.com/browse/MWPW-177915)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/feature/image/resize?martech=off |
| **After**   | https://mwpw-177915-2--da-express-milo--adobecom.aem.page/express/feature/image/resize?martech=off |

---

## Verification Steps

In order to reproduce this you'll need to 
1. navigate to one of the frictionless pages, 
2. open the chrome developer tools and click the 'toggle device' icon in order to enter the 'mobile view' which gives you the option to enter a custom width and height for the viewport. 
3. enter a width of 320px.
4. observe the position of the play/pause button

---

## Potential Regressions

This change is included inside of a media-query that targets viewport widths below 480px, so should be no potential regressions except for at that size, which is hard to achieve on browser (requires use of devtools [see additional notes below]). Regardless, here is a list of the pages that use the frictionless-quick-action block. 

- https://mwpw-177915-2--da-express-milo--adobecom.aem.page/express/feature/image/resize
- https://mwpw-177915-2--da-express-milo--adobecom.aem.page/express/feature/image/remove-background
- https://mwpw-177915-2--da-express-milo--adobecom.aem.page/express/feature/image/convert/svg
- https://mwpw-177915-2--da-express-milo--adobecom.aem.page/express/feature/video/trim/mp4
- https://mwpw-177915-2--da-express-milo--adobecom.aem.page/express/feature/image/convert/jpg-to-png

---

## Additional Notes

It's worth mentioning that the average user would not be able to reach this state very easily. Since this block uses a different treatment when rendering on an actual mobile device. The treatment that experiences this issue is only ever rendered on desktop browsers that somehow reach a width of 320px (which is not typically possible on desktop browsers, unless using the crome devtools, or perhaps some other accessibility checking tools).
