### PR TITLE
Added adjustment to ax-columns to retain two-column treatment until mobile breakpoint

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1026,7 +1026,7 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 600px) {
   main .section:has(.ax-columns.enterprise):not([data-padding='none'])>.content h2 {
     font-size: var(--heading-font-size-l);
     padding-top: var(--spacing-700);


### PR DESCRIPTION
## Summary

Added adjustment to ax-columns to retain two-column treatment until mobile breakpoint

---

## Jira Ticket

Resolves: [MWPW-170814](https://jira.corp.adobe.com/browse/MWPW-170814)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/photos?martech=off |
| **After**   | https://mwpw-170814--da-express-milo--adobecom.aem.page/express/photos?martech=off |

---

## Verification Steps

- Navigate to the Before link above
- Resize the browser window / viewport to be inbetween 600px and 900px wide. 
- Observe the single-column layout
Then:
- Navigate to the After link above
- Resize the browser window / viewport to be inbetween 600px and 900px wide. 
- Observe the two-column layout

---

## Potential Regressions

- https://mwpw-170814--da-express-milo--adobecom.aem.live/express/photos
- https://mwpw-170814--da-express-milo--adobecom.aem.live/express/create/background
- https://mwpw-170814--da-express-milo--adobecom.aem.live/express/create/cover/album
- https://mwpw-170814--da-express-milo--adobecom.aem.live/express/create/banner/event
- https://mwpw-170814--da-express-milo--adobecom.aem.live/jp/express/discover/ideas/line-richmenu


---

## Additional Notes

Since the ax-columns block is pretty widely used, we should make sure to be through in our testing.
