### PR TITLE
MWPW-187339 Extend TOC limit to 40

### DIFF
--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -74,7 +74,7 @@ function buildBlockConfig(block) {
   // Build content array with validation
   let i = 1;
   let content = config[`content-${i}`];
-  const MAX_ITERATIONS = 25; // Safety limit
+  const MAX_ITERATIONS = 40; // Safety limit
 
   while (content && i <= MAX_ITERATIONS) {
     const abbreviatedContent = config[`content-${i}-short`];
@@ -140,7 +140,6 @@ function createContentList(config) {
     id: 'toc-content',
     role: 'region',
     'aria-label': config.ariaLabel,
-    'aria-hidden': 'true',
   });
 
   // Create navigation links
@@ -180,23 +179,27 @@ function createSocialIcons() {
       'data-href': `https://www.twitter.com/share?&url=${url}&text=${title}`,
       'aria-label': 'Share on Twitter',
       tabindex: '0',
+      role: 'link',
     },
     linkedin: {
       'data-type': 'LinkedIn',
       'data-href': `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}&summary=${description}`,
       'aria-label': 'Share on LinkedIn',
       tabindex: '0',
+      role: 'link',
     },
     facebook: {
       'data-type': 'Facebook',
       'data-href': `https://www.facebook.com/sharer/sharer.php?u=${url}`,
       'aria-label': 'Share on Facebook',
       tabindex: '0',
+      role: 'link',
     },
     link: {
       id: 'toc-copy-link',
       'aria-label': 'Copy link to clipboard',
       tabindex: '0',
+      role: 'link',
     },
   };
 

--- a/nala/assets/urls.txt
+++ b/nala/assets/urls.txt
@@ -166,6 +166,8 @@ https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/text/text-
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/text/text-center
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/text/text-lockup
 
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/blocks/toc-seo/toc-seo
+
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/toggle-bar/toggle-bar
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/toggle-bar/toggle-bar-sticky
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/toggle-bar/toggle-bar-float-sticky

--- a/nala/blocks/toc-seo/toc-seo.block.json
+++ b/nala/blocks/toc-seo/toc-seo.block.json
@@ -1,0 +1,23 @@
+{
+  "block": "toc-seo",
+  "variants": [
+    {
+      "tcid": "0",
+      "name": "@toc-seo-default",
+      "selector": "div.toc-container",
+      "path": "/drafts/nala/blocks/toc-seo/toc-seo",
+      "data": {
+        "semantic": {
+          "texts": [],
+          "media": [],
+          "interactives": []
+        }
+      },
+      "tags": [
+        "@toc-seo",
+        "@default",
+        "@express"
+      ]
+    }
+  ]
+}

--- a/nala/blocks/toc-seo/toc-seo.page.cjs
+++ b/nala/blocks/toc-seo/toc-seo.page.cjs
@@ -1,0 +1,7 @@
+class TocSeoBlock {
+  constructor(page, selector = '.toc-container', nth = 0) {
+    this.page = page;
+    this.block = page.locator(selector).nth(nth);
+  }
+}
+module.exports = TocSeoBlock;

--- a/nala/blocks/toc-seo/toc-seo.spec.cjs
+++ b/nala/blocks/toc-seo/toc-seo.spec.cjs
@@ -1,0 +1,3 @@
+const schema = require('./toc-seo.block.json');
+
+module.exports = { features: schema.variants };

--- a/nala/blocks/toc-seo/toc-seo.test.cjs
+++ b/nala/blocks/toc-seo/toc-seo.test.cjs
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+const { features } = require('./toc-seo.spec.cjs');
+const TocSeoBlock = require('./toc-seo.page.cjs');
+const { runAccessibilityTest } = require('../../libs/accessibility.cjs');
+const { runSeoChecks } = require('../../libs/seo-check.cjs');
+
+test.describe('TocSeoBlock Test Suite', () => {
+  // Test Id : 0 : @toc-seo-default
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name} ${features[0].tags}`, async ({ page, baseURL }) => {
+    const { data } = features[0];
+    const testUrl = `${baseURL}${features[0].path}`;
+    const block = new TocSeoBlock(page, features[0].selector);
+    console.info(`[Test Page]: ${testUrl}`);
+
+    await test.step('step-1: Navigate to page', async () => {
+      await page.goto(testUrl);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(testUrl);
+    });
+
+    await test.step('step-2: Verify block content', async () => {
+      await expect(block.block).toBeVisible();
+      const sem = data.semantic;
+
+      for (const t of sem.texts) {
+        const locator = block.block.locator(t.selector).nth(t.nth || 0);
+        await expect(locator).toContainText(t.text);
+      }
+
+      for (const m of sem.media) {
+        const locator = block.block.locator(m.selector).nth(m.nth || 0);
+        const isHiddenSelector = m.selector.includes('.isHidden');
+        const isPicture = m.tag === 'picture';
+        const target = isPicture ? locator.locator('img') : locator;
+        if (isHiddenSelector) {
+          await expect(target).toBeHidden();
+        } else {
+          await expect(target).toBeVisible();
+        }
+      }
+
+      for (const iEl of sem.interactives) {
+        const locator = block.block.locator(iEl.selector).nth(iEl.nth || 0);
+        await expect(locator).toBeVisible({ timeout: 8000 });
+        if (iEl.type === 'link' && iEl.href) {
+          const href = await locator.getAttribute('href');
+          if (/^(tel:|mailto:|sms:|ftp:|[+]?[\d])/i.test(iEl.href)) {
+            await expect(href).toBe(iEl.href);
+          } else {
+            const expectedPath = new URL(iEl.href, 'https://dummy.base').pathname;
+            const actualPath = new URL(href, 'https://dummy.base').pathname;
+            await expect(actualPath).toBe(expectedPath);
+          }
+        }
+        if (iEl.text) await expect(locator).toContainText(iEl.text);
+      }
+    });
+
+    await test.step('step-3: Accessibility validation', async () => {
+      await runAccessibilityTest({ page, testScope: block.block, skipA11yTest: false });
+    });
+
+    await test.step('step-4: SEO validation', async () => {
+      await runSeoChecks({ page, feature: features[0], skipSeoTest: false });
+    });
+  });
+});

--- a/nala/libs/baseurl.cjs
+++ b/nala/libs/baseurl.cjs
@@ -3,7 +3,7 @@ import { head } from 'axios';
 
 export async function isBranchURLValid(url) {
   try {
-    const response = await head(`${url}/express/`);
+    const response = await head(url);
     if (response.status === 200) {
       console.info(`\nURL (${url}) returned a 200 status code. It is valid.`);
       return true;

--- a/nala/libs/baseurl.cjs
+++ b/nala/libs/baseurl.cjs
@@ -3,7 +3,7 @@ import { head } from 'axios';
 
 export async function isBranchURLValid(url) {
   try {
-    const response = await head(url);
+    const response = await head(`${url}/express/`);
     if (response.status === 200) {
       console.info(`\nURL (${url}) returned a 200 status code. It is valid.`);
       return true;

--- a/test/blocks/toc-seo/mocks/body-40.html
+++ b/test/blocks/toc-seo/mocks/body-40.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="toc-seo" content="on">
+  <meta name="toc-title" content="Table of Contents">
+  <meta name="toc-aria-label" content="Table of Contents Links">
+  <meta name="content-1" content="Section 1">
+  <meta name="content-2" content="Section 2">
+  <meta name="content-3" content="Section 3">
+  <meta name="content-4" content="Section 4">
+  <meta name="content-5" content="Section 5">
+  <meta name="content-6" content="Section 6">
+  <meta name="content-7" content="Section 7">
+  <meta name="content-8" content="Section 8">
+  <meta name="content-9" content="Section 9">
+  <meta name="content-10" content="Section 10">
+  <meta name="content-11" content="Section 11">
+  <meta name="content-12" content="Section 12">
+  <meta name="content-13" content="Section 13">
+  <meta name="content-14" content="Section 14">
+  <meta name="content-15" content="Section 15">
+  <meta name="content-16" content="Section 16">
+  <meta name="content-17" content="Section 17">
+  <meta name="content-18" content="Section 18">
+  <meta name="content-19" content="Section 19">
+  <meta name="content-20" content="Section 20">
+  <meta name="content-21" content="Section 21">
+  <meta name="content-22" content="Section 22">
+  <meta name="content-23" content="Section 23">
+  <meta name="content-24" content="Section 24">
+  <meta name="content-25" content="Section 25">
+  <meta name="content-26" content="Section 26">
+  <meta name="content-27" content="Section 27">
+  <meta name="content-28" content="Section 28">
+  <meta name="content-29" content="Section 29">
+  <meta name="content-30" content="Section 30">
+  <meta name="content-31" content="Section 31">
+  <meta name="content-32" content="Section 32">
+  <meta name="content-33" content="Section 33">
+  <meta name="content-34" content="Section 34">
+  <meta name="content-35" content="Section 35">
+  <meta name="content-36" content="Section 36">
+  <meta name="content-37" content="Section 37">
+  <meta name="content-38" content="Section 38">
+  <meta name="content-39" content="Section 39">
+  <meta name="content-40" content="Section 40">
+</head>
+<body>
+  <main>
+    <div class="section">
+      <h1>Main Title</h1>
+      <p>Introduction content</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 1</h2>
+      <p>Content for section 1</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 2</h2>
+      <p>Content for section 2</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 3</h2>
+      <p>Content for section 3</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 4</h2>
+      <p>Content for section 4</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 5</h2>
+      <p>Content for section 5</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 6</h2>
+      <p>Content for section 6</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 7</h2>
+      <p>Content for section 7</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 8</h2>
+      <p>Content for section 8</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 9</h2>
+      <p>Content for section 9</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 10</h2>
+      <p>Content for section 10</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 11</h2>
+      <p>Content for section 11</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 12</h2>
+      <p>Content for section 12</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 13</h2>
+      <p>Content for section 13</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 14</h2>
+      <p>Content for section 14</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 15</h2>
+      <p>Content for section 15</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 16</h2>
+      <p>Content for section 16</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 17</h2>
+      <p>Content for section 17</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 18</h2>
+      <p>Content for section 18</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 19</h2>
+      <p>Content for section 19</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 20</h2>
+      <p>Content for section 20</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 21</h2>
+      <p>Content for section 21</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 22</h2>
+      <p>Content for section 22</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 23</h2>
+      <p>Content for section 23</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 24</h2>
+      <p>Content for section 24</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 25</h2>
+      <p>Content for section 25</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 26</h2>
+      <p>Content for section 26</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 27</h2>
+      <p>Content for section 27</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 28</h2>
+      <p>Content for section 28</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 29</h2>
+      <p>Content for section 29</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 30</h2>
+      <p>Content for section 30</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 31</h2>
+      <p>Content for section 31</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 32</h2>
+      <p>Content for section 32</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 33</h2>
+      <p>Content for section 33</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 34</h2>
+      <p>Content for section 34</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 35</h2>
+      <p>Content for section 35</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 36</h2>
+      <p>Content for section 36</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 37</h2>
+      <p>Content for section 37</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 38</h2>
+      <p>Content for section 38</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 39</h2>
+      <p>Content for section 39</p>
+    </div>
+    
+    <div class="section">
+      <h2>Section 40</h2>
+      <p>Content for section 40</p>
+    </div>
+  </main>
+</body>
+</html>

--- a/test/blocks/toc-seo/toc-seo.test.js
+++ b/test/blocks/toc-seo/toc-seo.test.js
@@ -91,14 +91,27 @@ const setupTest = async (htmlFile) => {
   const tocBlock = document.createElement('div');
   tocBlock.classList.add('toc-seo');
 
-  // Add mock configuration rows
-  const configRows = [
-    ['toc-title', 'Table of Contents'],
-    ['toc-aria-label', 'Table of Contents Links'],
-    ['content-1', 'First Section'],
-    ['content-2', 'Second Section'],
-    ['content-3', 'Third Section'],
-  ];
+  // Read configuration from meta tags in the HTML
+  const configRows = [];
+  const metaTags = document.querySelectorAll('meta[name]');
+  metaTags.forEach((meta) => {
+    const name = meta.getAttribute('name');
+    const content = meta.getAttribute('content');
+    if (name && content) {
+      configRows.push([name, content]);
+    }
+  });
+
+  // Fallback to default config if no meta tags found
+  if (configRows.length === 0) {
+    configRows.push(
+      ['toc-title', 'Table of Contents'],
+      ['toc-aria-label', 'Table of Contents Links'],
+      ['content-1', 'First Section'],
+      ['content-2', 'Second Section'],
+      ['content-3', 'Third Section'],
+    );
+  }
 
   configRows.forEach(([key, value]) => {
     const row = document.createElement('div');
@@ -119,23 +132,26 @@ const setupTest = async (htmlFile) => {
   highlight.appendChild(highlightDiv);
   document.body.appendChild(highlight);
 
-  // Add main section with long-form content
-  const mainSection = document.createElement('main');
-  const section = document.createElement('div');
-  section.classList.add('section', 'long-form');
-  const content = document.createElement('div');
-  content.classList.add('content');
+  // Check if main section already exists in the HTML, if not create it
+  let mainSection = document.querySelector('main');
+  if (!mainSection) {
+    mainSection = document.createElement('main');
+    const section = document.createElement('div');
+    section.classList.add('section', 'long-form');
+    const content = document.createElement('div');
+    content.classList.add('content');
 
-  // Add test headers
-  ['First Section', 'Second Section', 'Third Section'].forEach((text) => {
-    const header = document.createElement('h2');
-    header.textContent = text;
-    content.appendChild(header);
-  });
+    // Add test headers
+    ['First Section', 'Second Section', 'Third Section'].forEach((text) => {
+      const header = document.createElement('h2');
+      header.textContent = text;
+      content.appendChild(header);
+    });
 
-  section.appendChild(content);
-  mainSection.appendChild(section);
-  document.body.appendChild(mainSection);
+    section.appendChild(content);
+    mainSection.appendChild(section);
+    document.body.appendChild(mainSection);
+  }
 
   await decorate(tocBlock);
   return document.querySelector('.toc-container');
@@ -209,6 +225,16 @@ describe('Table of Contents SEO - Links Test', () => {
       expect(link.textContent).to.equal(expectedTexts[index]);
       expect(link.getAttribute('href')).to.equal(`#content-${index + 1}`);
     });
+
+    cleanupTest();
+  });
+
+  it('should render all TOC links correctly with 40 links', async () => {
+    const toc = await setupTest('./mocks/body-40.html');
+    const content = toc.querySelector('.toc-content');
+    const links = content.querySelectorAll('a');
+
+    expect(links.length).to.equal(40);
 
     cleanupTest();
   });


### PR DESCRIPTION
## Summary

- Extending the number of items supported in the Table of Contents to 40
- Fixing nala issue where tests run on PRs weren't being tested on feature branches

---

## Jira Ticket

Resolves: [MWPW-187339](https://jira.corp.adobe.com/browse/MWPW-187339)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://meain--da-express-milo--adobecom.aem.page/drafts/methomas/toc-40 |
| **After**   | https://methomas-toc-40--da-express-milo--adobecom.aem.page/drafts/methomas/toc-40 |

---

## Verification Steps

- View the TOC. There should be 40 items. Previously there was a max of 25.

---

## Potential Regressions

- N/A

---

## Additional Notes

N/A
