### PR TITLE
[Color][MWPW-186819] Banner Cool Block (light and dark)

### DIFF
--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -1,10 +1,14 @@
 .banner-cool {
   --color-banner-cool-gradient-start: #bfe4ff;
   --color-banner-cool-gradient-end: #cecef6;
+  --banner-cool-stroke-gutter: 16px;
+  --banner-cool-logo-headline-gap: 12px;
   margin: 0 auto;
-  padding: var(--spacing-800) var(--spacing-500);
+  padding: var(--spacing-800) var(--banner-cool-stroke-gutter);
   text-align: center;
   background: linear-gradient(170.96deg, var(--color-banner-cool-gradient-start) -0.25%, var(--color-banner-cool-gradient-end) 104.12%);
+  word-break: normal;
+  overflow-wrap: normal;
 }
 
 .banner-cool .banner-cool-wrapper {
@@ -71,11 +75,17 @@
   text-decoration: underline;
 }
 
+.banner-cool h4 a.quick-link {
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+}
+
 .banner-cool .express-logo {
   display: block;
   width: 163px;
   height: auto;
-  margin: 0 auto;
+  margin: 0 auto var(--banner-cool-logo-headline-gap);
 }
 
 .banner-cool.multi-button .button-container {
@@ -127,9 +137,17 @@
 
 .banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary,
 .banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary.dark.reverse {
+  font-size: var(--body-font-size-l);
+  line-height: 1;
+  padding: 13px var(--spacing-400);
+  border-radius: var(--spacing-400);
   color: var(--color-content-neutral);
   background-color: transparent;
   border: var(--border-width-2) solid var(--color-content-neutral);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 var(--spacing-50) 0 0;
 }
 
 .banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary:hover,
@@ -155,7 +173,7 @@
 
 @media (min-width: 768px) {
   .banner-cool {
-    padding: var(--spacing-500) var(--spacing-400);
+    padding: var(--spacing-500) var(--banner-cool-stroke-gutter);
   }
 
   .banner-cool .banner-cool-inner {
@@ -187,7 +205,7 @@
 
 @media (min-width: 1024px) {
   .banner-cool {
-    padding: var(--spacing-800) var(--spacing-500);
+    padding: var(--spacing-800) var(--banner-cool-stroke-gutter);
   }
 
   .banner-cool .banner-cool-inner {
@@ -240,6 +258,14 @@
   color: var(--color-white);
 }
 
+.banner-cool.dark h4 a.quick-link {
+  color: var(--color-white);
+}
+
+.banner-cool.dark h4 a.quick-link:hover {
+  color: rgba(255, 255, 255, 0.8);
+}
+
 .banner-cool.dark .button-container a.button.bg-banner-button {
   background-color: var(--color-blue-cta);
   border: var(--border-width-2) solid var(--color-blue-cta);
@@ -253,9 +279,17 @@
 }
 
 .banner-cool.dark .button-container a.button.bg-banner-button-secondary {
+  font-size: var(--body-font-size-l);
+  line-height: 1;
+  padding: 13px var(--spacing-400);
+  border-radius: var(--spacing-400);
   color: rgba(255, 255, 255, 0.85);
   border-color: rgba(255, 255, 255, 0.85);
   background-color: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 var(--spacing-50) 0 0;
 }
 
 .banner-cool.dark .button-container a.button.bg-banner-button-secondary:hover {

--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -3,6 +3,10 @@
   --color-banner-cool-gradient-end: #cecef6;
   --banner-cool-stroke-gutter: 16px;
   --banner-cool-logo-headline-gap: 12px;
+  --banner-cool-h2-font-size-tablet: 32px;
+  --banner-cool-h2-font-size-desktop: 45px;
+  --banner-cool-h3-font-size-tablet: 18px;
+  --banner-cool-h3-font-size-desktop: 20px;
   margin: 0 auto;
   padding: var(--spacing-800) var(--banner-cool-stroke-gutter);
   text-align: center;
@@ -54,8 +58,13 @@
 }
 
 .banner-cool h2.ax-heading-xxl {
+  font-size: var(--banner-cool-h2-font-size-tablet);
   font-weight: var(--heading-font-weight-extra);
   line-height: 104%;
+}
+
+.banner-cool h3.ax-body-xl {
+  font-size: var(--banner-cool-h3-font-size-tablet);
 }
 
 .banner-cool p {
@@ -208,8 +217,16 @@
     padding: var(--spacing-800) var(--banner-cool-stroke-gutter);
   }
 
+  .banner-cool h2.ax-heading-xxl {
+    font-size: var(--banner-cool-h2-font-size-desktop);
+  }
+
   .banner-cool .banner-cool-inner {
     padding: var(--spacing-800) var(--spacing-500);
+  }
+
+  .banner-cool h3.ax-body-xl {
+    font-size: var(--banner-cool-h3-font-size-desktop);
   }
 
   .banner-cool h3.ax-body-xl,

--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -236,14 +236,13 @@
 }
 
 .banner-cool.dark .button-container a.button.bg-banner-button {
-  background-color: var(--color-blue-800);
-  border-color: var(--color-blue-800);
+  background-color: #3B63FB;
+  border: var(--border-width-2) solid #3B63FB;
   color: var(--color-white);
 }
 
 .banner-cool.dark .button-container a.button.bg-banner-button:hover {
-  background-color: rgb(77, 111, 249);
-  border-color: rgb(77, 111, 249);
+  background-color: #274dea;  border-color: #274dea;
   color: var(--color-white);
 }
 

--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -39,7 +39,6 @@
   width: 100%;
 }
 
-/* Reuse ax-heading/ax-body classes; only block-specific overrides */
 .banner-cool h2,
 .banner-cool h3,
 .banner-cool h4 {
@@ -77,7 +76,6 @@
   margin: 0 auto;
 }
 
-/* Multi-button layout - same as banner-bg */
 .banner-cool.multi-button .button-container {
   display: inline-block;
 }
@@ -101,12 +99,10 @@
   }
 }
 
-/* Single button container */
 .banner-cool .button-container:not(.multi-button .button-container) {
   margin-bottom: var(--spacing-300);
 }
 
-/* Primary button - same specs as banner-bg .bg-banner-button (override global .button.dark only in light theme) */
 .banner-cool .button-container a.button.bg-banner-button,
 .banner-cool:not(.dark) .button-container a.button.bg-banner-button.dark {
   font-size: var(--body-font-size-l);
@@ -129,7 +125,6 @@
   border-color: var(--color-black);
 }
 
-/* Second button - same specs as banner-bg .bg-banner-button-secondary (override global .button.dark.reverse only in light theme) */
 .banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary,
 .banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary.dark.reverse {
   color: var(--color-content-neutral);
@@ -144,7 +139,6 @@
   border-color: var(--color-black);
 }
 
-/* Buttons side by side when multiple (only the row that contains buttons) */
 .banner-cool.multi-button .banner-cool-actions-footnote > div:has(.button-container) {
   display: flex;
   flex-direction: row;
@@ -241,7 +235,6 @@
   color: var(--color-white);
 }
 
-/* Dark variant: light inner content, so use accent and white outline for contrast */
 .banner-cool.dark .button-container a.button.bg-banner-button {
   background-color: var(--color-blue-800);
   border-color: var(--color-blue-800);

--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -1,0 +1,273 @@
+.banner-cool {
+  margin: 0 auto;
+  padding: var(--spacing-800) var(--spacing-500);
+  text-align: center;
+  background: linear-gradient(170.96deg, #bfe4ff -0.25%, #cecef6 104.12%);
+}
+
+.banner-cool .banner-cool-wrapper {
+  max-width: none;
+}
+
+.banner-cool .banner-cool-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-200);
+  padding: var(--spacing-800) var(--spacing-500);
+  background: linear-gradient(95.37deg, rgba(255, 255, 255, 0.8) 18.1%, rgba(255, 255, 255, 0.4) 93.47%);
+  border: var(--border-width-2) solid var(--color-white);
+  border-radius: var(--spacing-300);
+  box-sizing: border-box;
+}
+
+.banner-cool .banner-cool-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-500);
+  width: 100%;
+  max-width: 812px;
+}
+
+.banner-cool .banner-cool-text-wrap,
+.banner-cool .banner-cool-actions-footnote {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-300);
+  width: 100%;
+}
+
+/* Reuse ax-heading/ax-body classes; only block-specific overrides */
+.banner-cool h2,
+.banner-cool h3,
+.banner-cool h4 {
+  margin: 0;
+  text-align: center;
+  color: var(--color-default-font);
+}
+
+.banner-cool h2.ax-heading-xxl {
+  font-weight: var(--heading-font-weight-extra);
+  line-height: 104%;
+}
+
+.banner-cool p {
+  margin: 0;
+  color: var(--color-dark-gray);
+  font-size: var(--body-font-size-l);
+  line-height: 1.3;
+}
+
+.banner-cool a:any-link {
+  color: var(--color-blue-800);
+}
+
+.banner-cool p.button-container + p a:any-link,
+.banner-cool .banner-cool-content p:last-of-type a:any-link {
+  color: var(--color-gray-800-variant);
+  text-decoration: underline;
+}
+
+.banner-cool .express-logo {
+  display: block;
+  width: 163px;
+  height: auto;
+  margin: 0 auto;
+}
+
+/* Multi-button layout - same as banner-bg */
+.banner-cool.multi-button .button-container {
+  display: inline-block;
+}
+
+.banner-cool.multi-button .button-container:last-child {
+  margin-right: 0;
+}
+
+@media (max-width: 767px) {
+  .banner-cool.multi-button .button-container {
+    margin-top: var(--spacing-100);
+    margin-bottom: var(--spacing-100);
+  }
+
+  .banner-cool.multi-button .button-container:first-child {
+    margin-top: var(--spacing-500);
+  }
+
+  .banner-cool.multi-button .button-container:last-child {
+    margin-bottom: var(--spacing-300);
+  }
+}
+
+/* Single button container */
+.banner-cool .button-container:not(.multi-button .button-container) {
+  margin-bottom: var(--spacing-300);
+}
+
+/* Primary button - same specs as banner-bg .bg-banner-button (override global .button.dark only in light theme) */
+.banner-cool .button-container a.button.bg-banner-button,
+.banner-cool:not(.dark) .button-container a.button.bg-banner-button.dark {
+  font-size: var(--body-font-size-l);
+  line-height: 1;
+  padding: 13px var(--spacing-400);
+  border-radius: var(--spacing-400);
+  background-color: var(--color-content-neutral);
+  border: var(--border-width-2) solid var(--color-content-neutral);
+  color: var(--color-white);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 var(--spacing-50) 0 0;
+}
+
+.banner-cool .button-container a.button.bg-banner-button:hover,
+.banner-cool:not(.dark) .button-container a.button.bg-banner-button.dark:hover {
+  color: var(--color-white);
+  background-color: var(--color-black);
+  border-color: var(--color-black);
+}
+
+/* Second button - same specs as banner-bg .bg-banner-button-secondary (override global .button.dark.reverse only in light theme) */
+.banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary,
+.banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary.dark.reverse {
+  color: var(--color-content-neutral);
+  background-color: transparent;
+  border: var(--border-width-2) solid var(--color-content-neutral);
+}
+
+.banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary:hover,
+.banner-cool:not(.dark) .button-container a.button.bg-banner-button-secondary.dark.reverse:hover {
+  color: var(--color-black);
+  background-color: var(--color-gray-325);
+  border-color: var(--color-black);
+}
+
+/* Buttons side by side when multiple (only the row that contains buttons) */
+.banner-cool.multi-button .banner-cool-actions-footnote > div:has(.button-container) {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--spacing-300);
+}
+
+.banner-cool a.button:focus-visible,
+.banner-cool a:any-link:focus-visible {
+  outline: var(--border-width-2) solid var(--color-gray-900);
+  outline-offset: var(--border-width-2);
+}
+
+@media (min-width: 768px) {
+  .banner-cool {
+    padding: var(--spacing-500) var(--spacing-400);
+  }
+
+  .banner-cool .banner-cool-inner {
+    padding: var(--spacing-800) var(--spacing-500);
+  }
+
+  .banner-cool .banner-cool-text-wrap {
+    gap: var(--spacing-200);
+  }
+}
+
+@media (min-width: 1024px) {
+  .banner-cool {
+    padding: var(--spacing-800) var(--spacing-500);
+  }
+
+  .banner-cool .banner-cool-inner {
+    padding: var(--spacing-800) var(--spacing-500);
+  }
+
+  .banner-cool h3.ax-body-xl,
+  .banner-cool h4.ax-body-xs {
+    color: var(--color-dark-gray);
+    line-height: var(--heading-line-height);
+  }
+
+  .banner-cool h4.ax-body-xs {
+    margin-top: var(--spacing-80);
+  }
+}
+
+@media (min-width: 1280px) {
+  .banner-cool h2.ax-heading-xxl {
+    font-size: var(--ax-heading-xl-size);
+    line-height: var(--ax-heading-xl-lh);
+  }
+}
+
+@media (min-width: 1680px) {
+  .banner-cool .banner-cool-wrapper {
+    padding: 0;
+  }
+}
+
+.banner-cool.dark {
+  background: var(--color-black);
+}
+
+.banner-cool.dark .banner-cool-inner {
+  background: linear-gradient(var(--color-black), var(--color-black)) padding-box,
+    linear-gradient(90deg, var(--color-green-800), var(--color-blue-800), var(--color-purple-1000), var(--color-orange-700)) border-box;
+  border: var(--border-width-2) solid transparent;
+  border-radius: var(--spacing-300);
+}
+
+.banner-cool.dark .banner-cool-content,
+.banner-cool.dark .banner-cool-inner {
+  color: var(--color-white);
+}
+
+.banner-cool.dark h2,
+.banner-cool.dark h3,
+.banner-cool.dark h4 {
+  color: var(--color-white);
+}
+
+.banner-cool.dark p {
+  color: var(--color-white);
+}
+
+.banner-cool.dark a:any-link {
+  color: var(--color-info-accent);
+}
+
+.banner-cool.dark p.button-container + p a:any-link,
+.banner-cool.dark .banner-cool-content p:last-of-type a:any-link {
+  color: var(--color-white);
+}
+
+/* Dark variant: light inner content, so use accent and white outline for contrast */
+.banner-cool.dark .button-container a.button.bg-banner-button {
+  background-color: var(--color-blue-800);
+  border-color: var(--color-blue-800);
+  color: var(--color-white);
+}
+
+.banner-cool.dark .button-container a.button.bg-banner-button:hover {
+  background-color: rgb(77, 111, 249);
+  border-color: rgb(77, 111, 249);
+  color: var(--color-white);
+}
+
+.banner-cool.dark .button-container a.button.bg-banner-button-secondary {
+  color: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.85);
+  background-color: transparent;
+}
+
+.banner-cool.dark .button-container a.button.bg-banner-button-secondary:hover {
+  color: var(--color-white);
+  background-color: rgba(255, 255, 255, 0.12);
+  border-color: var(--color-white);
+}
+
+.banner-cool.dark a.button:focus-visible,
+.banner-cool.dark a:any-link:focus-visible {
+  outline: var(--border-width-2) solid var(--color-white);
+  outline-offset: var(--border-width-2);
+}

--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -1,8 +1,10 @@
 .banner-cool {
+  --color-banner-cool-gradient-start: #bfe4ff;
+  --color-banner-cool-gradient-end: #cecef6;
   margin: 0 auto;
   padding: var(--spacing-800) var(--spacing-500);
   text-align: center;
-  background: linear-gradient(170.96deg, #bfe4ff -0.25%, #cecef6 104.12%);
+  background: linear-gradient(170.96deg, var(--color-banner-cool-gradient-start) -0.25%, var(--color-banner-cool-gradient-end) 104.12%);
 }
 
 .banner-cool .banner-cool-wrapper {
@@ -239,13 +241,14 @@
 }
 
 .banner-cool.dark .button-container a.button.bg-banner-button {
-  background-color: #3B63FB;
-  border: var(--border-width-2) solid #3B63FB;
+  background-color: var(--color-blue-cta);
+  border: var(--border-width-2) solid var(--color-blue-cta);
   color: var(--color-white);
 }
 
 .banner-cool.dark .button-container a.button.bg-banner-button:hover {
-  background-color: #274dea;  border-color: #274dea;
+  background-color: var(--color-blue-cta-hover);
+  border-color: var(--color-blue-cta-hover);
   color: var(--color-white);
 }
 

--- a/express/code/blocks/banner-cool/banner-cool.css
+++ b/express/code/blocks/banner-cool/banner-cool.css
@@ -84,19 +84,17 @@
   margin-right: 0;
 }
 
-@media (max-width: 767px) {
-  .banner-cool.multi-button .button-container {
-    margin-top: var(--spacing-100);
-    margin-bottom: var(--spacing-100);
-  }
+.banner-cool.multi-button .button-container {
+  margin-top: var(--spacing-100);
+  margin-bottom: var(--spacing-100);
+}
 
-  .banner-cool.multi-button .button-container:first-child {
-    margin-top: var(--spacing-500);
-  }
+.banner-cool.multi-button .button-container:first-child {
+  margin-top: var(--spacing-500);
+}
 
-  .banner-cool.multi-button .button-container:last-child {
-    margin-bottom: var(--spacing-300);
-  }
+.banner-cool.multi-button .button-container:last-child {
+  margin-bottom: var(--spacing-300);
 }
 
 .banner-cool .button-container:not(.multi-button .button-container) {
@@ -141,8 +139,8 @@
 
 .banner-cool.multi-button .banner-cool-actions-footnote > div:has(.button-container) {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
   gap: var(--spacing-300);
 }
@@ -165,6 +163,24 @@
   .banner-cool .banner-cool-text-wrap {
     gap: var(--spacing-200);
   }
+
+  .banner-cool.multi-button .button-container {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .banner-cool.multi-button .button-container:first-child {
+    margin-top: 0;
+  }
+
+  .banner-cool.multi-button .button-container:last-child {
+    margin-bottom: 0;
+  }
+
+  .banner-cool.multi-button .banner-cool-actions-footnote > div:has(.button-container) {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
 }
 
 @media (min-width: 1024px) {
@@ -184,19 +200,6 @@
 
   .banner-cool h4.ax-body-xs {
     margin-top: var(--spacing-80);
-  }
-}
-
-@media (min-width: 1280px) {
-  .banner-cool h2.ax-heading-xxl {
-    font-size: var(--ax-heading-xl-size);
-    line-height: var(--ax-heading-xl-lh);
-  }
-}
-
-@media (min-width: 1680px) {
-  .banner-cool .banner-cool-wrapper {
-    padding: 0;
   }
 }
 

--- a/express/code/blocks/banner-cool/banner-cool.js
+++ b/express/code/blocks/banner-cool/banner-cool.js
@@ -64,11 +64,6 @@ function injectLogo(block, section) {
   }
 }
 
-/**
- * Applies button styling to match banner-bg specs (accent, dark, bg-banner-button, bg-banner-button-secondary).
- * @param {HTMLElement} block - The banner block element
- * @param {string|boolean} variantClass - Truthy when background-style buttons should be applied (always for banner-cool)
- */
 function styleButtons(block, variantClass) {
   const buttons = Array.from(block.querySelectorAll('a.button'));
   if (buttons.length === 0) return;
@@ -147,7 +142,6 @@ export default async function decorate(block) {
     const axClass = AX_HEADING_BY_LEVEL[level];
     if (axClass) heading.classList.add(axClass);
   });
-  // Same as banner-bg: always use background-style buttons (frosted container)
   styleButtons(block, true);
   await formatPhoneNumbers(block);
   fixIcons(block);

--- a/express/code/blocks/banner-cool/banner-cool.js
+++ b/express/code/blocks/banner-cool/banner-cool.js
@@ -124,7 +124,7 @@ export default async function decorate(block) {
   while (block.children.length) {
     const child = block.children[0];
     if (child.querySelector('.button-container')) {
-      while(block.children.length) actionsFootnote.appendChild(block.children[0]);
+      while (block.children.length) actionsFootnote.appendChild(block.children[0]);
     } else {
       textWrap.appendChild(child);
     }

--- a/express/code/blocks/banner-cool/banner-cool.js
+++ b/express/code/blocks/banner-cool/banner-cool.js
@@ -40,16 +40,6 @@ const CONFIG = {
 
 let createTag;
 
-function applyVariantFromMetadata(block, section) {
-  const metadata = section?.querySelector('.section-metadata');
-  if (!metadata) return;
-  const config = readBlockConfig(metadata);
-  const style = (config.style || '').trim().toLowerCase();
-  if (style === 'dark') {
-    block.classList.add('dark');
-  }
-}
-
 function injectLogo(block, section) {
   const metadata = section?.querySelector('.section-metadata');
   if (!metadata) return;
@@ -112,8 +102,6 @@ export default async function decorate(block) {
 
   const section = block.closest('.section');
   if (section?.style?.background) block.style.background = section.style.background;
-
-  applyVariantFromMetadata(block, section);
 
   const wrapper = createTag('div', { class: 'banner-cool-wrapper' });
   const innerWrap = createTag('div', { class: 'banner-cool-inner' });

--- a/express/code/blocks/banner-cool/banner-cool.js
+++ b/express/code/blocks/banner-cool/banner-cool.js
@@ -1,0 +1,154 @@
+import {
+  getLibs,
+  decorateButtonsDeprecated,
+  fixIcons,
+  getIconElementDeprecated,
+  readBlockConfig,
+} from '../../scripts/utils.js';
+import { normalizeHeadings } from '../../scripts/utils/decorate.js';
+import { formatSalesPhoneNumber } from '../../scripts/utils/location-utils.js';
+
+const AX_HEADING_BY_LEVEL = {
+  h2: 'ax-heading-xxl',
+  h3: 'ax-body-xl',
+  h4: 'ax-body-xs',
+};
+
+const CONFIG = {
+  headings: ['h2', 'h3', 'h4'],
+  logo: {
+    icon: 'adobe-express-logo',
+    class: 'express-logo',
+    target: 'h2',
+  },
+  logoDark: {
+    icon: 'adobe-express-logo-white',
+    class: 'express-logo',
+    target: 'h2',
+  },
+  phoneNumber: {
+    selector: 'a[title="{{business-sales-numbers}}"]',
+  },
+  buttons: {
+    base: ['accent', 'dark'],
+    multiButton: ['reverse'],
+    background: ['bg-banner-button'],
+    backgroundSecondary: ['bg-banner-button-secondary'],
+    remove: ['primary', 'secondary'],
+  },
+};
+
+let createTag;
+
+function applyVariantFromMetadata(block, section) {
+  const metadata = section?.querySelector('.section-metadata');
+  if (!metadata) return;
+  const config = readBlockConfig(metadata);
+  const style = (config.style || '').trim().toLowerCase();
+  if (style === 'dark') {
+    block.classList.add('dark');
+  }
+}
+
+function injectLogo(block, section) {
+  const metadata = section?.querySelector('.section-metadata');
+  if (!metadata) return;
+
+  const config = readBlockConfig(metadata);
+  const shouldInject = ['on', 'yes'].includes(config['inject-logo']?.toLowerCase());
+
+  if (shouldInject) {
+    const logo = getIconElementDeprecated(block.classList.contains('dark') ? CONFIG.logoDark.icon : CONFIG.logo.icon);
+    logo.classList.add(CONFIG.logo.class);
+    block.querySelector(CONFIG.logo.target)?.parentElement?.prepend(logo);
+  }
+}
+
+/**
+ * Applies button styling to match banner-bg specs (accent, dark, bg-banner-button, bg-banner-button-secondary).
+ * @param {HTMLElement} block - The banner block element
+ * @param {string|boolean} variantClass - Truthy when background-style buttons should be applied (always for banner-cool)
+ */
+function styleButtons(block, variantClass) {
+  const buttons = Array.from(block.querySelectorAll('a.button'));
+  if (buttons.length === 0) return;
+
+  const isMultiButton = buttons.length > 1;
+  if (isMultiButton) {
+    block.classList.add('multi-button');
+  }
+
+  const stylingClasses = [...CONFIG.buttons.base];
+  if (variantClass) {
+    stylingClasses.push(...CONFIG.buttons.background);
+  }
+  if (isMultiButton) {
+    stylingClasses.push(...CONFIG.buttons.multiButton);
+  }
+
+  buttons.forEach((button, index) => {
+    const currentClasses = button.className.split(' ').filter(
+      (cls) => cls === 'button' || cls === 'a' || !CONFIG.buttons.remove.includes(cls),
+    );
+    const buttonClasses = [...currentClasses, ...stylingClasses];
+    if (variantClass && isMultiButton && index === 1) {
+      buttonClasses.push(...CONFIG.buttons.backgroundSecondary);
+    }
+    button.className = buttonClasses.join(' ');
+  });
+}
+
+async function formatPhoneNumbers(block) {
+  const tags = block.querySelectorAll(CONFIG.phoneNumber.selector);
+  if (tags.length === 0) return;
+  try {
+    await formatSalesPhoneNumber(tags);
+  } catch (e) {
+    window.lana?.log('banner-cool.js - error formatting sales phone numbers:', e.message);
+  }
+}
+
+export default async function decorate(block) {
+  const [utils] = await Promise.all([
+    import(`${getLibs()}/utils/utils.js`),
+    decorateButtonsDeprecated(block),
+  ]);
+  ({ createTag } = utils);
+
+  const section = block.closest('.section');
+  if (section?.style?.background) block.style.background = section.style.background;
+
+  applyVariantFromMetadata(block, section);
+
+  const wrapper = createTag('div', { class: 'banner-cool-wrapper' });
+  const innerWrap = createTag('div', { class: 'banner-cool-inner' });
+  const contentWrap = createTag('div', { class: 'banner-cool-content' });
+  const textWrap = createTag('div', { class: 'banner-cool-text-wrap' });
+  const actionsFootnote = createTag('div', { class: 'banner-cool-actions-footnote' });
+
+  while (block.children.length) {
+    const child = block.children[0];
+    if (child.querySelector('.button-container')) {
+      while(block.children.length) actionsFootnote.appendChild(block.children[0]);
+    } else {
+      textWrap.appendChild(child);
+    }
+  }
+
+  contentWrap.append(textWrap, actionsFootnote);
+  innerWrap.appendChild(contentWrap);
+  wrapper.appendChild(innerWrap);
+  block.appendChild(wrapper);
+
+  injectLogo(block, section);
+  normalizeHeadings(block, CONFIG.headings);
+  block.querySelectorAll('h2, h3, h4').forEach((heading) => {
+    const level = heading.tagName.toLowerCase();
+    const axClass = AX_HEADING_BY_LEVEL[level];
+    if (axClass) heading.classList.add(axClass);
+  });
+  // Same as banner-bg: always use background-style buttons (frosted container)
+  styleButtons(block, true);
+  await formatPhoneNumbers(block);
+  fixIcons(block);
+}

--- a/express/code/blocks/banner-cool/banner-cool.js
+++ b/express/code/blocks/banner-cool/banner-cool.js
@@ -50,6 +50,7 @@ function injectLogo(block, section) {
   if (shouldInject) {
     const logo = getIconElementDeprecated(block.classList.contains('dark') ? CONFIG.logoDark.icon : CONFIG.logo.icon);
     logo.classList.add(CONFIG.logo.class);
+    logo.setAttribute('alt', 'Adobe Express');
     block.querySelector(CONFIG.logo.target)?.parentElement?.prepend(logo);
   }
 }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -29,6 +29,8 @@
   --color-gray-800-variant: #292929;
   --color-gray-900: #222;
   --color-gray-950: #131313;
+  --color-green-800: #079355;
+  --color-blue-800: #4B75FF;
   --color-blue-600: #0066CC;
   --color-black: #000;
   --color-content-neutral: #222222;
@@ -46,6 +48,8 @@
   --color-info-secondary-hover: #d4d4d4;
   --color-info-secondary-down: #cdcdcd;
   --color-info-premium: #ebcf2d;
+  --color-orange-700: #E86A00;
+  --color-purple-1000: #8628D9;
   --gradient-highlight-vertical: linear-gradient(15deg, #7c84fc, #ff4dd2);
   --gradient-highlight-horizontal: linear-gradient(90deg, #ff4dd2, #7c84fc);
   --gradient-highlight-diagonal: linear-gradient(45deg, #7c84fc, #ff4dd2);

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -30,8 +30,10 @@
   --color-gray-900: #222;
   --color-gray-950: #131313;
   --color-green-800: #079355;
-  --color-blue-800: #4B75FF;
   --color-blue-600: #0066CC;
+  --color-blue-800: #4B75FF;
+  --color-blue-cta: #3B63FB;
+  --color-blue-cta-hover: #274DEA;
   --color-black: #000;
   --color-content-neutral: #222222;
   --color-brand-title: #000b1d;
@@ -136,8 +138,8 @@
 
   --S2-Buttons-Gen-AI: linear-gradient(96deg, #D73220 0%, #D92361 33%, #7155FA 100%);
  
-  --S2-Buttons-Premium: linear-gradient(95.85deg, #b539c8, #7155fa 66%, #3b63fb);
-  --S2-Buttons-Premium-Hover: linear-gradient(96deg, #9C28AF 0%, #6338EE 66%, #274DEA 100%);
+  --S2-Buttons-Premium: linear-gradient(95.85deg, #b539c8, #7155fa 66%, var(--color-blue-cta));
+  --S2-Buttons-Premium-Hover: linear-gradient(96deg, #9C28AF 0%, #6338EE 66%, var(--color-blue-cta-hover));
   --S2-Buttons-Premium-Down: linear-gradient(96deg, #871B9A 0%, #5424DB 66%, #1D3ECF 100%);
   /* current ax-grid system */
   --ax-grid-margin: 20px;

--- a/nala/assets/urls.txt
+++ b/nala/assets/urls.txt
@@ -166,3 +166,4 @@ https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/toggle-bar
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/tutorials/tutorials
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/tutorials/tutorials-twoperrow
 
+https://mwpw-186819-banner-cool-dark--da-express-milo--adobecom.aem.page/drafts/vineesha/banner-cool-dark

--- a/nala/blocks/banner-cool/banner-cool.block.json
+++ b/nala/blocks/banner-cool/banner-cool.block.json
@@ -1,0 +1,80 @@
+{
+  "block": "banner-cool",
+  "variants": [
+    {
+      "tcid": "0",
+      "name": "@banner-cool-dark-multi-button",
+      "selector": "div.banner-cool.dark.multi-button",
+      "path": "/drafts/nala/test-gen/banner-cool",
+      "data": {
+        "semantic": {
+          "texts": [
+            {
+              "selector": "h2.ax-heading-xxl",
+              "nth": 0,
+              "tag": "h2",
+              "text": "Harness your creative powers with Adobe Express.",
+              "markup": null
+            },
+            {
+              "selector": "h4.ax-body-xs",
+              "nth": 0,
+              "tag": "h4",
+              "text": "Harness your creative powers with Adobe Express Learn More.",
+              "markup": null
+            }
+          ],
+          "media": [
+            {
+              "selector": "img.icon.icon-adobe-express-logo-white.express-logo",
+              "nth": 0,
+              "tag": "img",
+              "src": "/express/code/icons/adobe-express-logo-white.svg",
+              "alt": "adobe-express-logo-white"
+            }
+          ],
+          "interactives": [
+            {
+              "type": "link",
+              "selector": "a.quick-link.button.accent.accent.dark.bg-banner-button.reverse",
+              "nth": 0,
+              "text": "Start 30-day free trial",
+              "href": "/K7QlvIv7FDb?url=%2Fdrafts%2Fnala%2Ftest-gen%2Fbanner-cool&placement=banner-cool&locale=en-US&contentRegion=us",
+              "ariaLabel": null,
+              "rel": "nofollow",
+              "title": "Start 30-day free trial",
+              "target": "_self"
+            },
+            {
+              "type": "link",
+              "selector": "a.quick-link.button.accent.accent.dark.bg-banner-button.reverse.bg-banner-button-secondary",
+              "nth": 0,
+              "text": "Get Adobe Express for free",
+              "href": "/K7QlvIv7FDb?url=%2Fdrafts%2Fnala%2Ftest-gen%2Fbanner-cool&placement=banner-cool&locale=en-US&contentRegion=us",
+              "ariaLabel": null,
+              "rel": "nofollow",
+              "title": "Get Adobe Express for free",
+              "target": "_self"
+            },
+            {
+              "type": "link",
+              "selector": "a.quick-link",
+              "nth": 2,
+              "text": "Learn More",
+              "href": "/K7QlvIv7FDb?url=%2Fdrafts%2Fnala%2Ftest-gen%2Fbanner-cool&placement=banner-cool&locale=en-US&contentRegion=us",
+              "ariaLabel": null,
+              "rel": "nofollow",
+              "title": "Learn More",
+              "target": "_self"
+            }
+          ]
+        }
+      },
+      "tags": [
+        "@banner-cool",
+        "@dark-multi-button",
+        "@express"
+      ]
+    }
+  ]
+}

--- a/nala/blocks/banner-cool/banner-cool.page.cjs
+++ b/nala/blocks/banner-cool/banner-cool.page.cjs
@@ -1,0 +1,7 @@
+class BannerCoolBlock {
+  constructor(page, selector = '.banner-cool', nth = 0) {
+    this.page = page;
+    this.block = page.locator(selector).nth(nth);
+  }
+}
+module.exports = BannerCoolBlock;

--- a/nala/blocks/banner-cool/banner-cool.spec.cjs
+++ b/nala/blocks/banner-cool/banner-cool.spec.cjs
@@ -1,0 +1,3 @@
+const schema = require('./banner-cool.block.json');
+
+module.exports = { features: schema.variants };

--- a/nala/blocks/banner-cool/banner-cool.test.cjs
+++ b/nala/blocks/banner-cool/banner-cool.test.cjs
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+const { features } = require('./banner-cool.spec.cjs');
+const BannerCoolBlock = require('./banner-cool.page.cjs');
+const { runAccessibilityTest } = require('../../libs/accessibility.cjs');
+const { runSeoChecks } = require('../../libs/seo-check.cjs');
+
+test.describe('BannerCoolBlock Test Suite', () => {
+  // Test Id : 0 : @banner-cool-dark-multi-button
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name} ${features[0].tags}`, async ({ page, baseURL }) => {
+    const { data } = features[0];
+    const testUrl = `${baseURL}${features[0].path}`;
+    const block = new BannerCoolBlock(page, features[0].selector);
+    console.info(`[Test Page]: ${testUrl}`);
+
+    await test.step('step-1: Navigate to page', async () => {
+      await page.goto(testUrl);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(testUrl);
+    });
+
+    await test.step('step-2: Verify block content', async () => {
+      await expect(block.block).toBeVisible();
+      const sem = data.semantic;
+
+      for (const t of sem.texts) {
+        const locator = block.block.locator(t.selector).nth(t.nth || 0);
+        await expect(locator).toContainText(t.text);
+      }
+
+      for (const m of sem.media) {
+        const locator = block.block.locator(m.selector).nth(m.nth || 0);
+        const isHiddenSelector = m.selector.includes('.isHidden');
+        const isPicture = m.tag === 'picture';
+        const target = isPicture ? locator.locator('img') : locator;
+        if (isHiddenSelector) {
+          await expect(target).toBeHidden();
+        } else {
+          await expect(target).toBeVisible();
+        }
+      }
+
+      for (const iEl of sem.interactives) {
+        const locator = block.block.locator(iEl.selector).nth(iEl.nth || 0);
+        await expect(locator).toBeVisible({ timeout: 8000 });
+        if (iEl.type === 'link' && iEl.href) {
+          const href = await locator.getAttribute('href');
+          if (/^(tel:|mailto:|sms:|ftp:|[+]?[\d])/i.test(iEl.href)) {
+            await expect(href).toBe(iEl.href);
+          } else {
+            const expectedPath = new URL(iEl.href, 'https://dummy.base').pathname;
+            const actualPath = new URL(href, 'https://dummy.base').pathname;
+            await expect(actualPath).toBe(expectedPath);
+          }
+        }
+        if (iEl.text) await expect(locator).toContainText(iEl.text);
+      }
+    });
+
+    await test.step('step-3: Accessibility validation', async () => {
+      await runAccessibilityTest({ page, testScope: block.block, skipA11yTest: false });
+    });
+
+    await test.step('step-4: SEO validation', async () => {
+      await runSeoChecks({ page, feature: features[0], skipSeoTest: false });
+    });
+  });
+});

--- a/test/blocks/banner-cool/banner-cool.test.js
+++ b/test/blocks/banner-cool/banner-cool.test.js
@@ -1,0 +1,224 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const imports = await Promise.all([
+  import('../../../express/code/scripts/scripts.js'),
+  import('../../../express/code/blocks/banner-cool/banner-cool.js'),
+]);
+const { default: decorate } = imports[1];
+
+const defaultHtml = await readFile({ path: './mocks/default.html' });
+const darkHtml = await readFile({ path: './mocks/dark.html' });
+const multiButtonHtml = await readFile({ path: './mocks/multi-button.html' });
+const phoneHtml = await readFile({ path: './mocks/phone.html' });
+const noButtonsHtml = await readFile({ path: './mocks/no-buttons.html' });
+const injectLogoOffHtml = await readFile({ path: './mocks/inject-logo-off.html' });
+
+describe('Banner Cool', () => {
+  before(() => {
+    window.isTestEnv = true;
+    if (!window.lana) window.lana = { log: () => {} };
+  });
+
+  it('Banner Cool exists', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+    expect(block).to.exist;
+  });
+
+  it('Banner Cool default (light) has light and multi-button classes', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+    expect(block.classList.contains('light')).to.be.true;
+    expect(block.classList.contains('multi-button')).to.be.true;
+  });
+
+  it('Banner Cool has correct wrapper structure', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const wrapper = block.querySelector('.banner-cool-wrapper');
+    const inner = block.querySelector('.banner-cool-inner');
+    const content = block.querySelector('.banner-cool-content');
+    const textWrap = block.querySelector('.banner-cool-text-wrap');
+    const actionsFootnote = block.querySelector('.banner-cool-actions-footnote');
+
+    expect(wrapper).to.exist;
+    expect(inner).to.exist;
+    expect(content).to.exist;
+    expect(textWrap).to.exist;
+    expect(actionsFootnote).to.exist;
+    expect(wrapper.contains(inner)).to.be.true;
+    expect(inner.contains(content)).to.be.true;
+    expect(content.contains(textWrap)).to.be.true;
+    expect(content.contains(actionsFootnote)).to.be.true;
+  });
+
+  it('Banner Cool has heading and button elements', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const h2 = block.querySelector('h2');
+    const h3 = block.querySelector('h3');
+    const h4 = block.querySelector('h4');
+    const buttons = block.querySelectorAll('a.button');
+    expect(h2).to.exist;
+    expect(h3).to.exist;
+    expect(h4).to.exist;
+    expect(buttons.length).to.be.at.least(2);
+  });
+
+  it('Banner Cool has expected heading text', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const h2 = block.querySelector('h2');
+    expect(h2.textContent).to.include('Harness your creative powers with Adobe Express');
+  });
+
+  it('Banner Cool applies ax heading classes', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const h2 = block.querySelector('h2');
+    const h3 = block.querySelector('h3');
+    const h4 = block.querySelector('h4');
+    expect(h2.classList.contains('ax-heading-xxl')).to.be.true;
+    expect(h3.classList.contains('ax-body-xl')).to.be.true;
+    expect(h4.classList.contains('ax-body-xs')).to.be.true;
+  });
+
+  it('Banner Cool styles buttons with accent, dark, and bg-banner-button', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const button = block.querySelector('a.button');
+    expect(button.classList.contains('accent')).to.be.true;
+    expect(button.classList.contains('dark')).to.be.true;
+    expect(button.classList.contains('bg-banner-button')).to.be.true;
+  });
+
+  it('Banner Cool injects logo when section metadata inject-logo is on', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.exist;
+  });
+
+  it('Banner Cool does not inject logo when inject-logo is not present in html', async () => {
+    document.body.innerHTML = multiButtonHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.not.exist;
+  });
+
+  it('Banner Cool has Learn More link in h4', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const learnMore = block.querySelector('h4 a.quick-link');
+    expect(learnMore).to.exist;
+    expect(learnMore.textContent).to.include('Learn More');
+  });
+
+  it('Banner Cool dark variant has dark class on block', async () => {
+    document.body.innerHTML = darkHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    expect(block.classList.contains('dark')).to.be.true;
+  });
+
+  it('Banner Cool multi-button adds secondary button class on second button', async () => {
+    document.body.innerHTML = multiButtonHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    expect(block.classList.contains('multi-button')).to.be.true;
+    const buttons = block.querySelectorAll('a.button');
+    expect(buttons.length).to.be.at.least(2);
+    expect(buttons[0].classList.contains('bg-banner-button')).to.be.true;
+    expect(buttons[1].classList.contains('bg-banner-button-secondary')).to.be.true;
+  });
+
+  it('Banner Cool with phone number has sales link', async () => {
+    document.body.innerHTML = phoneHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const phoneLink = block.querySelector('a[title="{{business-sales-numbers}}"]');
+    expect(phoneLink).to.exist;
+  });
+
+  it('Banner Cool with no buttons does not add multi-button and completes', async () => {
+    document.body.innerHTML = noButtonsHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    expect(block.classList.contains('multi-button')).to.be.false;
+    expect(block.querySelector('.banner-cool-wrapper')).to.exist;
+  });
+
+  it('Banner Cool does not inject logo when inject-logo is off in section metadata', async () => {
+    document.body.innerHTML = injectLogoOffHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.not.exist;
+  });
+
+  it('Banner Cool copies section background to block when section has style.background', async () => {
+    document.body.innerHTML = defaultHtml;
+    const block = document.querySelector('.banner-cool');
+    const section = block.closest('.section');
+    section.style.background = 'linear-gradient(red, blue)';
+    await decorate(block);
+
+    expect(block.style.background).to.equal('linear-gradient(red, blue)');
+  });
+
+  it('Banner Cool dark variant uses dark logo icon', async () => {
+    document.body.innerHTML = darkHtml;
+    const block = document.querySelector('.banner-cool');
+    await decorate(block);
+
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.exist;
+    const img = logo.querySelector('img');
+    if (img) {
+      expect(img.classList.contains('icon-adobe-express-logo-white') || img.getAttribute('alt') === 'adobe-express-logo-white').to.be.true;
+    } else {
+      expect(logo.classList.contains('icon-adobe-express-logo-white') || logo.querySelector('[class*="express-logo-white"]')).to.exist;
+    }
+  });
+
+  it('Banner Cool formatPhoneNumbers catches and logs when formatSalesPhoneNumber fails', async () => {
+    document.body.innerHTML = phoneHtml;
+    const block = document.querySelector('.banner-cool');
+    const logCalls = [];
+    window.lana = { log: (...args) => { logCalls.push(args); } };
+    const origFetch = window.fetch;
+    window.fetch = () => Promise.reject(new Error('mock fetch failure'));
+
+    await decorate(block);
+
+    window.fetch = origFetch;
+    expect(logCalls.some((args) => args[0] && args[0].includes('banner-cool.js'))).to.be.true;
+  });
+});

--- a/test/blocks/banner-cool/banner-cool.test.js
+++ b/test/blocks/banner-cool/banner-cool.test.js
@@ -136,7 +136,7 @@ describe('Banner Cool', () => {
     expect(learnMore.textContent).to.include('Learn More');
   });
 
-  it('Banner Cool dark variant has dark class on block', async () => {
+  it('Banner Cool dark variant preserves dark class from CMS authoring', async () => {
     document.body.innerHTML = darkHtml;
     const block = document.querySelector('.banner-cool');
     await decorate(block);

--- a/test/blocks/banner-cool/mocks/dark.html
+++ b/test/blocks/banner-cool/mocks/dark.html
@@ -1,0 +1,35 @@
+<div class="section">
+  <div class="section-metadata">
+    <div>
+      <div>inject-logo</div>
+      <div>on</div>
+    </div>
+  </div>
+  <div class="banner-cool dark multi-button block" data-block-name="banner-cool" data-block-status="loaded" daa-lh="b2|banner-cool">
+    <div>
+      <div>
+        <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>
+      </div>
+    </div>
+    <div>
+      <div>
+        <h3 id="harness-your-creative-powers-with-adobe-express-3">Harness your creative powers with Adobe Express.</h3>
+      </div>
+    </div>
+    <div>
+      <div class="button-container">
+        <a href="https://adobesparkpost.app.link/K7QlvIv7FDb" class="quick-link button accent" rel="nofollow" title="Start 30-day free trial" target="_self">Start 30-day free trial</a>
+      </div>
+    </div>
+    <div>
+      <div class="button-container">
+        <a href="https://adobesparkpost.app.link/K7QlvIv7FDb" class="quick-link button accent" rel="nofollow" title="Get Adobe Express for free" target="_self">Get Adobe Express for free</a>
+      </div>
+    </div>
+    <div>
+      <div>
+        <h4 id="harness-your-creative-powers-with-adobe-express-learn-more-1">Harness your creative powers with Adobe Express <a href="https://adobesparkpost.app.link/K7QlvIv7FDb" class="quick-link" rel="nofollow" title="Learn More" target="_self">Learn More</a>.</h4>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/blocks/banner-cool/mocks/dark.html
+++ b/test/blocks/banner-cool/mocks/dark.html
@@ -5,7 +5,7 @@
       <div>on</div>
     </div>
   </div>
-  <div class="banner-cool dark multi-button block" data-block-name="banner-cool" data-block-status="loaded" daa-lh="b2|banner-cool">
+  <div class="banner-cool dark block" data-block-name="banner-cool" data-block-status="loaded" daa-lh="b2|banner-cool">
     <div>
       <div>
         <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>

--- a/test/blocks/banner-cool/mocks/default.html
+++ b/test/blocks/banner-cool/mocks/default.html
@@ -5,7 +5,7 @@
       <div>yes</div>
     </div>
   </div>
-  <div class="banner-cool light multi-button block" data-block-name="banner-cool" data-block-status="loaded" daa-lh="b2|banner-cool">
+  <div class="banner-cool light block" data-block-name="banner-cool" data-block-status="loaded" daa-lh="b2|banner-cool">
     <div>
       <div>
         <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>

--- a/test/blocks/banner-cool/mocks/default.html
+++ b/test/blocks/banner-cool/mocks/default.html
@@ -1,0 +1,35 @@
+<div class="section">
+  <div class="section-metadata">
+    <div>
+      <div>inject-logo</div>
+      <div>yes</div>
+    </div>
+  </div>
+  <div class="banner-cool light multi-button block" data-block-name="banner-cool" data-block-status="loaded" daa-lh="b2|banner-cool">
+    <div>
+      <div>
+        <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>
+      </div>
+    </div>
+    <div>
+      <div>
+        <h3 id="harness-your-creative-powers-with-adobe-express-3">Harness your creative powers with Adobe Express.</h3>
+      </div>
+    </div>
+    <div>
+      <div class="button-container">
+        <a href="https://adobesparkpost.app.link/K7QlvIv7FDb?url=%2Fdrafts%2Fvineesha%2Fbanner-cool-dark&amp;placement=banner-cool-2&amp;locale=en-US&amp;contentRegion=us" class="quick-link button accent" rel="nofollow" title="Start 30-day free trial" target="_self">Start 30-day free trial</a>
+      </div>
+    </div>
+    <div>
+      <div class="button-container">
+        <a href="https://adobesparkpost.app.link/K7QlvIv7FDb?url=%2Fdrafts%2Fvineesha%2Fbanner-cool-dark&amp;placement=banner-cool-2&amp;locale=en-US&amp;contentRegion=us" class="quick-link button accent" rel="nofollow" title="Get Adobe Express for free" target="_self">Get Adobe Express for free</a>
+      </div>
+    </div>
+    <div>
+      <div>
+        <h4 id="harness-your-creative-powers-with-adobe-express-learn-more-1">Harness your creative powers with Adobe Express <a href="https://adobesparkpost.app.link/K7QlvIv7FDb?url=%2Fdrafts%2Fvineesha%2Fbanner-cool-dark&amp;placement=banner-cool-2&amp;locale=en-US&amp;contentRegion=us" class="quick-link" rel="nofollow" title="Learn More" target="_self">Learn More</a>.</h4>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/blocks/banner-cool/mocks/inject-logo-off.html
+++ b/test/blocks/banner-cool/mocks/inject-logo-off.html
@@ -1,0 +1,15 @@
+<div class="section">
+  <div class="section-metadata">
+    <div>
+      <div>inject-logo</div>
+      <div>off</div>
+    </div>
+  </div>
+  <div class="banner-cool light block" data-block-name="banner-cool" data-block-status="loading">
+    <div>
+      <div>
+        <h2 id="test">Test</h2>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/blocks/banner-cool/mocks/multi-button.html
+++ b/test/blocks/banner-cool/mocks/multi-button.html
@@ -1,0 +1,17 @@
+<div class="banner-cool light multi-button block" data-block-name="banner-cool" data-block-status="loading">
+  <div>
+    <div>
+      <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>
+    </div>
+  </div>
+  <div>
+    <div class="button-container">
+      <a href="https://adobesparkpost.app.link/K7QlvIv7FDb" title="Start 30-day free trial" class="button accent">Start 30-day free trial</a>
+    </div>
+  </div>
+  <div>
+    <div class="button-container">
+      <a href="https://adobesparkpost.app.link/K7QlvIv7FDb" title="Get Adobe Express for free" class="button accent">Get Adobe Express for free</a>
+    </div>
+  </div>
+</div>

--- a/test/blocks/banner-cool/mocks/multi-button.html
+++ b/test/blocks/banner-cool/mocks/multi-button.html
@@ -1,4 +1,4 @@
-<div class="banner-cool light multi-button block" data-block-name="banner-cool" data-block-status="loading">
+<div class="banner-cool light block" data-block-name="banner-cool" data-block-status="loading">
   <div>
     <div>
       <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>

--- a/test/blocks/banner-cool/mocks/no-buttons.html
+++ b/test/blocks/banner-cool/mocks/no-buttons.html
@@ -1,0 +1,7 @@
+<div class="banner-cool light block" data-block-name="banner-cool" data-block-status="loading">
+  <div>
+    <div>
+      <h2 id="heading-only">Heading only, no buttons.</h2>
+    </div>
+  </div>
+</div>

--- a/test/blocks/banner-cool/mocks/phone.html
+++ b/test/blocks/banner-cool/mocks/phone.html
@@ -1,0 +1,17 @@
+<div class="banner-cool light block" data-block-name="banner-cool" data-block-status="loading">
+  <div>
+    <div>
+      <h2 id="harness-your-creative-powers-with-adobe-express-2">Harness your creative powers with Adobe Express.</h2>
+    </div>
+  </div>
+  <div>
+    <div class="button-container">
+      <a href="https://adobesparkpost.app.link/K7QlvIv7FDb" title="Start 30-day free trial" class="button accent">Start 30-day free trial</a>
+    </div>
+  </div>
+  <div>
+    <div class="button-container">
+      <a href="tel:1234567890" title="{{business-sales-numbers}}" class="button accent">1234567890</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

## Summary

New **banner-cool** block with **light** and **dark** variants, implemented to match Figma and [MWPW-186819](https://jira.corp.adobe.com/browse/MWPW-186819).

### Figma references
- **Light:** [SoT Blocks – CTA style=2 button](https://www.figma.com/design/oEKwLBikshx4BgPmhtm7K9/-express---SoT-Blocks---Components?node-id=22641-15566)
- **Dark:** [Final Color Expansion CCEX – Style=Default](https://www.figma.com/design/mcJuQTxJdWsL0dMmqaecpn/Final-Color-Expansion-CCEX-221263?node-id=5629-179423)

### Files
- `express/code/blocks/banner-cool/banner-cool.js` – Decorate, variant, logo injection, button styling
- `express/code/blocks/banner-cool/banner-cool.css` – Light and dark styles per Figma (layout, colors, gradient border, responsive)

---

## Jira Ticket

Resolves: [MWPW-186819](https://jira.corp.adobe.com/browse/MWPW-186819)
---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/vineesha/banner-cool-dark |
| **After**   | https://MWPW-186819-banner-cool-dark--da-express-milo--adobecom.aem.page/drafts/vineesha/banner-cool-dark?martech=off |

---

## Verification Steps

This change adds a new block for banner-cool component. To verify the changes.
- Open https://main--da-express-milo--adobecom.aem.page/drafts/vineesha/banner-cool-dark
- The block will not render correctly
- Open  https://MWPW-186819-banner-cool-dark--da-express-milo--adobecom.aem.page/drafts/vineesha/banner-cool-dark
- The block will be rendered as per designs mentioned in the description.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
