### PR TITLE
MWPW-187614 Fix blog-posts-v2 width

### DIFF
--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.css
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.css
@@ -478,12 +478,6 @@ main .section:has(.blog-posts-v2)>.content>h3 {
     margin-left: auto;
   }
 
-  main .blog-posts-v2 {
-    max-width: 1087px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
   main .blog-posts-v2 .blog-hero-card .blog-card-image {
     min-width: 600px;
     max-width: 600px;


### PR DESCRIPTION
## Summary

Remove the custom width restriction on desktop, as per designs. This will line up the heading and the cards.

---

## Jira Ticket

Resolves: [MWPW-187614](https://jira.corp.adobe.com/browse/MWPW-187614)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.live/express/discover/qr-code-formats  |
| **After**   | https://methomas-blog-heading--da-express-milo--adobecom.aem.live/express/discover/qr-code-formats  |

---

## Verification Steps

- On desktop, scroll down to the heading "You might also like..." with cards under it, near the bottom of the page.
- "Before" the heading and cards weren't aligned. The cards were restricted to a smaller width.
- "After" the cards are the full width of the container and line up with the heading.

---

## Potential Regressions

- https://methomas-blog-heading--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/blog-posts-v2

---

## Additional Notes

N/A
