### PR TITLE
[Color][Service Layer][MWPW-187669] KulerPlugin Updates

### DIFF
--- a/express/code/libs/services/plugins/kuler/KulerPlugin.js
+++ b/express/code/libs/services/plugins/kuler/KulerPlugin.js
@@ -1,13 +1,20 @@
 import BaseApiService from '../../core/BaseApiService.js';
 import { KulerActionGroups } from './topics.js';
-import SearchActions from './actions/SearchActions.js';
-import ThemeActions from './actions/ThemeActions.js';
-import GradientActions from './actions/GradientActions.js';
-import LikeActions from './actions/LikeActions.js';
+import {
+  SearchActions,
+  ExploreActions,
+  ThemeActions,
+  GradientActions,
+  LikeActions,
+} from './actions/KulerActions.js';
 
 export default class KulerPlugin extends BaseApiService {
   static get serviceName() {
     return 'Kuler';
+  }
+
+  get baseUrl() {
+    return this.serviceConfig.baseSearchUrl;
   }
 
   /**
@@ -31,12 +38,15 @@ export default class KulerPlugin extends BaseApiService {
 
   registerActionGroups() {
     this.registerActionGroup(KulerActionGroups.SEARCH, new SearchActions(this));
+    this.registerActionGroup(KulerActionGroups.EXPLORE, new ExploreActions(this));
     this.registerActionGroup(KulerActionGroups.THEME, new ThemeActions(this));
     this.registerActionGroup(KulerActionGroups.GRADIENT, new GradientActions(this));
     this.registerActionGroup(KulerActionGroups.LIKE, new LikeActions(this));
   }
 
-  /** @returns {string[]} */
+  /**
+   * @returns {string[]}
+   */
   getActionGroupNames() {
     return Array.from(this.actionGroups.keys());
   }

--- a/express/code/libs/services/plugins/kuler/README.md
+++ b/express/code/libs/services/plugins/kuler/README.md
@@ -4,11 +4,28 @@
 
 ## Overview
 
-The Kuler Plugin provides access to Adobe Color (formerly Kuler) APIs for searching, creating, and managing color themes and gradients. It's a complex plugin with multiple action groups handling distinct functional areas.
+The Kuler Plugin provides access to Adobe Color (formerly Kuler) APIs for searching, exploring, creating, and managing color themes and gradients. It's a complex plugin with multiple action groups handling distinct functional areas.
+
+## Architecture
+
+The plugin uses a modular action group architecture where related actions are organized into separate action group classes. This design allows:
+
+- Better code organization and maintainability
+- Easier testing of individual action groups
+- Extensibility — new action groups can be added without modifying the main plugin
+- Reusability — other plugins can follow the same pattern
+
+### Constructor Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `serviceConfig` | Object | Kuler service config (baseUrl, apiKey, endpoints) |
+| `appConfig` | Object | Application config (features, environment) |
 
 ## Features
 
 - 🔍 **Search** - Search themes and gradients by term, tag, hex, or similar colors
+- 🗺️ **Explore** - Browse/explore themes and gradients with filter, sort, and time criteria
 - 🎨 **Themes** - Get, save, and delete color themes
 - 🌈 **Gradients** - Save and delete gradients
 - ❤️ **Likes** - Like and unlike themes
@@ -31,17 +48,22 @@ kuler: {
     themeBaseUrl: 'https://themes.adobe.io',
     likeBaseUrl: 'https://asset.adobe.io',
     gradientBaseUrl: 'https://gradient.adobe.io',
+    exploreBaseUrl: 'https://themesb3.adobe.io',
   },
 }
 ```
 
 ## Topics
 
+Topics define the available actions for the Kuler service. Use these with `plugin.dispatch()` for direct API access, or use the `KulerProvider` for a friendlier interface.
+
 | Topic | Description |
 |-------|-------------|
-| `search.themes` | Search for color themes |
-| `search.gradients` | Search for gradients |
-| `search.published` | Check if theme is published |
+| `search.themes` | Search for color themes via search.adobe.io |
+| `search.gradients` | Search for gradients via search.adobe.io |
+| `search.published` | Check if a theme/gradient is published (by URL or asset ID) |
+| `explore.themes` | Browse/explore themes via themesb3.adobe.io |
+| `explore.gradients` | Browse/explore gradients via themesb3.adobe.io |
 | `theme.get` | Get a specific theme by ID |
 | `theme.save` | Save/publish a theme |
 | `theme.delete` | Delete a published theme |
@@ -51,12 +73,15 @@ kuler: {
 
 ## Action Groups
 
-| Group | Actions | File |
-|-------|---------|------|
-| `search` | fetchThemeList, fetchGradientList, searchPublishedTheme | `actions/SearchActions.js` |
-| `theme` | fetchTheme, saveTheme, deleteTheme | `actions/ThemeActions.js` |
-| `gradient` | saveGradient, deleteGradient | `actions/GradientActions.js` |
-| `like` | updateLikeStatus | `actions/LikeActions.js` |
+All action groups are defined in `actions/KulerActions.js`.
+
+| Group | Class | Actions | Description |
+|-------|-------|---------|-------------|
+| `search` | `SearchActions` | fetchThemeList, fetchGradientList, searchPublishedTheme | Search via search.adobe.io. Builds JSON-encoded `q` parameter queries. |
+| `explore` | `ExploreActions` | fetchExploreThemes, fetchExploreGradients | Browse/explore via themesb3.adobe.io using filter/sort/time parameters. |
+| `theme` | `ThemeActions` | fetchTheme, saveTheme, deleteTheme | Theme CRUD operations. Uses `ValidationError` for input validation. |
+| `gradient` | `GradientActions` | saveGradient, deleteGradient | Gradient CRUD operations. Uses `ValidationError` for input validation. |
+| `like` | `LikeActions` | updateLikeStatus | Like/unlike operations. Uses `ValidationError` for input validation. |
 
 ## Usage
 
@@ -77,6 +102,27 @@ const themes = await kuler.searchThemes('sunset', {
 // Search gradients
 const gradients = await kuler.searchGradients('ocean');
 
+// Explore/browse themes (via themesb3.adobe.io)
+const explored = await kuler.exploreThemes({
+  filter: 'public',     // 'public' | 'my_themes'
+  sort: 'create_time',  // 'create_time' | 'like_count' | 'view_count' | 'random'
+  time: 'month',        // 'all' | 'month' | 'week'
+  page: 1,
+});
+
+// Explore/browse gradients
+const exploredGradients = await kuler.exploreGradients({
+  filter: 'public',
+  sort: 'like_count',
+  time: 'all',
+});
+
+// Check if an asset is published on Kuler
+const published = await kuler.checkIfPublished('asset-id', 'GRADIENT');
+
+// Search published by URL
+const result = await kuler.searchPublished(fullSearchUrl);
+
 // Get specific theme
 const theme = await kuler.getTheme('theme-id');
 
@@ -85,6 +131,12 @@ await kuler.saveTheme(themeData, ccLibrariesResponse);
 
 // Delete theme (requires authentication)
 await kuler.deleteTheme({ id: 'theme-id', name: 'Theme Name' });
+
+// Save gradient (requires authentication)
+await kuler.saveGradient(gradientData, ccLibrariesResponse);
+
+// Delete gradient (requires authentication)
+await kuler.deleteGradient({ id: 'gradient-id', name: 'Gradient Name' });
 
 // Like/unlike theme (requires authentication)
 await kuler.updateLike({ id: 'theme-id', like: { user: null }, source: 'KULER' });
@@ -105,19 +157,54 @@ const result = await kulerPlugin.dispatch(KulerTopics.SEARCH.THEMES, {
   pageNumber: 1,
 });
 
+// Explore themes
+const explored = await kulerPlugin.dispatch(KulerTopics.EXPLORE.THEMES, {
+  filter: 'public',
+  sort: 'create_time',
+  time: 'month',
+  pageNumber: 1,
+});
+
 // Get theme
 const theme = await kulerPlugin.dispatch(KulerTopics.THEME.GET, 'theme-id');
 ```
 
 ## API Details
 
-### Search Criteria
+### Search (search.adobe.io)
+
+Kuler search expects a `q` parameter with a JSON-encoded query object (e.g. `q={"term":"value"}`). Results are paginated with a default batch size of 72. Authenticated users receive additional `metadata=all` in responses.
+
+#### Search Criteria
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `main` | string | Search query |
 | `typeOfQuery` | string | Query type: `term`, `tag`, `hex`, `similarHex` |
 | `pageNumber` | number | Page number (1-indexed) |
+
+### Explore (themesb3.adobe.io)
+
+The explore/browse endpoint uses filter, sort, and time parameters instead of search queries. Results are paginated with a default batch size of 72.
+
+#### Explore Criteria
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `filter` | string | `'public'` | Filter mode: `public` or `my_themes` |
+| `sort` | string | `'create_time'` | Sort field (see Sort Values below) |
+| `time` | string | `'month'` | Time filter: `all`, `month`, `week` |
+| `pageNumber` | number | `1` | Page number (1-indexed) |
+
+#### Sort Values
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `ALL_THEMES` | `create_time` | Newest first |
+| `MOST_POPULAR` | `like_count` | Most liked |
+| `MOST_USED` | `view_count` | Most viewed |
+| `RANDOM` | `random` | Random order |
+| `MY_PUBLISHED` | `my_themes` | User's own published themes |
 
 ### Theme Data Structure
 
@@ -138,19 +225,31 @@ const theme = await kulerPlugin.dispatch(KulerTopics.THEME.GET, 'theme-id');
 }
 ```
 
+### Response Transforms
+
+The `providers/transforms.js` module provides helpers for normalizing API responses:
+
+| Transform | Description |
+|-----------|-------------|
+| `themeToGradient(theme)` | Converts a theme (0-1 RGB swatches) to a normalized gradient object |
+| `themesToGradients(themes)` | Batch version of `themeToGradient` |
+| `gradientApiResponseToGradient(apiData)` | Parses gradient API response (0-255 RGB stops) to a normalized gradient |
+| `gradientApiResponsesToGradients(array)` | Batch version of `gradientApiResponseToGradient` |
+
 ## Authentication
 
-- **Search operations**: Work without authentication
+- **Search and Explore operations**: Work without authentication (authenticated users get additional metadata)
 - **Save/Delete/Like operations**: Require user authentication via Adobe IMS
 
 ## Related Files
 
-- `KulerPlugin.js` - Main plugin class
-- `topics.js` - Topic definitions
-- `actions/` - Action group implementations
-- `../../providers/KulerProvider.js` - Consumer-friendly provider
+- `KulerPlugin.js` — Main plugin class
+- `topics.js` — Topic and action group definitions
+- `actions/KulerActions.js` — All action group implementations (SearchActions, ExploreActions, ThemeActions, GradientActions, LikeActions)
+- `../../providers/KulerProvider.js` — Consumer-friendly provider
+- `../../providers/transforms.js` — Response transform utilities
 
 ---
 
-**Version:** 2.0  
+**Version:** 3.0  
 **Last Updated:** February 2026

--- a/express/code/libs/services/plugins/kuler/actions/KulerActions.js
+++ b/express/code/libs/services/plugins/kuler/actions/KulerActions.js
@@ -1,0 +1,527 @@
+/* eslint-disable max-classes-per-file */
+import BaseActionGroup from '../../../core/BaseActionGroup.js';
+import { ValidationError } from '../../../core/Errors.js';
+import { KulerTopics } from '../topics.js';
+
+const KULER_DEFAULT_BATCH_SIZE = 72;
+
+/**
+ * Criteria constants matching the Kuler API sort values.
+ */
+const KULER_CRITERIA = {
+  ALL_THEMES: 'create_time',
+  MOST_POPULAR: 'like_count',
+  MOST_USED: 'view_count',
+  RANDOM: 'random',
+  MY_PUBLISHED: 'my_themes',
+};
+
+export class SearchActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [KulerTopics.SEARCH.THEMES]: this.fetchThemeList.bind(this),
+      [KulerTopics.SEARCH.GRADIENTS]: this.fetchGradientList.bind(this),
+      [KulerTopics.SEARCH.PUBLISHED]: this.searchPublishedTheme.bind(this),
+    };
+  }
+
+  /**
+   * @param {Object} criteria
+   * @param {string} criteria.main
+   * @param {string} [criteria.typeOfQuery]
+   * @returns {string}
+   */
+  static buildKulerQuery(criteria) {
+    const type = criteria.typeOfQuery || 'term';
+    const queryObj = { [type]: criteria.main };
+    return JSON.stringify(queryObj);
+  }
+
+  /**
+   * @param {Object} criteria
+   * @param {string} criteria.main
+   * @param {string} [criteria.typeOfQuery]
+   * @param {number} criteria.pageNumber
+   * @param {string} assetType
+   * @returns {string}
+   */
+  buildSearchUrl(criteria, assetType = 'THEME') {
+    const basePath = this.plugin.baseUrl;
+    const searchPath = this.plugin.endpoints.search;
+
+    const pageNum = Number.parseInt(String(criteria.pageNumber || 1), 10);
+    const startIndex = (pageNum - 1) * KULER_DEFAULT_BATCH_SIZE;
+    const queryParam = encodeURIComponent(SearchActions.buildKulerQuery(criteria));
+
+    let url = `${basePath}${searchPath}?q=${queryParam}`;
+
+    const auth = this.plugin.getAuthState();
+    if (auth.isLoggedIn && auth.token) {
+      url = `${url}&metadata=all`;
+    }
+
+    url = `${url}&startIndex=${startIndex}&maxNumber=${KULER_DEFAULT_BATCH_SIZE}&assetType=${assetType}`;
+
+    return url;
+  }
+
+  /**
+   * Build a URL to check if an asset is published on Kuler by its CC Library asset ID.
+   * @param {string} assetId - The CC Library asset ID
+   * @param {string} [assetType='GRADIENT'] - THEME or GRADIENT
+   * @returns {string}
+   */
+  buildPublishedCheckUrl(assetId, assetType = 'GRADIENT') {
+    const basePath = this.plugin.baseUrl;
+    const searchPath = this.plugin.endpoints.search;
+    const queryObj = { asset_id: assetId };
+    const queryParam = encodeURIComponent(JSON.stringify(queryObj));
+    return `${basePath}${searchPath}?q=${queryParam}&maxNumber=1&assetType=${assetType}`;
+  }
+
+  /**
+   * @param {Object} criteria
+   * @param {string} criteria.main
+   * @param {string} [criteria.typeOfQuery]
+   * @param {number} criteria.pageNumber
+   * @param {string} [assetType]
+   * @returns {Promise<Object>}
+   */
+  async fetchThemeList(criteria, assetType = 'THEME') {
+    const url = this.buildSearchUrl(criteria, assetType);
+    return this.plugin.fetchWithFullUrl(url, 'GET');
+  }
+
+  /**
+   * @param {Object} criteria
+   * @param {string} criteria.main
+   * @param {string} [criteria.typeOfQuery]
+   * @param {number} criteria.pageNumber
+   * @returns {Promise<Object>}
+   */
+  async fetchGradientList(criteria) {
+    return this.fetchThemeList(criteria, 'GRADIENT');
+  }
+
+  /**
+   * Search for a published theme/gradient by URL or asset ID.
+   * @param {string|Object} urlOrParams - Full URL string, or { assetId, assetType }
+   * @returns {Promise<Object>}
+   * @throws {ValidationError}
+   */
+  async searchPublishedTheme(urlOrParams) {
+    if (typeof urlOrParams === 'object' && urlOrParams.assetId) {
+      const { assetId, assetType = 'GRADIENT' } = urlOrParams;
+      const url = this.buildPublishedCheckUrl(assetId, assetType);
+      return this.plugin.fetchWithFullUrl(url, 'GET');
+    }
+
+    let fullUrl = urlOrParams;
+    if (typeof fullUrl === 'string' && !fullUrl.startsWith('http://') && !fullUrl.startsWith('https://')) {
+      fullUrl = `${this.plugin.baseUrl}${fullUrl}`;
+    }
+
+    return this.plugin.fetchWithFullUrl(fullUrl, 'GET');
+  }
+}
+
+/**
+ * ExploreActions handles the Browse/Explore flow that fetches
+ * gradients and themes from the themesb3.adobe.io endpoint
+ * using filter/sort/time parameters instead of search queries.
+ */
+export class ExploreActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [KulerTopics.EXPLORE.THEMES]: this.fetchExploreThemes.bind(this),
+      [KulerTopics.EXPLORE.GRADIENTS]: this.fetchExploreGradients.bind(this),
+    };
+  }
+
+  /**
+   * Build a browse/explore URL for the B3 endpoint.
+   * @param {string} assetPath - e.g. '/themes' or '/gradient'
+   * @param {Object} [criteria]
+   * @param {string} [criteria.filter='public']
+   * @param {string} [criteria.sort='create_time']
+   * @param {string} [criteria.time='month']
+   * @param {number} [criteria.pageNumber=1]
+   * @returns {string}
+   */
+  buildExploreUrl(assetPath, criteria = {}) {
+    const { exploreBaseUrl } = this.plugin.serviceConfig;
+    const { api } = this.plugin.endpoints;
+
+    const filter = criteria.filter || 'public';
+    const sort = criteria.sort || KULER_CRITERIA.ALL_THEMES;
+    const time = criteria.time || 'month';
+    const pageNum = Number.parseInt(String(criteria.pageNumber || 1), 10);
+    const startIndex = (pageNum - 1) * KULER_DEFAULT_BATCH_SIZE;
+
+    let url = `${exploreBaseUrl}${api}${assetPath}`;
+
+    if (filter === KULER_CRITERIA.MY_PUBLISHED || filter === 'my_themes') {
+      url = `${url}?filter=${filter}`;
+    } else {
+      url = `${url}?filter=${filter}&sort=${sort}&time=${time}`;
+    }
+
+    const auth = this.plugin.getAuthState();
+    if (auth.isLoggedIn && auth.token) {
+      url = `${url}&metadata=all`;
+    }
+
+    url = `${url}&startIndex=${startIndex}&maxNumber=${KULER_DEFAULT_BATCH_SIZE}`;
+    return url;
+  }
+
+  /**
+   * Fetch themes from the Explore/Browse endpoint.
+   * @param {Object} [criteria]
+   * @returns {Promise<Object>}
+   */
+  async fetchExploreThemes(criteria = {}) {
+    const { themePath } = this.plugin.endpoints;
+    const url = this.buildExploreUrl(themePath, criteria);
+    return this.plugin.fetchWithFullUrl(url, 'GET');
+  }
+
+  /**
+   * Fetch gradients from the Explore/Browse endpoint.
+   * @param {Object} [criteria]
+   * @returns {Promise<Object>}
+   */
+  async fetchExploreGradients(criteria = {}) {
+    const { gradientPath } = this.plugin.endpoints;
+    const url = this.buildExploreUrl(gradientPath, criteria);
+    return this.plugin.fetchWithFullUrl(url, 'GET');
+  }
+}
+
+export class ThemeActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [KulerTopics.THEME.GET]: this.fetchTheme.bind(this),
+      [KulerTopics.THEME.SAVE]: this.saveTheme.bind(this),
+      [KulerTopics.THEME.DELETE]: this.deleteTheme.bind(this),
+    };
+  }
+
+  /**
+   * @param {string} themeId
+   * @returns {string}
+   */
+  buildThemeUrl(themeId) {
+    const { serviceConfig, endpoints } = this.plugin;
+    return `${serviceConfig.themeBaseUrl}${endpoints.api}${endpoints.themePath}/${themeId}`;
+  }
+
+  /**
+   * @returns {string}
+   */
+  buildThemeSaveUrl() {
+    const { serviceConfig, endpoints } = this.plugin;
+    return `${serviceConfig.themeBaseUrl}${endpoints.api}${endpoints.themePath}`;
+  }
+
+  /**
+   * @param {string} themeId
+   * @returns {string}
+   */
+  buildThemeDeleteUrl(themeId) {
+    return this.buildThemeUrl(themeId);
+  }
+
+  /**
+   * @param {Array} swatches
+   * @param {Object} themeData
+   * @returns {Array}
+   */
+  static convertSwatchesToKulerFormat(swatches, themeData) {
+    const COLOR_MODE = {
+      RGB: 'rgb',
+      CMYK: 'cmyk',
+      HSV: 'hsv',
+      LAB: 'lab',
+    };
+
+    let colorMode = COLOR_MODE.RGB;
+    if (swatches.length > 0) {
+      const firstSwatch = swatches[0];
+      if (firstSwatch.cmyk) colorMode = COLOR_MODE.CMYK;
+      else if (firstSwatch.hsv) colorMode = COLOR_MODE.HSV;
+      else if (firstSwatch.lab) colorMode = COLOR_MODE.LAB;
+    }
+
+    return swatches.map((swatch, index) => {
+      let values = [];
+
+      switch (colorMode) {
+        case COLOR_MODE.RGB:
+          if (swatch.rgb) {
+            values = [swatch.rgb.r, swatch.rgb.g, swatch.rgb.b];
+          }
+          break;
+        case COLOR_MODE.CMYK:
+          if (swatch.cmyk) {
+            values = [swatch.cmyk.c, swatch.cmyk.m, swatch.cmyk.y, swatch.cmyk.k];
+          }
+          break;
+        case COLOR_MODE.HSV:
+          if (swatch.hsv) {
+            values = [swatch.hsv.h, swatch.hsv.s, swatch.hsv.v];
+          }
+          break;
+        case COLOR_MODE.LAB:
+          if (swatch.lab) {
+            values = [swatch.lab.l, swatch.lab.a, swatch.lab.b];
+          }
+          break;
+        default: return swatch;
+      }
+
+      const result = {
+        mode: colorMode,
+        values,
+      };
+
+      if (themeData.swatches?.[index]?.label) {
+        result.swatchLabel = themeData.swatches[index].label;
+      }
+
+      return result;
+    });
+  }
+
+  /**
+   * @param {Object} themeData
+   * @param {Object} ccLibrariesResponse
+   * @returns {Object}
+   */
+  static buildThemePostData(themeData, ccLibrariesResponse) {
+    const swatches = ThemeActions.convertSwatchesToKulerFormat(themeData.swatches || [], themeData);
+
+    return {
+      name: themeData.name || 'My Color Theme',
+      swatches,
+      assets: {
+        assetid: ccLibrariesResponse.id,
+        libraryid: ccLibrariesResponse.libraryid,
+      },
+      tags: themeData.tags || [],
+      harmony: {
+        baseSwatchIndex: themeData.harmony?.baseSwatchIndex || 0,
+        mood: themeData.harmony?.mood?.toLowerCase(),
+        rule: (themeData.harmony?.rule || 'custom').toLowerCase(),
+        sourceURL: themeData.harmony?.sourceURL || '',
+      },
+      ...(themeData.accessibilityData && { accessibilityData: themeData.accessibilityData }),
+    };
+  }
+
+  /**
+   * @param {string} themeId
+   * @returns {Promise<Object>}
+   * @throws {ValidationError}
+   */
+  async fetchTheme(themeId) {
+    if (!themeId) {
+      throw new ValidationError('Theme ID is required', {
+        field: 'themeId',
+        serviceName: 'Kuler',
+        topic: KulerTopics.THEME.GET,
+      });
+    }
+    const url = this.buildThemeUrl(themeId);
+    return this.plugin.fetchWithFullUrl(url, 'GET');
+  }
+
+  /**
+   * @param {Object} themeData
+   * @param {string} themeData.name
+   * @param {Array} themeData.swatches
+   * @param {Array} [themeData.tags]
+   * @param {Object} [themeData.harmony]
+   * @param {Object} ccLibrariesResponse
+   * @param {string} ccLibrariesResponse.id
+   * @param {string} ccLibrariesResponse.libraryid
+   * @returns {Promise<Object>}
+   * @throws {ValidationError}
+   */
+  async saveTheme(themeData, ccLibrariesResponse) {
+    if (!themeData) {
+      throw new ValidationError('Theme data is required', {
+        field: 'themeData',
+        serviceName: 'Kuler',
+        topic: KulerTopics.THEME.SAVE,
+      });
+    }
+    if (!themeData.swatches?.length) {
+      throw new ValidationError('Theme must have at least one swatch', {
+        field: 'themeData.swatches',
+        serviceName: 'Kuler',
+        topic: KulerTopics.THEME.SAVE,
+      });
+    }
+    if (!ccLibrariesResponse?.id) {
+      throw new ValidationError('CC Libraries response ID is required', {
+        field: 'ccLibrariesResponse.id',
+        serviceName: 'Kuler',
+        topic: KulerTopics.THEME.SAVE,
+      });
+    }
+    if (!ccLibrariesResponse?.libraryid) {
+      throw new ValidationError('CC Libraries response library ID is required', {
+        field: 'ccLibrariesResponse.libraryid',
+        serviceName: 'Kuler',
+        topic: KulerTopics.THEME.SAVE,
+      });
+    }
+    const url = this.buildThemeSaveUrl();
+    const postData = ThemeActions.buildThemePostData(themeData, ccLibrariesResponse);
+    return this.plugin.fetchWithFullUrl(url, 'POST', postData);
+  }
+
+  /**
+   * @param {Object} payload
+   * @param {string} payload.id
+   * @param {string} payload.name
+   * @returns {Promise<Object>}
+   * @throws {ValidationError}
+   */
+  async deleteTheme(payload) {
+    if (!payload?.id) {
+      throw new ValidationError('Theme ID is required for deletion', {
+        field: 'payload.id',
+        serviceName: 'Kuler',
+        topic: KulerTopics.THEME.DELETE,
+      });
+    }
+    const url = this.buildThemeDeleteUrl(payload.id);
+    const response = await this.plugin.fetchWithFullUrl(url, 'DELETE');
+    return {
+      response,
+      themeName: payload.name,
+    };
+  }
+}
+
+export class GradientActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [KulerTopics.GRADIENT.SAVE]: this.saveGradient.bind(this),
+      [KulerTopics.GRADIENT.DELETE]: this.deleteGradient.bind(this),
+    };
+  }
+
+  /**
+   * @returns {string}
+   */
+  buildGradientSaveUrl() {
+    const { serviceConfig, endpoints } = this.plugin;
+    return `${serviceConfig.gradientBaseUrl}${endpoints.api}${endpoints.gradientPath}`;
+  }
+
+  /**
+   * @param {string} gradientId
+   * @returns {string}
+   */
+  buildGradientDeleteUrl(gradientId) {
+    const { serviceConfig, endpoints } = this.plugin;
+    return `${serviceConfig.gradientBaseUrl}${endpoints.api}${endpoints.gradientPath}/${gradientId}`;
+  }
+
+  /**
+   * @param {Object} gradientData
+   * @param {Object} [ccLibrariesResponse]
+   * @returns {Promise<Object>}
+   * @throws {ValidationError}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async saveGradient(gradientData, ccLibrariesResponse) {
+    if (!gradientData) {
+      throw new ValidationError('Gradient data is required', {
+        field: 'gradientData',
+        serviceName: 'Kuler',
+        topic: KulerTopics.GRADIENT.SAVE,
+      });
+    }
+    const url = this.buildGradientSaveUrl();
+    return this.plugin.fetchWithFullUrl(url, 'POST', gradientData);
+  }
+
+  /**
+   * @param {Object} payload
+   * @param {string} payload.id
+   * @param {string} payload.name
+   * @returns {Promise<Object>}
+   * @throws {ValidationError}
+   */
+  async deleteGradient(payload) {
+    if (!payload?.id) {
+      throw new ValidationError('Gradient ID is required for deletion', {
+        field: 'payload.id',
+        serviceName: 'Kuler',
+        topic: KulerTopics.GRADIENT.DELETE,
+      });
+    }
+    const url = this.buildGradientDeleteUrl(payload.id);
+    const response = await this.plugin.fetchWithFullUrl(url, 'DELETE');
+    return {
+      response,
+      gradientName: payload.name,
+    };
+  }
+}
+
+export class LikeActions extends BaseActionGroup {
+  getHandlers() {
+    return {
+      [KulerTopics.LIKE.UPDATE]: this.updateLikeStatus.bind(this),
+    };
+  }
+
+  /**
+   * @param {string} themeId
+   * @returns {string}
+   */
+  buildThemeLikeUrl(themeId) {
+    const { serviceConfig, endpoints } = this.plugin;
+    return `${serviceConfig.likeBaseUrl}${endpoints.themePath}/${themeId}/like`;
+  }
+
+  /**
+   * @param {string} themeId
+   * @returns {string}
+   */
+  buildThemeUnlikeUrl(themeId) {
+    const { serviceConfig, endpoints } = this.plugin;
+    return `${serviceConfig.likeBaseUrl}${endpoints.themePath}/${themeId}/like`;
+  }
+
+  /**
+   * @param {Object} payload
+   * @param {string} payload.id
+   * @param {Object} payload.like
+   * @param {Object} [payload.like.user]
+   * @param {string} payload.source
+   * @returns {Promise<void>}
+   * @throws {ValidationError}
+   */
+  async updateLikeStatus(payload) {
+    if (!payload?.id) {
+      throw new ValidationError('Theme ID is required for like/unlike', {
+        field: 'payload.id',
+        serviceName: 'Kuler',
+        topic: KulerTopics.LIKE.UPDATE,
+      });
+    }
+    if (payload.like?.user) {
+      const url = this.buildThemeUnlikeUrl(payload.id);
+      await this.plugin.fetchWithFullUrl(url, 'DELETE');
+    } else {
+      const url = this.buildThemeLikeUrl(payload.id);
+      await this.plugin.fetchWithFullUrl(url, 'POST', {});
+    }
+  }
+}

--- a/express/code/libs/services/plugins/kuler/topics.js
+++ b/express/code/libs/services/plugins/kuler/topics.js
@@ -4,11 +4,14 @@ export const KulerTopics = {
     GRADIENTS: 'search.gradients',
     PUBLISHED: 'search.published',
   },
+  EXPLORE: {
+    THEMES: 'explore.themes',
+    GRADIENTS: 'explore.gradients',
+  },
   THEME: {
     GET: 'theme.get',
     SAVE: 'theme.save',
     DELETE: 'theme.delete',
-    NAMES: 'theme.names',
   },
   GRADIENT: {
     SAVE: 'gradient.save',
@@ -21,6 +24,7 @@ export const KulerTopics = {
 
 export const KulerActionGroups = {
   SEARCH: 'search',
+  EXPLORE: 'explore',
   THEME: 'theme',
   GRADIENT: 'gradient',
   LIKE: 'like',

--- a/express/code/libs/services/providers/KulerProvider.js
+++ b/express/code/libs/services/providers/KulerProvider.js
@@ -1,0 +1,195 @@
+import BaseProvider from './BaseProvider.js';
+import { KulerTopics, KulerActionGroups } from '../plugins/kuler/topics.js';
+
+export default class KulerProvider extends BaseProvider {
+  /** @type {Object} */
+  #actions = {};
+
+  /** @param {Object} plugin */
+  constructor(plugin) {
+    super(plugin);
+    this.#initActions();
+  }
+
+  #initActions() {
+    const {
+      SEARCH, EXPLORE, THEME, GRADIENT, LIKE,
+    } = KulerActionGroups;
+
+    this.#actions = {
+      searchThemes: this.plugin.useAction(SEARCH, KulerTopics.SEARCH.THEMES),
+      searchGradients: this.plugin.useAction(SEARCH, KulerTopics.SEARCH.GRADIENTS),
+      searchPublished: this.plugin.useAction(SEARCH, KulerTopics.SEARCH.PUBLISHED),
+      exploreThemes: this.plugin.useAction(EXPLORE, KulerTopics.EXPLORE.THEMES),
+      exploreGradients: this.plugin.useAction(EXPLORE, KulerTopics.EXPLORE.GRADIENTS),
+      getTheme: this.plugin.useAction(THEME, KulerTopics.THEME.GET),
+      saveTheme: this.plugin.useAction(THEME, KulerTopics.THEME.SAVE),
+      deleteTheme: this.plugin.useAction(THEME, KulerTopics.THEME.DELETE),
+      saveGradient: this.plugin.useAction(GRADIENT, KulerTopics.GRADIENT.SAVE),
+      deleteGradient: this.plugin.useAction(GRADIENT, KulerTopics.GRADIENT.DELETE),
+      updateLike: this.plugin.useAction(LIKE, KulerTopics.LIKE.UPDATE),
+    };
+  }
+
+  /**
+   * @param {string} query
+   * @param {Object} [options]
+   * @returns {Object}
+   */
+  // eslint-disable-next-line class-methods-use-this
+  #transformSearchParams(query, options = {}) {
+    return {
+      main: query,
+      typeOfQuery: options.typeOfQuery || 'term',
+      pageNumber: options.page || 1,
+    };
+  }
+
+  /**
+   * Search themes via search.adobe.io.
+   * @param {string} query
+   * @param {Object} [options]
+   * @param {'term'|'tag'|'hex'|'similarHex'} [options.typeOfQuery='term']
+   * @param {number} [options.page=1]
+   * @returns {Promise<Object|null>}
+   */
+  async searchThemes(query, options = {}) {
+    const criteria = this.#transformSearchParams(query, options);
+    return this.safeExecute(() => this.#actions.searchThemes(criteria));
+  }
+
+  /**
+   * Search gradients via search.adobe.io.
+   * @param {string} query
+   * @param {Object} [options]
+   * @returns {Promise<Object|null>}
+   */
+  async searchGradients(query, options = {}) {
+    const criteria = this.#transformSearchParams(query, options);
+    return this.safeExecute(() => this.#actions.searchGradients(criteria));
+  }
+
+  /**
+   * Browse/explore themes via themesb3.adobe.io.
+   * @param {Object} [options]
+   * @param {string} [options.filter='public'] - 'public' or 'my_themes'
+   * @param {string} [options.sort='create_time'] - Sort field
+   * @param {string} [options.time='month'] - Time filter: 'all', 'month', 'week'
+   * @param {number} [options.page=1]
+   * @returns {Promise<Object|null>}
+   */
+  async exploreThemes(options = {}) {
+    const criteria = {
+      filter: options.filter || 'public',
+      sort: options.sort || 'create_time',
+      time: options.time || 'month',
+      pageNumber: options.page || 1,
+    };
+    return this.safeExecute(() => this.#actions.exploreThemes(criteria));
+  }
+
+  /**
+   * Browse/explore gradients via themesb3.adobe.io.
+   * @param {Object} [options]
+   * @param {string} [options.filter='public'] - 'public' or 'my_themes'
+   * @param {string} [options.sort='create_time'] - Sort field
+   * @param {string} [options.time='month'] - Time filter: 'all', 'month', 'week'
+   * @param {number} [options.page=1]
+   * @returns {Promise<Object|null>}
+   */
+  async exploreGradients(options = {}) {
+    const criteria = {
+      filter: options.filter || 'public',
+      sort: options.sort || 'create_time',
+      time: options.time || 'month',
+      pageNumber: options.page || 1,
+    };
+    return this.safeExecute(() => this.#actions.exploreGradients(criteria));
+  }
+
+  /**
+   * @param {string} themeId
+   * @returns {Promise<Object|null>}
+   */
+  async getTheme(themeId) {
+    return this.safeExecute(() => this.#actions.getTheme(themeId));
+  }
+
+  /**
+   * @param {Object} themeData
+   * @param {Object} ccLibrariesResponse
+   * @returns {Promise<Object|null>}
+   */
+  async saveTheme(themeData, ccLibrariesResponse) {
+    return this.safeExecute(() => this.#actions.saveTheme(themeData, ccLibrariesResponse));
+  }
+
+  /**
+   * @param {Object} payload
+   * @param {string} payload.id
+   * @param {string} payload.name
+   * @returns {Promise<Object|null>}
+   */
+  async deleteTheme(payload) {
+    return this.safeExecute(() => this.#actions.deleteTheme(payload));
+  }
+
+  /**
+   * @param {Object} gradientData
+   * @param {Object} [ccLibrariesResponse]
+   * @returns {Promise<Object|null>}
+   */
+  async saveGradient(gradientData, ccLibrariesResponse) {
+    return this.safeExecute(() => this.#actions.saveGradient(gradientData, ccLibrariesResponse));
+  }
+
+  /**
+   * @param {Object} payload
+   * @param {string} payload.id
+   * @param {string} payload.name
+   * @returns {Promise<Object|null>}
+   */
+  async deleteGradient(payload) {
+    return this.safeExecute(() => this.#actions.deleteGradient(payload));
+  }
+
+  /**
+   * @param {Object} payload
+   * @param {string} payload.id
+   * @param {Object} payload.like
+   * @param {string} payload.source
+   * @returns {Promise<void|null>}
+   */
+  async updateLike(payload) {
+    return this.safeExecute(() => this.#actions.updateLike(payload));
+  }
+
+  /**
+   * Search for a published theme/gradient by URL.
+   * @param {string} url - Full search URL
+   * @returns {Promise<Object|null>}
+   */
+  async searchPublished(url) {
+    return this.safeExecute(() => this.#actions.searchPublished(url));
+  }
+
+  /**
+   * Check if a gradient/theme is published on Kuler by its CC Library asset ID.
+   * @param {string} assetId - The CC Library asset ID
+   * @param {string} [assetType='GRADIENT'] - THEME or GRADIENT
+   * @returns {Promise<Object|null>}
+   */
+  async checkIfPublished(assetId, assetType = 'GRADIENT') {
+    return this.safeExecute(
+      () => this.#actions.searchPublished({ assetId, assetType }),
+    );
+  }
+}
+
+/**
+ * @param {Object} plugin
+ * @returns {KulerProvider}
+ */
+export function createKulerProvider(plugin) {
+  return new KulerProvider(plugin);
+}

--- a/express/code/libs/services/providers/index.js
+++ b/express/code/libs/services/providers/index.js
@@ -1,1 +1,2 @@
 export { default as BaseProvider } from './BaseProvider.js';
+export { default as KulerProvider, createKulerProvider } from './KulerProvider.js';

--- a/express/code/libs/services/providers/transforms.js
+++ b/express/code/libs/services/providers/transforms.js
@@ -1,0 +1,192 @@
+/**
+ * @typedef {Object} SearchOptions
+ * @property {'term'|'tag'|'hex'|'similarHex'} [typeOfQuery='term']
+ * @property {number} [pageNumber=1]
+ */
+
+/**
+ * @typedef {Object} SearchCriteria
+ * @property {string} main
+ * @property {'term'|'tag'|'hex'|'similarHex'} typeOfQuery
+ * @property {number} pageNumber
+ */
+
+/**
+ * @typedef {Object} StockOptions
+ * @property {number} [count=20]
+ * @property {number} [offset=0]
+ */
+
+/**
+ * @typedef {Object} StockCriteria
+ * @property {number} count
+ * @property {number} offset
+ */
+
+/**
+ * @param {string} query
+ * @param {SearchOptions} [options]
+ * @returns {SearchCriteria}
+ */
+export function searchTransform(query, options = {}) {
+  return {
+    main: query,
+    typeOfQuery: options.typeOfQuery || 'term',
+    pageNumber: options.pageNumber || 1,
+  };
+}
+
+/**
+ * @param {StockOptions} [params]
+ * @returns {StockCriteria}
+ */
+export function stockTransform(params = {}) {
+  return {
+    count: params.count || 20,
+    offset: params.offset || 0,
+    ...params,
+  };
+}
+
+/**
+ * @param {*} value
+ * @returns {*}
+ */
+export function identityTransform(value) {
+  return value;
+}
+
+/**
+ * @param {string} key
+ * @returns {Function}
+ */
+export function namedTransform(key) {
+  return (value) => ({ [key]: value });
+}
+
+/**
+ * Convert a theme-style API response (with swatches) to a gradient object.
+ * Theme swatches use 0-1 RGB range.
+ *
+ * @param {Object} theme
+ * @param {string} theme.id
+ * @param {string} [theme.name]
+ * @param {Array} [theme.swatches]
+ * @returns {Object}
+ */
+export function themeToGradient(theme) {
+  const swatches = theme.swatches || [];
+
+  const colors = swatches.map((swatch) => {
+    if (swatch.hex) {
+      return `#${swatch.hex}`;
+    }
+    if (swatch.values && swatch.values.length >= 3) {
+      const r = Math.round(Number.parseFloat(swatch.values[0]) * 255);
+      const g = Math.round(Number.parseFloat(swatch.values[1]) * 255);
+      const b = Math.round(Number.parseFloat(swatch.values[2]) * 255);
+      return `#${[r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('').toUpperCase()}`;
+    }
+    return '#CCCCCC';
+  });
+
+  const colorStops = colors.map((color, index) => ({
+    color,
+    position: colors.length > 1 ? index / (colors.length - 1) : 0,
+  }));
+
+  return {
+    id: theme.id,
+    name: theme.name || 'Unnamed Theme',
+    type: 'linear',
+    angle: 90,
+    colorStops,
+    coreColors: colors,
+    likes: theme.likes ?? theme.appreciations ?? 0,
+    creator: theme.author?.name || '',
+    tags: theme.tags || [],
+    _source: 'kuler',
+    _theme: theme,
+  };
+}
+
+/**
+ * @param {Array} themes
+ * @returns {Array}
+ */
+export function themesToGradients(themes) {
+  if (!Array.isArray(themes)) return [];
+  return themes.map(themeToGradient);
+}
+
+/**
+ * Convert an RGB stop value from the gradient API (0-255 range) to a hex color.
+ * @param {Object} stopColor - color object with mode and value
+ * @returns {string} hex color string
+ */
+function gradientStopToHex(stopColor) {
+  if (!stopColor?.[0]?.mode || !stopColor?.[0]?.value) return '#CCCCCC';
+
+  const { mode, value } = stopColor[0];
+  if (mode.toLowerCase() === 'rgb') {
+    const r = Math.round(value.r);
+    const g = Math.round(value.g);
+    const b = Math.round(value.b);
+    return `#${[r, g, b].map((v) => Math.min(255, Math.max(0, v)).toString(16).padStart(2, '0')).join('').toUpperCase()}`;
+  }
+  return '#CCCCCC';
+}
+
+/**
+ * Parse a gradient API response item that uses the
+ * `gradientSecondaryRepresentation.rendition` structure.
+ *
+ * The gradient API returns RGB values in 0-255 range (not 0-1 like themes).
+ * Each stop has: { color: [{ mode, value: { r, g, b } }], midpoint, offset }
+ *
+ * @param {Object} apiData - Single gradient item from the API
+ * @returns {Object} Normalized gradient object
+ */
+export function gradientApiResponseToGradient(apiData) {
+  const rendition = apiData.gradientSecondaryRepresentation?.rendition;
+
+  if (!rendition) {
+    return themeToGradient(apiData);
+  }
+
+  const stops = rendition.stops || [];
+  const colorStops = stops.map((stop) => ({
+    color: gradientStopToHex(stop.color),
+    position: stop.offset ?? 0,
+    midpoint: stop.midpoint ?? 0.5,
+  }));
+
+  const coreColors = colorStops.map((s) => s.color);
+
+  return {
+    id: apiData.id,
+    name: apiData.name || 'Unnamed Gradient',
+    type: rendition.type || 'linear',
+    angle: rendition.angle || 90,
+    aspectRatio: rendition.aspectRatio || 1,
+    interpolation: rendition.interpolation || 'linear',
+    colorStops,
+    coreColors,
+    likes: apiData.likes ?? apiData.appreciations ?? 0,
+    creator: apiData.author?.name || '',
+    tags: apiData.tags || [],
+    hasNextPage: apiData.hasNextPage,
+    _source: 'kuler-gradient',
+    _theme: apiData,
+  };
+}
+
+/**
+ * Parse an array of gradient API responses.
+ * @param {Array} apiDataArray
+ * @returns {Array}
+ */
+export function gradientApiResponsesToGradients(apiDataArray) {
+  if (!Array.isArray(apiDataArray)) return [];
+  return apiDataArray.map(gradientApiResponseToGradient);
+}

--- a/test/services/kuler/CHECKLIST.md
+++ b/test/services/kuler/CHECKLIST.md
@@ -1,0 +1,360 @@
+# Kuler — Test Coverage Checklist
+
+> Comprehensive list of all test cases covered for the **Kuler** plugin
+> and its children (action groups, providers). Update this file whenever tests
+> are added, modified, or removed.
+>
+> Core lifecycle behavior (`ServiceManager` reset/init/registration),
+> `BaseApiService` methods (`get`/`post`/`handleResponse`/`getHeaders`),
+> `BaseActionGroup` base class, and `BaseProvider.safeExecute` are validated
+> by core framework tests and are **not** duplicated here.
+
+---
+
+## Plugin: `KulerPlugin`
+
+**Test file:** `KulerPlugin.test.js`
+
+### Feature Flag Gating (`isActivated`)
+
+- [x] Returns `true` when feature flag is not set
+- [x] Returns `true` when feature flag is explicitly `true`
+- [x] Returns `false` when feature flag is explicitly `false`
+- [x] Returns `true` when `features` key is missing entirely
+- [x] Returns `true` when `appConfig` is `null`
+- [x] Returns `true` when `appConfig` is `undefined`
+- [x] Returns `true` when `features` is `null`
+
+### Action Group Registration
+
+- [x] Registers exactly the five expected action groups (search, explore, theme, gradient, like)
+- [x] Registers a callable handler for every topic across all groups (including EXPLORE)
+- [x] Does not register unhandled `THEME.NAMES` topic
+- [x] Has exactly the right number of registered topics (11)
+
+### Service Name
+
+- [x] `serviceName` returns `"Kuler"`
+
+---
+
+## Action Group: `SearchActions`
+
+**Test file:** `actions/SearchActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Returns a handler for every `KulerTopics.SEARCH` topic
+- [x] Contains no unexpected topic keys
+
+### `buildKulerQuery` (static)
+
+- [x] Defaults to `"term"` when `typeOfQuery` is absent
+- [x] Uses each query type correctly (`term`, `tag`, `hex`, `similarHex`)
+- [x] Handles empty string query
+- [x] Handles special characters in query
+
+### `buildPublishedCheckUrl`
+
+- [x] Constructs base URL from `plugin.baseUrl` + `endpoints.search`
+- [x] Encodes `asset_id` as a JSON query parameter
+- [x] Defaults `assetType` to `GRADIENT`
+- [x] Accepts `THEME` assetType
+- [x] Includes `maxNumber=1`
+
+### `buildSearchUrl`
+
+- [x] Constructs base URL from `plugin.baseUrl` + `endpoints.search`
+- [x] Encodes query parameter
+- [x] Defaults `assetType` to `THEME`
+- [x] Accepts `GRADIENT` assetType
+- [x] Includes `maxNumber=72`
+- [x] Computes `startIndex=0` for page 1
+- [x] Computes `startIndex=72` for page 2
+- [x] Computes `startIndex=144` for page 3
+- [x] Defaults to page 1 when `pageNumber` is missing
+- [x] Defaults to page 1 when `pageNumber` is `null`
+- [x] Handles string `pageNumber` via `parseInt`
+- [x] Includes `metadata=all` when user is logged in with a valid token
+- [x] Omits `metadata=all` when user is logged out
+- [x] Omits `metadata=all` when logged in but token is missing
+- [x] Places `metadata=all` before `startIndex` in URL order
+
+### `fetchThemeList`
+
+- [x] Calls fetch with built URL and GET method
+- [x] Returns parsed response via `handleResponse`
+
+### `fetchGradientList`
+
+- [x] Delegates to `fetchThemeList` with `GRADIENT` assetType
+
+### `makeRequestWithFullUrl`
+
+- [x] Sends headers from `plugin.getHeaders()`
+- [x] Does not attach body for GET
+- [x] Does not attach body for DELETE
+- [x] JSON.stringifies body for POST
+- [x] JSON.stringifies body for PUT
+- [x] Sends FormData as-is and removes Content-Type
+- [x] Does not attach body when body is `null` for POST
+- [x] Delegates response to `plugin.handleResponse`
+
+### `searchPublishedTheme`
+
+- [x] Prepends `baseUrl` for relative paths
+- [x] Uses full URL as-is for `https://` URLs
+- [x] Uses full URL as-is for `http://` URLs
+- [x] Uses GET method
+- [x] Uses `buildPublishedCheckUrl` when passed `{ assetId }` object
+- [x] Respects `assetType` from `{ assetId, assetType }` object
+- [x] Uses GET method for `{ assetId }` path
+
+---
+
+## Action Group: `ExploreActions`
+
+**Test file:** `actions/ExploreActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Returns a handler for every `KulerTopics.EXPLORE` topic
+- [x] Contains no unexpected topic keys
+
+### `buildExploreUrl`
+
+- [x] Constructs base URL from `exploreBaseUrl` + `api` + `assetPath`
+- [x] Defaults to `https://themesb3.adobe.io` when `exploreBaseUrl` is absent
+- [x] Defaults `api` to `/api/v2` when endpoint is absent
+- [x] Defaults `filter` to `"public"`
+- [x] Defaults `sort` to `"create_time"`
+- [x] Defaults `time` to `"month"`
+- [x] Accepts custom `filter`, `sort`, and `time` criteria
+- [x] Omits `sort` and `time` when filter is `"my_themes"`
+- [x] Computes `startIndex=0` for page 1
+- [x] Computes `startIndex=72` for page 2
+- [x] Computes `startIndex=144` for page 3
+- [x] Defaults to page 1 when `pageNumber` is missing
+- [x] Includes `maxNumber=72`
+- [x] Handles string `pageNumber` via `parseInt`
+- [x] Includes `metadata=all` when user is logged in with a valid token
+- [x] Omits `metadata=all` when user is logged out
+- [x] Omits `metadata=all` when logged in but token is missing
+- [x] Places `metadata=all` before `startIndex` in URL order
+
+### `fetchExploreThemes`
+
+- [x] Calls `fetchWithFullUrl` with built URL and GET method
+- [x] Uses configured `themePath`
+- [x] Defaults `themePath` to `/themes` when endpoint is absent
+- [x] Returns parsed response via `handleResponse`
+
+### `fetchExploreGradients`
+
+- [x] Calls `fetchWithFullUrl` with gradient path and GET method
+- [x] Uses configured `gradientPath`
+- [x] Defaults `gradientPath` to `/gradient` when endpoint is absent
+- [x] Returns parsed response via `handleResponse`
+
+---
+
+## Action Group: `ThemeActions`
+
+**Test file:** `actions/ThemeActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Maps GET, SAVE, DELETE topics to functions
+- [x] Has exactly 3 handlers
+
+### URL Builders
+
+| Method | Configured Endpoints | Default Fallback | Piecemeal Fallback |
+|--------|:---:|:---:|:---:|
+| `buildThemeUrl()` | [x] | [x] | [x] |
+| `buildThemeSaveUrl()` | [x] | [x] | — |
+| `buildThemeDeleteUrl()` | [x] (delegates) | — | — |
+
+### `convertSwatchesToKulerFormat` (static)
+
+- [x] Converts RGB swatches
+- [x] Converts CMYK swatches
+- [x] Converts HSV swatches
+- [x] Converts LAB swatches
+- [x] Detects color mode from FIRST swatch only
+- [x] Produces empty values when swatch lacks detected mode data
+- [x] Defaults to RGB when first swatch has no recognized mode key
+- [x] Includes `swatchLabel` from themeData when present
+- [x] Omits `swatchLabel` when themeData has no label at that index
+- [x] Omits `swatchLabel` when `themeData.swatches` is undefined
+- [x] Returns empty array for empty swatches input
+- [x] Handles swatches with zero values correctly
+- [x] Converts all 5 swatches in a realistic multi-swatch RGB theme _(colorWeb parity)_
+
+### `buildThemePostData` (static)
+
+- [x] Builds complete post data with all fields
+- [x] Defaults `name` to `"My Color Theme"`
+- [x] Defaults `tags` to empty array
+- [x] Defaults `harmony.rule` to `"custom"`
+- [x] Defaults `harmony.baseSwatchIndex` to `0`
+- [x] Defaults `harmony.sourceURL` to empty string
+- [x] Lowercases `harmony.mood`
+- [x] Handles undefined `harmony.mood` gracefully
+- [x] Lowercases `harmony.rule`
+- [x] Includes `accessibilityData` when present
+- [x] Omits `accessibilityData` when absent
+- [x] Treats `null` swatches as empty via fallback
+- [x] Treats `undefined` swatches as empty via fallback
+- [x] Does not include unrecognized theme properties in post data (author, source, href, etc.) _(colorWeb parity)_
+
+### Validation
+
+| Action Method | Invalid Inputs | Error Metadata |
+|---------------|:---:|:---:|
+| `fetchTheme(themeId)` — null, undefined, empty string, zero | [x] | [x] |
+| `saveTheme(themeData, ccResponse)` — null/undefined themeData, empty swatches, missing ccResponse fields | [x] | [x] |
+| `deleteTheme(payload)` — null, undefined, missing id, empty id | [x] | [x] |
+
+### saveTheme Integration
+
+- [x] Includes all swatches in POST body for a multi-swatch theme _(colorWeb parity)_
+
+### Edge Cases
+
+- [x] `deleteTheme` returns response wrapped with `themeName`
+- [x] `deleteTheme` handles missing `name` gracefully (undefined `themeName`)
+
+---
+
+## Action Group: `GradientActions`
+
+**Test file:** `actions/GradientActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Returns a handler for every `KulerTopics.GRADIENT` topic
+- [x] Has exactly 2 handlers
+
+### URL Builders
+
+| Method | Configured Endpoints | Default Fallback | Piecemeal Fallback |
+|--------|:---:|:---:|:---:|
+| `buildGradientSaveUrl()` | [x] | [x] | [x] |
+| `buildGradientDeleteUrl()` | [x] | [x] | — |
+
+### Validation
+
+| Action Method | Invalid Inputs | Error Metadata |
+|---------------|:---:|:---:|
+| `saveGradient(gradientData)` — null, undefined | [x] | [x] |
+| `saveGradient({})` — does NOT throw (truthy) | [x] | — |
+| `deleteGradient(payload)` — null, undefined, missing id, empty id | [x] | [x] |
+
+### saveGradient Integration
+
+- [x] POSTs full gradient structure with multiple stops intact _(colorWeb parity)_
+
+### Edge Cases
+
+- [x] `deleteGradient` returns response wrapped with `gradientName`
+- [x] `deleteGradient` handles missing `name` gracefully (undefined `gradientName`)
+
+---
+
+## Action Group: `LikeActions`
+
+**Test file:** `actions/LikeActions.test.js`
+
+### Structural Correctness (`getHandlers`)
+
+- [x] Maps `KulerTopics.LIKE.UPDATE` to a function
+- [x] Has exactly 1 handler
+
+### URL Builders
+
+| Method | Configured Endpoints | Default Fallback |
+|--------|:---:|:---:|
+| `buildThemeLikeUrl()` | [x] | [x] |
+| `buildThemeUnlikeUrl()` | [x] | [x] |
+
+### Validation
+
+| Action Method | Invalid Inputs | Error Metadata |
+|---------------|:---:|:---:|
+| `updateLikeStatus(payload)` — null, undefined, missing id, empty id | [x] | [x] |
+
+### Like/Unlike Branching
+
+- [x] POSTs to `/likeDuplicate` when user has NOT liked (no `like.user`)
+- [x] POSTs to `/likeDuplicate` when `like` is undefined
+- [x] POSTs with empty object body when liking
+- [x] DELETEs to `/like` when user HAS liked (`like.user` exists)
+- [x] POSTs when `like.user` is `null`
+- [x] POSTs when `like.user` is `undefined`
+- [x] POSTs when `like.user` is boolean `false` _(colorWeb parity)_
+- [x] Returns `undefined` (void)
+
+---
+
+## Provider: `KulerProvider`
+
+**Test file:** `providers/KulerProvider.test.js`
+
+### Delegation Wiring
+
+| Provider Method | Returns Data | Passes Args Correctly |
+|-----------------|:---:|:---:|
+| `searchThemes()` | [x] | [x] |
+| `searchGradients()` | [x] | [x] |
+| `getTheme()` | [x] | [x] |
+| `saveTheme()` | [x] | [x] |
+| `deleteTheme()` | [x] | [x] |
+| `saveGradient()` | [x] | [x] |
+| `deleteGradient()` | [x] | [x] |
+| `updateLike()` | [x] | [x] |
+| `searchPublished()` | [x] | [x] |
+| `exploreThemes()` | [x] | [x] |
+| `exploreGradients()` | [x] | [x] |
+| `checkIfPublished()` | [x] | [x] |
+
+### Param Transformation (`#transformSearchParams`)
+
+- [x] Defaults to page 1 and typeOfQuery `"term"`
+- [x] Passes custom page and typeOfQuery through
+
+### Error Boundary (`safeExecute`)
+
+| Provider Method | Returns `null` on Network Error | Returns `null` on Validation Error |
+|-----------------|:---:|:---:|
+| `searchThemes()` | [x] | — |
+| `searchGradients()` | [x] | — |
+| `getTheme()` | [x] | [x] |
+| `saveTheme()` | — | [x] (null data + empty swatches) |
+| `deleteTheme()` | [x] | [x] |
+| `saveGradient()` | [x] | [x] |
+| `deleteGradient()` | — | [x] |
+| `updateLike()` | [x] | [x] |
+| `searchPublished()` | [x] | — |
+| `exploreThemes()` | [x] | — |
+| `exploreGradients()` | [x] | — |
+| `checkIfPublished()` | [x] | — |
+
+### Logging
+
+- [x] Errors are logged to `window.lana`
+
+### Factory Functions
+
+- [x] `createKulerProvider()` returns `KulerProvider` instance
+- [x] `createKulerProvider()` returns a new instance each call
+
+---
+
+## Coverage Gaps
+
+_No known gaps — ExploreActions, buildPublishedCheckUrl, and provider explore/checkIfPublished tests added February 2026._
+
+---
+
+**Last Updated:** February 2026

--- a/test/services/kuler/KulerPlugin.test.js
+++ b/test/services/kuler/KulerPlugin.test.js
@@ -1,0 +1,102 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import KulerPlugin from '../../../express/code/libs/services/plugins/kuler/KulerPlugin.js';
+import { KulerTopics, KulerActionGroups } from '../../../express/code/libs/services/plugins/kuler/topics.js';
+
+function createTestPlugin(PluginClass, overrides = {}) {
+  return new PluginClass({
+    serviceConfig: {
+      baseSearchUrl: 'https://test.com',
+      apiKey: 'test-key',
+      endpoints: {},
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('KulerPlugin', () => {
+  afterEach(() => sinon.restore());
+
+  // ─── Feature Flag Gating ────────────────────────────────────────────────
+
+  describe('isActivated (feature flag)', () => {
+    let plugin;
+
+    beforeEach(() => {
+      plugin = createTestPlugin(KulerPlugin);
+    });
+
+    [
+      { label: 'ENABLE_KULER not set', config: { features: {} }, expected: true },
+      { label: 'ENABLE_KULER is true', config: { features: { ENABLE_KULER: true } }, expected: true },
+      { label: 'ENABLE_KULER is explicitly false', config: { features: { ENABLE_KULER: false } }, expected: false },
+      { label: 'no features key', config: {}, expected: true },
+      { label: 'null appConfig', config: null, expected: true },
+      { label: 'undefined appConfig', config: undefined, expected: true },
+      { label: 'features is null', config: { features: null }, expected: true },
+    ].forEach(({ label, config, expected }) => {
+      it(`should return ${expected} when ${label}`, () => {
+        expect(plugin.isActivated(config)).to.equal(expected);
+      });
+    });
+  });
+
+  // ─── Action Group Registration ──────────────────────────────────────────
+
+  describe('action group registration', () => {
+    let plugin;
+
+    beforeEach(() => {
+      plugin = createTestPlugin(KulerPlugin);
+    });
+
+    it('should register exactly the five expected action groups (search, explore, theme, gradient, like)', () => {
+      const expected = Object.values(KulerActionGroups);
+      const registered = plugin.getActionGroupNames();
+
+      expect(registered).to.have.lengthOf(expected.length);
+      expected.forEach((group) => {
+        expect(registered).to.include(group);
+      });
+    });
+
+    it('should register a callable handler for every handled topic', () => {
+      const handledTopics = [
+        ...Object.values(KulerTopics.SEARCH),
+        ...Object.values(KulerTopics.EXPLORE),
+        KulerTopics.THEME.GET,
+        KulerTopics.THEME.SAVE,
+        KulerTopics.THEME.DELETE,
+        ...Object.values(KulerTopics.GRADIENT),
+        ...Object.values(KulerTopics.LIKE),
+      ];
+
+      handledTopics.forEach((topic) => {
+        const handler = plugin.topicRegistry.get(topic);
+        expect(handler, `missing handler for topic "${topic}"`).to.be.a('function');
+      });
+    });
+
+    it('should not register stale THEME.NAMES topic (defined in topics.js but unhandled)', () => {
+      expect(plugin.topicRegistry.has(KulerTopics.THEME.NAMES)).to.be.false;
+    });
+
+    it('should have exactly the right number of registered topics (11)', () => {
+      // SEARCH: 3, EXPLORE: 2, THEME: 3 (GET/SAVE/DELETE), GRADIENT: 2, LIKE: 1
+      const expectedCount = 3 + 2 + 3 + 2 + 1;
+      expect(plugin.topicRegistry.size).to.equal(expectedCount);
+    });
+  });
+
+  // ─── serviceName ────────────────────────────────────────────────────────
+
+  describe('serviceName', () => {
+    it('should return "Kuler"', () => {
+      expect(KulerPlugin.serviceName).to.equal('Kuler');
+    });
+  });
+});

--- a/test/services/kuler/actions/ExploreActions.test.js
+++ b/test/services/kuler/actions/ExploreActions.test.js
@@ -1,0 +1,220 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { ExploreActions } from '../../../../express/code/libs/services/plugins/kuler/actions/KulerActions.js';
+import { KulerTopics } from '../../../../express/code/libs/services/plugins/kuler/topics.js';
+import { createMockPlugin, stubFetch } from './helpers.js';
+
+describe('ExploreActions', () => {
+  let actions;
+  let mockPlugin;
+  let fetchStub;
+
+  beforeEach(() => {
+    mockPlugin = createMockPlugin({
+      serviceConfig: {
+        exploreBaseUrl: 'https://themesb3.test.io',
+      },
+      endpoints: {
+        api: '/api/v2',
+        themePath: '/themes',
+        gradientPath: '/gradient',
+      },
+    });
+    actions = new ExploreActions(mockPlugin);
+    fetchStub = stubFetch({ themes: [{ id: 'e-1' }] });
+  });
+
+  afterEach(() => sinon.restore());
+
+  // ─── getHandlers ──────────────────────────────────────────────────────
+
+  describe('getHandlers', () => {
+    it('should map every KulerTopics.EXPLORE value to a function', () => {
+      const handlers = actions.getHandlers();
+      Object.values(KulerTopics.EXPLORE).forEach((topic) => {
+        expect(handlers).to.have.property(topic).that.is.a('function');
+      });
+    });
+
+    it('should have no extra keys beyond KulerTopics.EXPLORE', () => {
+      const handlers = actions.getHandlers();
+      const expected = Object.values(KulerTopics.EXPLORE);
+      expect(Object.keys(handlers)).to.have.lengthOf(expected.length);
+    });
+  });
+
+  // ─── buildExploreUrl ──────────────────────────────────────────────────
+
+  describe('buildExploreUrl', () => {
+    it('should construct base URL from exploreBaseUrl + api + assetPath', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.match(/^https:\/\/themesb3\.test\.io\/api\/v2\/themes\?/);
+    });
+
+    it('should default to https://themesb3.adobe.io when exploreBaseUrl is absent', () => {
+      mockPlugin.serviceConfig.exploreBaseUrl = undefined;
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.match(/^https:\/\/themesb3\.adobe\.io\/api\/v2\/themes\?/);
+    });
+
+    it('should default api to /api/v2 when endpoint is absent', () => {
+      mockPlugin.endpoints.api = undefined;
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('/api/v2/themes');
+    });
+
+    it('should default filter to "public"', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('filter=public');
+    });
+
+    it('should default sort to "create_time"', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('sort=create_time');
+    });
+
+    it('should default time to "month"', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('time=month');
+    });
+
+    it('should accept custom filter, sort, and time criteria', () => {
+      const url = actions.buildExploreUrl('/themes', {
+        filter: 'all',
+        sort: 'like_count',
+        time: 'week',
+      });
+      expect(url).to.include('filter=all');
+      expect(url).to.include('sort=like_count');
+      expect(url).to.include('time=week');
+    });
+
+    // ── my_themes filter branch ──
+
+    it('should omit sort and time when filter is "my_themes"', () => {
+      const url = actions.buildExploreUrl('/themes', { filter: 'my_themes' });
+      expect(url).to.include('filter=my_themes');
+      expect(url).to.not.include('sort=');
+      expect(url).to.not.include('time=');
+    });
+
+    // ── Pagination ──
+
+    it('should compute startIndex=0 for page 1', () => {
+      const url = actions.buildExploreUrl('/themes', { pageNumber: 1 });
+      expect(url).to.include('startIndex=0');
+    });
+
+    it('should compute startIndex=72 for page 2', () => {
+      const url = actions.buildExploreUrl('/themes', { pageNumber: 2 });
+      expect(url).to.include('startIndex=72');
+    });
+
+    it('should compute startIndex=144 for page 3', () => {
+      const url = actions.buildExploreUrl('/themes', { pageNumber: 3 });
+      expect(url).to.include('startIndex=144');
+    });
+
+    it('should default to page 1 when pageNumber is missing', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('startIndex=0');
+    });
+
+    it('should include maxNumber=72', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('maxNumber=72');
+    });
+
+    it('should handle string pageNumber via parseInt', () => {
+      const url = actions.buildExploreUrl('/themes', { pageNumber: '3' });
+      expect(url).to.include('startIndex=144');
+    });
+
+    // ── Auth-dependent metadata ──
+
+    it('should include metadata=all when user is logged in with a valid token', () => {
+      mockPlugin.getAuthState.returns({ isLoggedIn: true, token: 'valid-token' });
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.include('metadata=all');
+    });
+
+    it('should NOT include metadata=all when user is logged out', () => {
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.not.include('metadata=all');
+    });
+
+    it('should NOT include metadata=all when logged in but token is missing', () => {
+      mockPlugin.getAuthState.returns({ isLoggedIn: true, token: undefined });
+      const url = actions.buildExploreUrl('/themes');
+      expect(url).to.not.include('metadata=all');
+    });
+
+    it('should place metadata=all before startIndex in URL order', () => {
+      mockPlugin.getAuthState.returns({ isLoggedIn: true, token: 'valid-token' });
+      const url = actions.buildExploreUrl('/themes');
+      const metaIdx = url.indexOf('metadata=all');
+      const startIdx = url.indexOf('startIndex=');
+      expect(metaIdx).to.be.lessThan(startIdx);
+    });
+  });
+
+  // ─── fetchExploreThemes ───────────────────────────────────────────────
+
+  describe('fetchExploreThemes', () => {
+    it('should call fetchWithFullUrl with built URL and GET method', async () => {
+      await actions.fetchExploreThemes({ filter: 'public', pageNumber: 1 });
+      expect(mockPlugin.handleResponse.calledOnce).to.be.true;
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/themes');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('should use configured themePath', async () => {
+      await actions.fetchExploreThemes();
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/api/v2/themes');
+    });
+
+    it('should default themePath to /themes when endpoint is absent', async () => {
+      mockPlugin.endpoints.themePath = undefined;
+      await actions.fetchExploreThemes();
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/api/v2/themes');
+    });
+
+    it('should return parsed response via handleResponse', async () => {
+      const result = await actions.fetchExploreThemes();
+      expect(result).to.deep.equal({ themes: [{ id: 'e-1' }] });
+    });
+  });
+
+  // ─── fetchExploreGradients ────────────────────────────────────────────
+
+  describe('fetchExploreGradients', () => {
+    it('should call fetchWithFullUrl with gradient path and GET method', async () => {
+      await actions.fetchExploreGradients({ filter: 'public', pageNumber: 1 });
+      expect(mockPlugin.handleResponse.calledOnce).to.be.true;
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/gradient');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('should use configured gradientPath', async () => {
+      await actions.fetchExploreGradients();
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/api/v2/gradient');
+    });
+
+    it('should default gradientPath to /gradient when endpoint is absent', async () => {
+      mockPlugin.endpoints.gradientPath = undefined;
+      await actions.fetchExploreGradients();
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/api/v2/gradient');
+    });
+
+    it('should return parsed response via handleResponse', async () => {
+      const result = await actions.fetchExploreGradients();
+      expect(result).to.deep.equal({ themes: [{ id: 'e-1' }] });
+    });
+  });
+});

--- a/test/services/kuler/actions/GradientActions.test.js
+++ b/test/services/kuler/actions/GradientActions.test.js
@@ -1,0 +1,174 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { GradientActions } from '../../../../express/code/libs/services/plugins/kuler/actions/KulerActions.js';
+import { KulerTopics } from '../../../../express/code/libs/services/plugins/kuler/topics.js';
+import { expectValidationError, createMockPlugin, stubFetch } from './helpers.js';
+
+describe('GradientActions', () => {
+  let actions;
+  let mockPlugin;
+  let fetchStub;
+
+  beforeEach(() => {
+    mockPlugin = createMockPlugin();
+    actions = new GradientActions(mockPlugin);
+    fetchStub = stubFetch({ id: 'grad-1' });
+  });
+
+  afterEach(() => sinon.restore());
+
+  // ─── getHandlers ──────────────────────────────────────────────────────
+
+  describe('getHandlers', () => {
+    it('should map every KulerTopics.GRADIENT value to a function', () => {
+      const handlers = actions.getHandlers();
+      Object.values(KulerTopics.GRADIENT).forEach((topic) => {
+        expect(handlers).to.have.property(topic).that.is.a('function');
+      });
+    });
+
+    it('should have exactly 2 handlers', () => {
+      expect(Object.keys(actions.getHandlers())).to.have.lengthOf(2);
+    });
+  });
+
+  // ─── URL Builders ─────────────────────────────────────────────────────
+
+  describe('buildGradientSaveUrl', () => {
+    it('should build URL from configured endpoints', () => {
+      expect(actions.buildGradientSaveUrl()).to.equal('https://gradient.test.io/api/v2/gradient');
+    });
+
+    it('should fall back to all defaults when endpoints are empty', () => {
+      mockPlugin.serviceConfig = {};
+      mockPlugin.endpoints = {};
+      expect(actions.buildGradientSaveUrl()).to.equal('https://gradient.adobe.io/api/v2/gradient');
+    });
+
+    it('should fall back piecemeal (only gradientBaseUrl set)', () => {
+      mockPlugin.serviceConfig = { gradientBaseUrl: 'https://custom.io' };
+      expect(actions.buildGradientSaveUrl()).to.equal('https://custom.io/api/v2/gradient');
+    });
+  });
+
+  describe('buildGradientDeleteUrl', () => {
+    it('should append gradient ID to save URL', () => {
+      expect(actions.buildGradientDeleteUrl('g-1')).to.equal(
+        'https://gradient.test.io/api/v2/gradient/g-1',
+      );
+    });
+
+    it('should fall back to defaults when endpoints are empty', () => {
+      mockPlugin.serviceConfig = {};
+      mockPlugin.endpoints = {};
+      expect(actions.buildGradientDeleteUrl('g-1')).to.equal(
+        'https://gradient.adobe.io/api/v2/gradient/g-1',
+      );
+    });
+  });
+
+  // ─── saveGradient ─────────────────────────────────────────────────────
+
+  describe('saveGradient', () => {
+    describe('validation', () => {
+      [
+        { label: 'null', input: null },
+        { label: 'undefined', input: undefined },
+      ].forEach(({ label, input }) => {
+        it(`should throw ValidationError for ${label} gradientData`, async () => {
+          await expectValidationError(
+            () => actions.saveGradient(input),
+            (err) => {
+              expect(err.field).to.equal('gradientData');
+              expect(err.serviceName).to.equal('Kuler');
+              expect(err.topic).to.equal('GRADIENT.SAVE');
+            },
+          );
+        });
+      });
+
+      it('should NOT throw for empty object (falsy check only)', async () => {
+        // {} is truthy, so it passes validation and POSTs
+        await actions.saveGradient({});
+        expect(fetchStub.calledOnce).to.be.true;
+      });
+    });
+
+    it('should POST gradient data to correct URL', async () => {
+      const data = { name: 'Blue Fade', stops: [{ color: '#0000FF' }] };
+      await actions.saveGradient(data);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://gradient.test.io/api/v2/gradient');
+      expect(opts.method).to.equal('POST');
+      expect(JSON.parse(opts.body)).to.deep.equal(data);
+    });
+
+    // ── colorWeb parity ──
+
+    it('should POST full gradient structure with multiple stops intact', async () => {
+      const gradientData = {
+        name: 'gradient_colorful',
+        stops: [
+          { color: [{ mode: 'RGB', value: { r: 71, g: 56, b: 215 } }], position: 0 },
+          { color: [{ mode: 'RGB', value: { r: 131, g: 114, b: 157 } }], position: 0.5 },
+          { color: [{ mode: 'RGB', value: { r: 86, g: 18, b: 183 } }], position: 1 },
+        ],
+        interpolation: 'linear',
+        angle: 0,
+        aspectRatio: 1,
+        source: 'KULER',
+        type: 'linear',
+      };
+      await actions.saveGradient(gradientData);
+
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/gradient');
+      const body = JSON.parse(opts.body);
+      expect(body.stops).to.have.lengthOf(3);
+      expect(body.interpolation).to.equal('linear');
+      expect(body.type).to.equal('linear');
+      expect(body.source).to.equal('KULER');
+    });
+  });
+
+  // ─── deleteGradient ───────────────────────────────────────────────────
+
+  describe('deleteGradient', () => {
+    describe('validation', () => {
+      [
+        { label: 'null payload', input: null },
+        { label: 'undefined payload', input: undefined },
+        { label: 'missing id', input: { name: 'x' } },
+        { label: 'empty id', input: { id: '', name: 'x' } },
+      ].forEach(({ label, input }) => {
+        it(`should throw ValidationError for ${label}`, async () => {
+          await expectValidationError(
+            () => actions.deleteGradient(input),
+            (err) => {
+              expect(err.field).to.equal('payload.id');
+              expect(err.topic).to.equal('GRADIENT.DELETE');
+            },
+          );
+        });
+      });
+    });
+
+    it('should DELETE to correct URL', async () => {
+      await actions.deleteGradient({ id: 'g-del', name: 'Old' });
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://gradient.test.io/api/v2/gradient/g-del');
+      expect(opts.method).to.equal('DELETE');
+    });
+
+    it('should return response wrapped with gradientName', async () => {
+      const result = await actions.deleteGradient({ id: 'g', name: 'Sunset Grad' });
+      expect(result.gradientName).to.equal('Sunset Grad');
+      expect(result.response).to.deep.equal({ id: 'grad-1' });
+    });
+
+    it('should handle missing name gracefully (undefined gradientName)', async () => {
+      const result = await actions.deleteGradient({ id: 'g' });
+      expect(result.gradientName).to.be.undefined;
+    });
+  });
+});

--- a/test/services/kuler/actions/LikeActions.test.js
+++ b/test/services/kuler/actions/LikeActions.test.js
@@ -1,0 +1,150 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { LikeActions } from '../../../../express/code/libs/services/plugins/kuler/actions/KulerActions.js';
+import { KulerTopics } from '../../../../express/code/libs/services/plugins/kuler/topics.js';
+import { expectValidationError, createMockPlugin, stubFetch } from './helpers.js';
+
+describe('LikeActions', () => {
+  let actions;
+  let mockPlugin;
+  let fetchStub;
+
+  beforeEach(() => {
+    mockPlugin = createMockPlugin();
+    actions = new LikeActions(mockPlugin);
+    fetchStub = stubFetch({});
+  });
+
+  afterEach(() => sinon.restore());
+
+  // ─── getHandlers ──────────────────────────────────────────────────────
+
+  describe('getHandlers', () => {
+    it('should map KulerTopics.LIKE.UPDATE to a function', () => {
+      const handlers = actions.getHandlers();
+      expect(handlers).to.have.property(KulerTopics.LIKE.UPDATE).that.is.a('function');
+    });
+
+    it('should have exactly 1 handler', () => {
+      expect(Object.keys(actions.getHandlers())).to.have.lengthOf(1);
+    });
+  });
+
+  // ─── URL Builders ─────────────────────────────────────────────────────
+
+  describe('buildThemeLikeUrl', () => {
+    it('should build like URL with /likeDuplicate suffix', () => {
+      expect(actions.buildThemeLikeUrl('t-1')).to.equal(
+        'https://asset.test.io/themes/t-1/likeDuplicate',
+      );
+    });
+
+    it('should fall back to defaults when endpoints are empty', () => {
+      mockPlugin.endpoints = {};
+      expect(actions.buildThemeLikeUrl('t-1')).to.equal(
+        'https://asset.adobe.io/themes/t-1/likeDuplicate',
+      );
+    });
+  });
+
+  describe('buildThemeUnlikeUrl', () => {
+    it('should build unlike URL with /like suffix', () => {
+      expect(actions.buildThemeUnlikeUrl('t-1')).to.equal(
+        'https://asset.test.io/themes/t-1/like',
+      );
+    });
+
+    it('should fall back to defaults when endpoints are empty', () => {
+      mockPlugin.endpoints = {};
+      expect(actions.buildThemeUnlikeUrl('t-1')).to.equal(
+        'https://asset.adobe.io/themes/t-1/like',
+      );
+    });
+  });
+
+  // ─── updateLikeStatus ─────────────────────────────────────────────────
+
+  describe('updateLikeStatus', () => {
+    describe('validation', () => {
+      [
+        { label: 'null payload', input: null },
+        { label: 'undefined payload', input: undefined },
+        { label: 'missing id', input: { like: {} } },
+        { label: 'empty id', input: { id: '', like: {} } },
+      ].forEach(({ label, input }) => {
+        it(`should throw ValidationError for ${label}`, async () => {
+          await expectValidationError(
+            () => actions.updateLikeStatus(input),
+            (err) => {
+              expect(err.field).to.equal('payload.id');
+              expect(err.serviceName).to.equal('Kuler');
+              expect(err.topic).to.equal('LIKE.UPDATE');
+            },
+          );
+        });
+      });
+    });
+
+    describe('like/unlike branching', () => {
+      it('should POST to /likeDuplicate when user has NOT liked (no like.user)', async () => {
+        await actions.updateLikeStatus({ id: 't-1', like: {}, source: 'KULER' });
+        const [url, opts] = fetchStub.firstCall.args;
+        expect(url).to.include('/likeDuplicate');
+        expect(opts.method).to.equal('POST');
+      });
+
+      it('should POST to /likeDuplicate when like is undefined', async () => {
+        await actions.updateLikeStatus({ id: 't-1', source: 'KULER' });
+        const [url, opts] = fetchStub.firstCall.args;
+        expect(url).to.include('/likeDuplicate');
+        expect(opts.method).to.equal('POST');
+      });
+
+      it('should POST with empty object body when liking', async () => {
+        await actions.updateLikeStatus({ id: 't-1', like: {} });
+        const [, opts] = fetchStub.firstCall.args;
+        expect(JSON.parse(opts.body)).to.deep.equal({});
+      });
+
+      it('should DELETE to /like when user HAS liked (like.user exists)', async () => {
+        await actions.updateLikeStatus({
+          id: 't-1',
+          like: { user: { id: 'u1' } },
+          source: 'KULER',
+        });
+        const [url, opts] = fetchStub.firstCall.args;
+        expect(url).to.equal('https://asset.test.io/themes/t-1/like');
+        expect(url).to.not.include('likeDuplicate');
+        expect(opts.method).to.equal('DELETE');
+      });
+
+      it('should POST when like.user is null', async () => {
+        await actions.updateLikeStatus({ id: 't-1', like: { user: null } });
+        const [url, opts] = fetchStub.firstCall.args;
+        expect(url).to.include('/likeDuplicate');
+        expect(opts.method).to.equal('POST');
+      });
+
+      it('should POST when like.user is undefined', async () => {
+        await actions.updateLikeStatus({ id: 't-1', like: { user: undefined } });
+        const [url, opts] = fetchStub.firstCall.args;
+        expect(url).to.include('/likeDuplicate');
+        expect(opts.method).to.equal('POST');
+      });
+
+      it('should not return a value (void)', async () => {
+        const result = await actions.updateLikeStatus({ id: 't-1', like: {} });
+        expect(result).to.be.undefined;
+      });
+
+      // ── colorWeb parity ──
+
+      it('should POST (like) when like.user is boolean false', async () => {
+        await actions.updateLikeStatus({ id: 't-1', like: { count: 0, user: false } });
+        const [url, opts] = fetchStub.firstCall.args;
+        expect(url).to.include('/likeDuplicate');
+        expect(opts.method).to.equal('POST');
+      });
+    });
+  });
+});

--- a/test/services/kuler/actions/SearchActions.test.js
+++ b/test/services/kuler/actions/SearchActions.test.js
@@ -1,0 +1,314 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { SearchActions } from '../../../../express/code/libs/services/plugins/kuler/actions/KulerActions.js';
+import { KulerTopics } from '../../../../express/code/libs/services/plugins/kuler/topics.js';
+import { createMockPlugin, stubFetch } from './helpers.js';
+
+describe('SearchActions', () => {
+  let actions;
+  let mockPlugin;
+  let fetchStub;
+
+  beforeEach(() => {
+    mockPlugin = createMockPlugin();
+    actions = new SearchActions(mockPlugin);
+    fetchStub = stubFetch({ themes: [{ id: '1' }] });
+  });
+
+  afterEach(() => sinon.restore());
+
+  // ─── getHandlers ──────────────────────────────────────────────────────
+
+  describe('getHandlers', () => {
+    it('should map every KulerTopics.SEARCH value to a function', () => {
+      const handlers = actions.getHandlers();
+      Object.values(KulerTopics.SEARCH).forEach((topic) => {
+        expect(handlers).to.have.property(topic).that.is.a('function');
+      });
+    });
+
+    it('should have no extra keys beyond KulerTopics.SEARCH', () => {
+      const handlers = actions.getHandlers();
+      const expected = Object.values(KulerTopics.SEARCH);
+      expect(Object.keys(handlers)).to.have.lengthOf(expected.length);
+    });
+  });
+
+  // ─── buildKulerQuery (static) ─────────────────────────────────────────
+
+  describe('buildKulerQuery', () => {
+    it('should default to "term" when typeOfQuery is absent', () => {
+      const result = JSON.parse(SearchActions.buildKulerQuery({ main: 'sunset' }));
+      expect(result).to.deep.equal({ term: 'sunset' });
+    });
+
+    ['term', 'tag', 'hex', 'similarHex'].forEach((type) => {
+      it(`should use "${type}" as the query key`, () => {
+        const result = JSON.parse(SearchActions.buildKulerQuery({ main: 'val', typeOfQuery: type }));
+        expect(result).to.have.property(type, 'val');
+      });
+    });
+
+    it('should handle empty string query', () => {
+      const result = JSON.parse(SearchActions.buildKulerQuery({ main: '' }));
+      expect(result).to.deep.equal({ term: '' });
+    });
+
+    it('should handle special characters in query', () => {
+      const query = '#FF00FF & "quoted"';
+      const result = JSON.parse(SearchActions.buildKulerQuery({ main: query }));
+      expect(result.term).to.equal(query);
+    });
+  });
+
+  // ─── buildSearchUrl ───────────────────────────────────────────────────
+
+  describe('buildSearchUrl', () => {
+    it('should construct base URL from plugin.baseUrl + endpoints.search', () => {
+      const url = actions.buildSearchUrl({ main: 'test', pageNumber: 1 });
+      expect(url).to.match(/^https:\/\/test-kuler\.com\/search\?/);
+    });
+
+    it('should encode the query parameter', () => {
+      const url = actions.buildSearchUrl({ main: 'sunset', pageNumber: 1 });
+      expect(url).to.include('q=%7B%22term%22%3A%22sunset%22%7D');
+    });
+
+    it('should default assetType to THEME', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      expect(url).to.include('assetType=THEME');
+    });
+
+    it('should accept GRADIENT assetType', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 }, 'GRADIENT');
+      expect(url).to.include('assetType=GRADIENT');
+    });
+
+    it('should include maxNumber=72', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      expect(url).to.include('maxNumber=72');
+    });
+
+    // ── Pagination edge cases ──
+
+    it('should compute startIndex=0 for page 1', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      expect(url).to.include('startIndex=0');
+    });
+
+    it('should compute startIndex=72 for page 2', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 2 });
+      expect(url).to.include('startIndex=72');
+    });
+
+    it('should compute startIndex=144 for page 3', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 3 });
+      expect(url).to.include('startIndex=144');
+    });
+
+    it('should default to page 1 when pageNumber is missing', () => {
+      const url = actions.buildSearchUrl({ main: 'x' });
+      expect(url).to.include('startIndex=0');
+    });
+
+    it('should default to page 1 when pageNumber is null', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: null });
+      expect(url).to.include('startIndex=0');
+    });
+
+    it('should handle string pageNumber via parseInt', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: '3' });
+      expect(url).to.include('startIndex=144');
+    });
+
+    // ── Auth-dependent metadata ──
+
+    it('should include metadata=all when user is logged in with a valid token', () => {
+      mockPlugin.getAuthState.returns({ isLoggedIn: true, token: 'valid-token' });
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      expect(url).to.include('metadata=all');
+    });
+
+    it('should NOT include metadata=all when user is logged out', () => {
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      expect(url).to.not.include('metadata=all');
+    });
+
+    it('should NOT include metadata=all when logged in but token is missing', () => {
+      mockPlugin.getAuthState.returns({ isLoggedIn: true, token: undefined });
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      expect(url).to.not.include('metadata=all');
+    });
+
+    it('should place metadata=all before startIndex in URL order', () => {
+      mockPlugin.getAuthState.returns({ isLoggedIn: true, token: 'valid-token' });
+      const url = actions.buildSearchUrl({ main: 'x', pageNumber: 1 });
+      const metaIdx = url.indexOf('metadata=all');
+      const startIdx = url.indexOf('startIndex=');
+      expect(metaIdx).to.be.lessThan(startIdx);
+    });
+  });
+
+  // ─── buildPublishedCheckUrl ──────────────────────────────────────────
+
+  describe('buildPublishedCheckUrl', () => {
+    it('should construct URL from plugin.baseUrl + endpoints.search', () => {
+      const url = actions.buildPublishedCheckUrl('asset-123');
+      expect(url).to.match(/^https:\/\/test-kuler\.com\/search\?/);
+    });
+
+    it('should encode the asset_id as a JSON query parameter', () => {
+      const url = actions.buildPublishedCheckUrl('asset-123');
+      const expected = encodeURIComponent(JSON.stringify({ asset_id: 'asset-123' }));
+      expect(url).to.include(`q=${expected}`);
+    });
+
+    it('should default assetType to GRADIENT', () => {
+      const url = actions.buildPublishedCheckUrl('asset-123');
+      expect(url).to.include('assetType=GRADIENT');
+    });
+
+    it('should accept THEME assetType', () => {
+      const url = actions.buildPublishedCheckUrl('asset-123', 'THEME');
+      expect(url).to.include('assetType=THEME');
+    });
+
+    it('should include maxNumber=1', () => {
+      const url = actions.buildPublishedCheckUrl('asset-123');
+      expect(url).to.include('maxNumber=1');
+    });
+  });
+
+  // ─── fetchThemeList ───────────────────────────────────────────────────
+
+  describe('fetchThemeList', () => {
+    it('should call fetch with built URL and GET method', async () => {
+      await actions.fetchThemeList({ main: 'sunset', pageNumber: 1 });
+      expect(fetchStub.calledOnce).to.be.true;
+
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('assetType=THEME');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('should return parsed response via handleResponse', async () => {
+      const result = await actions.fetchThemeList({ main: 'test', pageNumber: 1 });
+      expect(result).to.deep.equal({ themes: [{ id: '1' }] });
+      expect(mockPlugin.handleResponse.calledOnce).to.be.true;
+    });
+  });
+
+  // ─── fetchGradientList ────────────────────────────────────────────────
+
+  describe('fetchGradientList', () => {
+    it('should delegate to fetchThemeList with GRADIENT assetType', async () => {
+      await actions.fetchGradientList({ main: 'blue', pageNumber: 1 });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('assetType=GRADIENT');
+    });
+  });
+
+  // ─── makeRequestWithFullUrl ───────────────────────────────────────────
+
+  describe('makeRequestWithFullUrl', () => {
+    it('should send headers from plugin.getHeaders()', async () => {
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'GET');
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.headers['x-api-key']).to.equal('test-key');
+    });
+
+    it('should not attach body for GET even when body arg is provided', async () => {
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'GET', { data: 1 });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.body).to.be.undefined;
+    });
+
+    it('should not attach body for DELETE even when body arg is provided', async () => {
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'DELETE', { data: 1 });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.body).to.be.undefined;
+    });
+
+    it('should JSON.stringify body for POST', async () => {
+      const body = { name: 'theme' };
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'POST', body);
+      const [, opts] = fetchStub.firstCall.args;
+      expect(JSON.parse(opts.body)).to.deep.equal(body);
+    });
+
+    it('should JSON.stringify body for PUT', async () => {
+      const body = { name: 'updated' };
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'PUT', body);
+      const [, opts] = fetchStub.firstCall.args;
+      expect(JSON.parse(opts.body)).to.deep.equal(body);
+    });
+
+    it('should send FormData as-is and remove Content-Type', async () => {
+      const formData = new FormData();
+      formData.append('file', 'data');
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'POST', formData);
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.body).to.be.instanceOf(FormData);
+      expect(opts.headers['Content-Type']).to.be.undefined;
+    });
+
+    it('should not attach body when body is null for POST', async () => {
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'POST', null);
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.body).to.be.undefined;
+    });
+
+    it('should delegate response to plugin.handleResponse', async () => {
+      await actions.makeRequestWithFullUrl('https://api.test/x', 'GET');
+      expect(mockPlugin.handleResponse.calledOnce).to.be.true;
+    });
+  });
+
+  // ─── searchPublishedTheme ─────────────────────────────────────────────
+
+  describe('searchPublishedTheme', () => {
+    it('should prepend baseUrl for relative paths', async () => {
+      await actions.searchPublishedTheme('/themes/123');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://test-kuler.com/themes/123');
+    });
+
+    it('should use full URL as-is for https:// URLs', async () => {
+      await actions.searchPublishedTheme('https://custom.com/t/1');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://custom.com/t/1');
+    });
+
+    it('should use full URL as-is for http:// URLs', async () => {
+      await actions.searchPublishedTheme('http://custom.com/t/1');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.equal('http://custom.com/t/1');
+    });
+
+    it('should use GET method', async () => {
+      await actions.searchPublishedTheme('/themes/123');
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('should use buildPublishedCheckUrl when passed { assetId } object', async () => {
+      await actions.searchPublishedTheme({ assetId: 'abc-456' });
+      const [url] = fetchStub.firstCall.args;
+      const expected = encodeURIComponent(JSON.stringify({ asset_id: 'abc-456' }));
+      expect(url).to.include(`q=${expected}`);
+      expect(url).to.include('assetType=GRADIENT');
+    });
+
+    it('should respect assetType from { assetId, assetType } object', async () => {
+      await actions.searchPublishedTheme({ assetId: 'abc-456', assetType: 'THEME' });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('assetType=THEME');
+    });
+
+    it('should use GET method for { assetId } path', async () => {
+      await actions.searchPublishedTheme({ assetId: 'abc-456' });
+      const [, opts] = fetchStub.firstCall.args;
+      expect(opts.method).to.equal('GET');
+    });
+  });
+});

--- a/test/services/kuler/actions/ThemeActions.test.js
+++ b/test/services/kuler/actions/ThemeActions.test.js
@@ -1,0 +1,488 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { ThemeActions } from '../../../../express/code/libs/services/plugins/kuler/actions/KulerActions.js';
+import { KulerTopics } from '../../../../express/code/libs/services/plugins/kuler/topics.js';
+import { expectValidationError, createMockPlugin, stubFetch } from './helpers.js';
+
+describe('ThemeActions', () => {
+  let actions;
+  let mockPlugin;
+  let fetchStub;
+
+  beforeEach(() => {
+    mockPlugin = createMockPlugin();
+    actions = new ThemeActions(mockPlugin);
+    fetchStub = stubFetch({ id: 'theme-1' });
+  });
+
+  afterEach(() => sinon.restore());
+
+  // ─── getHandlers ──────────────────────────────────────────────────────
+
+  describe('getHandlers', () => {
+    it('should map GET, SAVE, DELETE topics to functions', () => {
+      const handlers = actions.getHandlers();
+      [KulerTopics.THEME.GET, KulerTopics.THEME.SAVE, KulerTopics.THEME.DELETE].forEach((t) => {
+        expect(handlers).to.have.property(t).that.is.a('function');
+      });
+    });
+
+    it('should have exactly 3 handlers', () => {
+      expect(Object.keys(actions.getHandlers())).to.have.lengthOf(3);
+    });
+  });
+
+  // ─── URL Builders ─────────────────────────────────────────────────────
+
+  describe('buildThemeUrl', () => {
+    it('should build URL from configured endpoints', () => {
+      expect(actions.buildThemeUrl('abc')).to.equal('https://themes.test.io/api/v2/themes/abc');
+    });
+
+    it('should fall back to defaults when endpoints are empty', () => {
+      mockPlugin.serviceConfig = {};
+      mockPlugin.endpoints = {};
+      expect(actions.buildThemeUrl('abc')).to.equal('https://themes.adobe.io/api/v2/themes/abc');
+    });
+
+    it('should fall back piecemeal (only themeBaseUrl set)', () => {
+      mockPlugin.serviceConfig = { themeBaseUrl: 'https://custom.io' };
+      expect(actions.buildThemeUrl('x')).to.equal('https://custom.io/api/v2/themes/x');
+    });
+  });
+
+  describe('buildThemeSaveUrl', () => {
+    it('should build URL without trailing ID', () => {
+      expect(actions.buildThemeSaveUrl()).to.equal('https://themes.test.io/api/v2/themes');
+    });
+
+    it('should fall back to defaults when endpoints are empty', () => {
+      mockPlugin.serviceConfig = {};
+      mockPlugin.endpoints = {};
+      expect(actions.buildThemeSaveUrl()).to.equal('https://themes.adobe.io/api/v2/themes');
+    });
+  });
+
+  describe('buildThemeDeleteUrl', () => {
+    it('should match buildThemeUrl (delegates)', () => {
+      expect(actions.buildThemeDeleteUrl('del-1')).to.equal(actions.buildThemeUrl('del-1'));
+    });
+  });
+
+  // ─── convertSwatchesToKulerFormat (static) ────────────────────────────
+
+  describe('convertSwatchesToKulerFormat', () => {
+    it('should convert RGB swatches', () => {
+      const swatches = [{ rgb: { r: 255, g: 128, b: 0 } }, { rgb: { r: 0, g: 0, b: 255 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result).to.have.lengthOf(2);
+      expect(result[0]).to.deep.include({ mode: 'rgb', values: [255, 128, 0] });
+      expect(result[1]).to.deep.include({ mode: 'rgb', values: [0, 0, 255] });
+    });
+
+    it('should convert CMYK swatches', () => {
+      const swatches = [{ cmyk: { c: 0, m: 100, y: 100, k: 0 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result[0]).to.deep.include({ mode: 'cmyk', values: [0, 100, 100, 0] });
+    });
+
+    it('should convert HSV swatches', () => {
+      const swatches = [{ hsv: { h: 180, s: 50, v: 100 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result[0]).to.deep.include({ mode: 'hsv', values: [180, 50, 100] });
+    });
+
+    it('should convert LAB swatches', () => {
+      const swatches = [{ lab: { l: 50, a: 20, b: -30 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result[0]).to.deep.include({ mode: 'lab', values: [50, 20, -30] });
+    });
+
+    it('should detect color mode from the FIRST swatch only', () => {
+      // First swatch is CMYK; second has RGB but should still be treated as CMYK
+      const swatches = [
+        { cmyk: { c: 0, m: 0, y: 0, k: 100 } },
+        { cmyk: { c: 50, m: 0, y: 0, k: 0 }, rgb: { r: 0, g: 0, b: 0 } },
+      ];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result[0].mode).to.equal('cmyk');
+      expect(result[1].mode).to.equal('cmyk');
+    });
+
+    it('should produce empty values when swatch lacks the detected mode data', () => {
+      // First swatch has CMYK (sets mode), second lacks cmyk property
+      const swatches = [
+        { cmyk: { c: 0, m: 0, y: 0, k: 0 } },
+        { rgb: { r: 255, g: 0, b: 0 } }, // no cmyk key
+      ];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result[1].values).to.deep.equal([]);
+    });
+
+    it('should default to RGB mode when first swatch has no recognized mode key', () => {
+      const swatches = [{ rgb: { r: 10, g: 20, b: 30 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+      expect(result[0].mode).to.equal('rgb');
+    });
+
+    it('should include swatchLabel from themeData when present', () => {
+      const swatches = [{ rgb: { r: 255, g: 0, b: 0 } }];
+      const themeData = { swatches: [{ label: 'Primary Red' }] };
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, themeData);
+
+      expect(result[0].swatchLabel).to.equal('Primary Red');
+    });
+
+    it('should omit swatchLabel when themeData has no label at that index', () => {
+      const swatches = [{ rgb: { r: 0, g: 0, b: 0 } }, { rgb: { r: 255, g: 255, b: 255 } }];
+      const themeData = { swatches: [{ label: 'Black' }] }; // only index 0 has label
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, themeData);
+
+      expect(result[0].swatchLabel).to.equal('Black');
+      expect(result[1]).to.not.have.property('swatchLabel');
+    });
+
+    it('should omit swatchLabel when themeData.swatches is undefined', () => {
+      const swatches = [{ rgb: { r: 0, g: 0, b: 0 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+      expect(result[0]).to.not.have.property('swatchLabel');
+    });
+
+    it('should return empty array for empty swatches input', () => {
+      expect(ThemeActions.convertSwatchesToKulerFormat([], {})).to.deep.equal([]);
+    });
+
+    it('should handle swatches with zero values correctly', () => {
+      const swatches = [{ rgb: { r: 0, g: 0, b: 0 } }];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+      expect(result[0].values).to.deep.equal([0, 0, 0]);
+    });
+
+    // ── colorWeb parity ──
+
+    it('should convert all 5 swatches in a realistic multi-swatch RGB theme', () => {
+      const swatches = [
+        { rgb: { r: 71, g: 56, b: 215 } },
+        { rgb: { r: 131, g: 114, b: 157 } },
+        { rgb: { r: 86, g: 18, b: 183 } },
+        { rgb: { r: 44, g: 30, b: 120 } },
+        { rgb: { r: 22, g: 10, b: 78 } },
+      ];
+      const result = ThemeActions.convertSwatchesToKulerFormat(swatches, {});
+
+      expect(result).to.have.lengthOf(5);
+      result.forEach((s) => {
+        expect(s.mode).to.equal('rgb');
+        expect(s.values).to.have.lengthOf(3);
+      });
+      expect(result[0].values).to.deep.equal([71, 56, 215]);
+      expect(result[4].values).to.deep.equal([22, 10, 78]);
+    });
+  });
+
+  // ─── buildThemePostData (static) ──────────────────────────────────────
+
+  describe('buildThemePostData', () => {
+    const ccResponse = { id: 'asset-1', libraryid: 'lib-1' };
+
+    it('should build complete post data with all fields', () => {
+      const themeData = {
+        name: 'Sunset',
+        swatches: [{ rgb: { r: 255, g: 128, b: 0 } }],
+        tags: ['warm', 'sunset'],
+        harmony: {
+          baseSwatchIndex: 2,
+          mood: 'VIBRANT',
+          rule: 'Analogous',
+          sourceURL: 'https://source.com',
+        },
+      };
+      const result = ThemeActions.buildThemePostData(themeData, ccResponse);
+
+      expect(result.name).to.equal('Sunset');
+      expect(result.swatches).to.have.lengthOf(1);
+      expect(result.assets).to.deep.equal({ assetid: 'asset-1', libraryid: 'lib-1' });
+      expect(result.tags).to.deep.equal(['warm', 'sunset']);
+      expect(result.harmony).to.deep.equal({
+        baseSwatchIndex: 2,
+        mood: 'vibrant',
+        rule: 'analogous',
+        sourceURL: 'https://source.com',
+      });
+    });
+
+    it('should default name to "My Color Theme"', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result.name).to.equal('My Color Theme');
+    });
+
+    it('should default tags to empty array', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result.tags).to.deep.equal([]);
+    });
+
+    it('should default harmony.rule to "custom"', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result.harmony.rule).to.equal('custom');
+    });
+
+    it('should default harmony.baseSwatchIndex to 0', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result.harmony.baseSwatchIndex).to.equal(0);
+    });
+
+    it('should default harmony.sourceURL to empty string', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result.harmony.sourceURL).to.equal('');
+    });
+
+    it('should lowercase harmony.mood', () => {
+      const result = ThemeActions.buildThemePostData(
+        { swatches: [], harmony: { mood: 'DARK' } },
+        ccResponse,
+      );
+      expect(result.harmony.mood).to.equal('dark');
+    });
+
+    it('should handle undefined harmony.mood gracefully', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result.harmony.mood).to.be.undefined;
+    });
+
+    it('should lowercase harmony.rule', () => {
+      const result = ThemeActions.buildThemePostData(
+        { swatches: [], harmony: { rule: 'TRIAD' } },
+        ccResponse,
+      );
+      expect(result.harmony.rule).to.equal('triad');
+    });
+
+    it('should include accessibilityData when present', () => {
+      const themeData = { swatches: [], accessibilityData: { wcag: 'AA' } };
+      const result = ThemeActions.buildThemePostData(themeData, ccResponse);
+      expect(result.accessibilityData).to.deep.equal({ wcag: 'AA' });
+    });
+
+    it('should omit accessibilityData when absent', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: [] }, ccResponse);
+      expect(result).to.not.have.property('accessibilityData');
+    });
+
+    it('should treat null swatches as empty via fallback', () => {
+      const result = ThemeActions.buildThemePostData({ swatches: null }, ccResponse);
+      expect(result.swatches).to.deep.equal([]);
+    });
+
+    it('should treat undefined swatches as empty via fallback', () => {
+      const result = ThemeActions.buildThemePostData({}, ccResponse);
+      expect(result.swatches).to.deep.equal([]);
+    });
+
+    // ── colorWeb parity ──
+
+    it('should not include unrecognized theme properties in post data', () => {
+      const themeData = {
+        name: 'ROYAL BLUE HUES',
+        swatches: [{ rgb: { r: 71, g: 56, b: 215 } }],
+        tags: [{ value: 'glowing' }],
+        harmony: { baseSwatchIndex: 4, mood: 'custom', rule: 'monochromatic', sourceURL: '' },
+        author: { guid: 'F17BE33C569FF3F77F000101@AdobeID', name: 'Christian DeVito' },
+        source: 'KULER',
+        href: 'https://color.adobe.com/ROYAL-BLUE-HUES-color-theme-8775504/',
+        id: '8775504',
+        like: { count: 0, user: false },
+        view: { count: 0, user: false },
+        themeSavedToCCLibraries: { value: false },
+      };
+      const result = ThemeActions.buildThemePostData(themeData, ccResponse);
+
+      expect(result).to.have.all.keys('name', 'swatches', 'assets', 'tags', 'harmony');
+      expect(result).to.not.have.any.keys('author', 'source', 'href', 'id', 'like', 'view', 'themeSavedToCCLibraries');
+      expect(result.harmony.rule).to.equal('monochromatic');
+      expect(result.harmony.baseSwatchIndex).to.equal(4);
+    });
+  });
+
+  // ─── fetchTheme ───────────────────────────────────────────────────────
+
+  describe('fetchTheme', () => {
+    describe('validation', () => {
+      [
+        { label: 'null', input: null },
+        { label: 'undefined', input: undefined },
+        { label: 'empty string', input: '' },
+        { label: 'zero (falsy)', input: 0 },
+      ].forEach(({ label, input }) => {
+        it(`should throw ValidationError for ${label}`, async () => {
+          await expectValidationError(
+            () => actions.fetchTheme(input),
+            (err) => {
+              expect(err.field).to.equal('themeId');
+              expect(err.serviceName).to.equal('Kuler');
+              expect(err.topic).to.equal('THEME.GET');
+            },
+          );
+        });
+      });
+    });
+
+    it('should call correct theme URL with GET', async () => {
+      await actions.fetchTheme('t-123');
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://themes.test.io/api/v2/themes/t-123');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('should return parsed response', async () => {
+      const result = await actions.fetchTheme('t-123');
+      expect(result).to.deep.equal({ id: 'theme-1' });
+    });
+  });
+
+  // ─── saveTheme ────────────────────────────────────────────────────────
+
+  describe('saveTheme', () => {
+    const validTheme = { name: 'T', swatches: [{ rgb: { r: 0, g: 0, b: 0 } }] };
+    const validCC = { id: 'a-1', libraryid: 'l-1' };
+
+    describe('validation', () => {
+      it('should throw when themeData is null', async () => {
+        await expectValidationError(
+          () => actions.saveTheme(null, validCC),
+          (err) => {
+            expect(err.field).to.equal('themeData');
+            expect(err.topic).to.equal('THEME.SAVE');
+          },
+        );
+      });
+
+      it('should throw when themeData is undefined', async () => {
+        await expectValidationError(() => actions.saveTheme(undefined, validCC));
+      });
+
+      it('should throw when swatches is empty array', async () => {
+        await expectValidationError(
+          () => actions.saveTheme({ swatches: [] }, validCC),
+          (err) => expect(err.field).to.equal('themeData.swatches'),
+        );
+      });
+
+      it('should throw when swatches is undefined', async () => {
+        await expectValidationError(
+          () => actions.saveTheme({}, validCC),
+          (err) => expect(err.field).to.equal('themeData.swatches'),
+        );
+      });
+
+      it('should throw when ccLibrariesResponse is null', async () => {
+        await expectValidationError(
+          () => actions.saveTheme(validTheme, null),
+          (err) => expect(err.field).to.equal('ccLibrariesResponse.id'),
+        );
+      });
+
+      it('should throw when ccLibrariesResponse.id is missing', async () => {
+        await expectValidationError(
+          () => actions.saveTheme(validTheme, { libraryid: 'l' }),
+          (err) => expect(err.field).to.equal('ccLibrariesResponse.id'),
+        );
+      });
+
+      it('should throw when ccLibrariesResponse.libraryid is missing', async () => {
+        await expectValidationError(
+          () => actions.saveTheme(validTheme, { id: 'a' }),
+          (err) => expect(err.field).to.equal('ccLibrariesResponse.libraryid'),
+        );
+      });
+
+      it('should throw when both ccLibrariesResponse fields are empty strings', async () => {
+        await expectValidationError(
+          () => actions.saveTheme(validTheme, { id: '', libraryid: '' }),
+          (err) => expect(err.field).to.equal('ccLibrariesResponse.id'),
+        );
+      });
+    });
+
+    it('should POST to save URL with built post data', async () => {
+      await actions.saveTheme(validTheme, validCC);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://themes.test.io/api/v2/themes');
+      expect(opts.method).to.equal('POST');
+
+      const body = JSON.parse(opts.body);
+      expect(body.name).to.equal('T');
+      expect(body.assets).to.deep.equal({ assetid: 'a-1', libraryid: 'l-1' });
+    });
+
+    // ── colorWeb parity ──
+
+    it('should include all swatches in POST body for a multi-swatch theme', async () => {
+      const themeData = {
+        name: 'ROYAL BLUE HUES',
+        swatches: [
+          { rgb: { r: 71, g: 56, b: 215 } },
+          { rgb: { r: 131, g: 114, b: 157 } },
+          { rgb: { r: 86, g: 18, b: 183 } },
+          { rgb: { r: 44, g: 30, b: 120 } },
+          { rgb: { r: 22, g: 10, b: 78 } },
+        ],
+        harmony: { baseSwatchIndex: 4, mood: 'custom', rule: 'monochromatic' },
+      };
+      await actions.saveTheme(themeData, validCC);
+
+      const body = JSON.parse(fetchStub.firstCall.args[1].body);
+      expect(body.swatches).to.have.lengthOf(5);
+      expect(body.swatches[0]).to.deep.include({ mode: 'rgb', values: [71, 56, 215] });
+      expect(body.swatches[4]).to.deep.include({ mode: 'rgb', values: [22, 10, 78] });
+      expect(body.harmony.baseSwatchIndex).to.equal(4);
+      expect(body.harmony.rule).to.equal('monochromatic');
+    });
+  });
+
+  // ─── deleteTheme ──────────────────────────────────────────────────────
+
+  describe('deleteTheme', () => {
+    describe('validation', () => {
+      [
+        { label: 'null payload', input: null },
+        { label: 'undefined payload', input: undefined },
+        { label: 'missing id', input: { name: 'x' } },
+        { label: 'empty id', input: { id: '', name: 'x' } },
+      ].forEach(({ label, input }) => {
+        it(`should throw ValidationError for ${label}`, async () => {
+          await expectValidationError(
+            () => actions.deleteTheme(input),
+            (err) => {
+              expect(err.field).to.equal('payload.id');
+              expect(err.topic).to.equal('THEME.DELETE');
+            },
+          );
+        });
+      });
+    });
+
+    it('should DELETE to correct URL', async () => {
+      await actions.deleteTheme({ id: 'del-1', name: 'Old' });
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.equal('https://themes.test.io/api/v2/themes/del-1');
+      expect(opts.method).to.equal('DELETE');
+    });
+
+    it('should return response wrapped with themeName', async () => {
+      const result = await actions.deleteTheme({ id: 'd', name: 'My Theme' });
+      expect(result.themeName).to.equal('My Theme');
+      expect(result.response).to.deep.equal({ id: 'theme-1' });
+    });
+
+    it('should handle missing name gracefully (undefined themeName)', async () => {
+      const result = await actions.deleteTheme({ id: 'd' });
+      expect(result.themeName).to.be.undefined;
+    });
+  });
+});

--- a/test/services/kuler/actions/helpers.js
+++ b/test/services/kuler/actions/helpers.js
@@ -1,0 +1,56 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { ValidationError } from '../../../../express/code/libs/services/core/Errors.js';
+
+/**
+ * Assert that `fn` throws a ValidationError, then run optional extra checks.
+ */
+export async function expectValidationError(fn, extraAssertions = () => {}) {
+  try {
+    await fn();
+    expect.fail('Should have thrown ValidationError');
+  } catch (err) {
+    expect(err).to.be.instanceOf(ValidationError);
+    extraAssertions(err);
+  }
+}
+
+/**
+ * Build a mock KulerPlugin with sensible defaults that can be overridden.
+ */
+export function createMockPlugin(overrides = {}) {
+  return {
+    baseUrl: 'https://test-kuler.com',
+    serviceConfig: {
+      themeBaseUrl: 'https://themes.test.io',
+      gradientBaseUrl: 'https://gradient.test.io',
+      likeBaseUrl: 'https://asset.test.io',
+      ...overrides.serviceConfig,
+    },
+    endpoints: {
+      search: '/search',
+      api: '/api/v2',
+      themePath: '/themes',
+      gradientPath: '/gradient',
+      ...overrides.endpoints,
+    },
+    getAuthState: sinon.stub().returns({ isLoggedIn: false }),
+    getHeaders: sinon.stub().returns({
+      'Content-Type': 'application/json',
+      'x-api-key': 'test-key',
+    }),
+    handleResponse: sinon.stub().callsFake((resp) => resp.json()),
+    ...overrides,
+  };
+}
+
+/**
+ * Stub `window.fetch` to resolve with a JSON-serialisable `responseData`.
+ */
+export function stubFetch(responseData = {}) {
+  return sinon.stub(window, 'fetch').resolves({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(responseData),
+  });
+}

--- a/test/services/kuler/providers/KulerProvider.test.js
+++ b/test/services/kuler/providers/KulerProvider.test.js
@@ -1,0 +1,315 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import KulerProvider, { createKulerProvider } from '../../../../express/code/libs/services/providers/KulerProvider.js';
+import KulerPlugin from '../../../../express/code/libs/services/plugins/kuler/KulerPlugin.js';
+
+function createTestPlugin(overrides = {}) {
+  return new KulerPlugin({
+    serviceConfig: {
+      baseSearchUrl: 'https://test-kuler.com',
+      exploreBaseUrl: 'https://themesb3.test.io',
+      themeBaseUrl: 'https://themes.test.io',
+      gradientBaseUrl: 'https://gradient.test.io',
+      likeBaseUrl: 'https://asset.test.io',
+      apiKey: 'test-key',
+      endpoints: {
+        search: '/search',
+        api: '/api/v2',
+        themePath: '/themes',
+        gradientPath: '/gradient',
+      },
+      ...overrides.serviceConfig,
+    },
+    appConfig: {
+      features: {},
+      ...overrides.appConfig,
+    },
+  });
+}
+
+describe('KulerProvider', () => {
+  let plugin;
+  let provider;
+  let fetchStub;
+
+  const mockData = { themes: [{ id: '1', name: 'Sunset' }] };
+
+  beforeEach(() => {
+    plugin = createTestPlugin();
+    fetchStub = sinon.stub(window, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockData),
+    });
+    window.adobeIMS = {
+      isSignedInUser: sinon.stub().returns(false),
+      getAccessToken: sinon.stub().returns(null),
+    };
+    window.lana = { log: sinon.stub() };
+    provider = new KulerProvider(plugin);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete window.adobeIMS;
+    delete window.lana;
+  });
+
+  // ─── Delegation Wiring ──────────────────────────────────────────────────
+
+  describe('delegation wiring', () => {
+    it('searchThemes dispatches to search action and returns data', async () => {
+      const result = await provider.searchThemes('sunset');
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(result).to.deep.equal(mockData);
+    });
+
+    it('searchThemes transforms query + options into criteria', async () => {
+      await provider.searchThemes('sunset', { page: 2, typeOfQuery: 'tag' });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('startIndex=72');
+      expect(url).to.include(encodeURIComponent('"tag"'));
+      expect(url).to.include(encodeURIComponent('"sunset"'));
+    });
+
+    it('searchThemes defaults to page 1 and typeOfQuery "term"', async () => {
+      await provider.searchThemes('blue');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('startIndex=0');
+      expect(url).to.include(encodeURIComponent('"term"'));
+    });
+
+    it('searchGradients dispatches with GRADIENT assetType', async () => {
+      await provider.searchGradients('blue');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('assetType=GRADIENT');
+    });
+
+    it('searchGradients transforms params like searchThemes', async () => {
+      await provider.searchGradients('warm', { page: 3, typeOfQuery: 'hex' });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('startIndex=144');
+      expect(url).to.include(encodeURIComponent('"hex"'));
+    });
+
+    it('getTheme dispatches with themeId', async () => {
+      await provider.getTheme('t-123');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/themes/t-123');
+    });
+
+    it('saveTheme dispatches with themeData and ccLibrariesResponse', async () => {
+      const themeData = { name: 'T', swatches: [{ rgb: { r: 0, g: 0, b: 0 } }] };
+      const ccResponse = { id: 'a', libraryid: 'l' };
+      await provider.saveTheme(themeData, ccResponse);
+
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/themes');
+      expect(opts.method).to.equal('POST');
+    });
+
+    it('deleteTheme dispatches with payload', async () => {
+      await provider.deleteTheme({ id: 'del-1', name: 'Old' });
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/themes/del-1');
+      expect(opts.method).to.equal('DELETE');
+    });
+
+    it('saveGradient dispatches with gradientData', async () => {
+      await provider.saveGradient({ name: 'Grad' });
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/gradient');
+      expect(opts.method).to.equal('POST');
+    });
+
+    it('deleteGradient dispatches with payload', async () => {
+      await provider.deleteGradient({ id: 'g-1', name: 'Old Grad' });
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/gradient/g-1');
+      expect(opts.method).to.equal('DELETE');
+    });
+
+    it('updateLike dispatches like action', async () => {
+      await provider.updateLike({ id: 't-1', like: {}, source: 'KULER' });
+      expect(fetchStub.calledOnce).to.be.true;
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('/likeDuplicate');
+    });
+
+    it('searchPublished dispatches with URL', async () => {
+      await provider.searchPublished('/themes/search?q=test');
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/themes/search');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('exploreThemes dispatches to explore action and returns data', async () => {
+      const result = await provider.exploreThemes();
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(result).to.deep.equal(mockData);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/themes');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('exploreThemes passes custom filter, sort, time, and page', async () => {
+      await provider.exploreThemes({ filter: 'my_themes', sort: 'like_count', time: 'week', page: 2 });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('filter=my_themes');
+      expect(url).to.include('startIndex=72');
+    });
+
+    it('exploreGradients dispatches to explore action and returns data', async () => {
+      const result = await provider.exploreGradients();
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(result).to.deep.equal(mockData);
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include('/gradient');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('exploreGradients passes custom options through', async () => {
+      await provider.exploreGradients({ sort: 'view_count', time: 'all', page: 3 });
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('sort=view_count');
+      expect(url).to.include('time=all');
+      expect(url).to.include('startIndex=144');
+    });
+
+    it('checkIfPublished dispatches searchPublished with { assetId, assetType }', async () => {
+      await provider.checkIfPublished('lib-asset-1', 'GRADIENT');
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.include(encodeURIComponent('"asset_id"'));
+      expect(url).to.include(encodeURIComponent('"lib-asset-1"'));
+      expect(url).to.include('assetType=GRADIENT');
+      expect(opts.method).to.equal('GET');
+    });
+
+    it('checkIfPublished defaults assetType to GRADIENT', async () => {
+      await provider.checkIfPublished('lib-asset-2');
+      const [url] = fetchStub.firstCall.args;
+      expect(url).to.include('assetType=GRADIENT');
+    });
+  });
+
+  // ─── Error Boundary (safeExecute) ───────────────────────────────────────
+
+  describe('error boundary (safeExecute)', () => {
+    it('searchThemes returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.searchThemes('test');
+      expect(result).to.be.null;
+    });
+
+    it('searchGradients returns null on network error', async () => {
+      fetchStub.rejects(new TypeError('Failed to fetch'));
+      const result = await provider.searchGradients('test');
+      expect(result).to.be.null;
+    });
+
+    it('getTheme returns null on validation error (empty themeId)', async () => {
+      const result = await provider.getTheme('');
+      expect(result).to.be.null;
+    });
+
+    it('getTheme returns null on network error', async () => {
+      fetchStub.rejects(new Error('timeout'));
+      const result = await provider.getTheme('t-1');
+      expect(result).to.be.null;
+    });
+
+    it('saveTheme returns null when themeData is null', async () => {
+      const result = await provider.saveTheme(null, null);
+      expect(result).to.be.null;
+    });
+
+    it('saveTheme returns null when swatches are empty', async () => {
+      const result = await provider.saveTheme({ swatches: [] }, { id: 'a', libraryid: 'l' });
+      expect(result).to.be.null;
+    });
+
+    it('deleteTheme returns null when payload.id is missing', async () => {
+      const result = await provider.deleteTheme({ name: 'x' });
+      expect(result).to.be.null;
+    });
+
+    it('deleteTheme returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.deleteTheme({ id: 'd-1', name: 'x' });
+      expect(result).to.be.null;
+    });
+
+    it('saveGradient returns null when gradientData is null', async () => {
+      const result = await provider.saveGradient(null);
+      expect(result).to.be.null;
+    });
+
+    it('saveGradient returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.saveGradient({ name: 'g' });
+      expect(result).to.be.null;
+    });
+
+    it('deleteGradient returns null when payload.id is missing', async () => {
+      const result = await provider.deleteGradient({ name: 'x' });
+      expect(result).to.be.null;
+    });
+
+    it('updateLike returns null when payload.id is missing', async () => {
+      const result = await provider.updateLike({ like: {} });
+      expect(result).to.be.null;
+    });
+
+    it('updateLike returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.updateLike({ id: 't-1', like: {} });
+      expect(result).to.be.null;
+    });
+
+    it('searchPublished returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.searchPublished('/themes/search');
+      expect(result).to.be.null;
+    });
+
+    it('exploreThemes returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.exploreThemes();
+      expect(result).to.be.null;
+    });
+
+    it('exploreGradients returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.exploreGradients();
+      expect(result).to.be.null;
+    });
+
+    it('checkIfPublished returns null on network error', async () => {
+      fetchStub.rejects(new Error('Network error'));
+      const result = await provider.checkIfPublished('asset-1');
+      expect(result).to.be.null;
+    });
+
+    it('errors are logged to window.lana', async () => {
+      fetchStub.rejects(new Error('boom'));
+      await provider.searchThemes('test');
+      expect(window.lana.log.calledOnce).to.be.true;
+      expect(window.lana.log.firstCall.args[0]).to.include('error');
+    });
+  });
+
+  // ─── Factory Function ─────────────────────────────────────────────────
+
+  describe('createKulerProvider factory', () => {
+    it('should return a KulerProvider instance', () => {
+      const instance = createKulerProvider(plugin);
+      expect(instance).to.be.instanceOf(KulerProvider);
+    });
+
+    it('should return a new instance each call', () => {
+      const a = createKulerProvider(plugin);
+      const b = createKulerProvider(plugin);
+      expect(a).to.not.equal(b);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Kuler (Adobe Color) service layer integration for searching, exploring, managing, and interacting with color themes and gradients. Implements a plugin-based architecture with **five** action groups (Search, Explore, Theme, Gradient, Like) backed by multiple Adobe API endpoints. Uses Adobe IMS Bearer authentication for write operations; search and explore work anonymously.

- **API Endpoints:**
  - `search.adobe.io/api/v2` — Theme & gradient search
  - `themesb3.adobe.io/api/v2` — Theme & gradient explore/browse
  - `themes.adobe.io` — Theme CRUD
  - `gradient.adobe.io` — Gradient CRUD
  - `asset.adobe.io` — Like/unlike
- **Feature Flag:** `ENABLE_KULER` (defaults to `true`; set to `false` to disable)
- **Auth:** Adobe IMS (`window.adobeIMS`) — Bearer token for create/modify/delete; anonymous search and explore supported
- **Pages Using This:** Service layer only — Color Explorer Hybrid integration is a follow-up

---

## Jira Ticket

Resolves: [MWPW-187669](https://jira.corp.adobe.com/browse/MWPW-187669)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://dhansingh-color-service-layer-kuler--da-express-milo--adobecom.aem.page/drafts/dhananjay/color-poc/?martech=off |

---

## Verification Steps

- **Feature flag off:** Override `ENABLE_KULER` to `false` during `init()` and confirm the Kuler plugin does not activate (`isActivated` returns `false`, provider returns `null`).
- **Feature flag on (default):** Confirm `await serviceManager.getProvider('kuler')` returns a valid `KulerProvider` instance.
- **Anonymous search:** Call `kuler.searchThemes('sunset')` without logging in — results should return.
- **Authenticated writes:** Log in via IMS, then call `kuler.saveTheme(...)` — verify Bearer token is attached in request headers.
- **Stage environment:** Confirm stage URLs (`search-stage.adobe.io`, `themes-stage.adobe.io`, etc.) are used when Milo env is `'stage'`.

---

## Potential Regressions

- https://dhansingh-color-service-layer-kuler--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

- **Architecture:** Follows plugin/provider pattern — `KulerPlugin` (extends `BaseApiService`) registers five action groups, and `KulerProvider` (extends `BaseProvider`) exposes a safe public API with `safeExecute` error handling and `window.lana` logging.
- **Action groups:** SearchActions (3 topics), ExploreActions (2 topics), ThemeActions (3 topics), GradientActions (2 topics), LikeActions (1 topic) — **11 topics total**.
- **Pagination:** 72 items per page for both search and explore endpoints.
- **Swatch conversion:** `convertSwatchesToKulerFormat` supports RGB, CMYK, HSV, and LAB color modes.
- **Response transforms:** `themeToGradient` / `gradientApiResponseToGradient` normalize API responses for UI consumption.
- **Comprehensive tests:** Plugin (`KulerPlugin.test.js`), all five action groups (`SearchActions.test.js`, `ExploreActions.test.js`, `ThemeActions.test.js`, `GradientActions.test.js`, `LikeActions.test.js`), and provider (`KulerProvider.test.js`) — see `test/services/kuler/CHECKLIST.md` for full coverage matrix.
- **Documentation:** Plugin README, architecture docs, and config docs updated to reflect the Kuler implementation.