### PR TITLE
Added print-addon-interaction event to all customization input buttons

### DIFF
--- a/express/code/blocks/print-product-detail/createComponents/createProductInfoHeadingSection.js
+++ b/express/code/blocks/print-product-detail/createComponents/createProductInfoHeadingSection.js
@@ -78,7 +78,7 @@ function createProductTitleAndRatingsContainer(productDetails) {
   const productTitle = createTag(
     'h1',
     {
-      class: 'pdpx-product-title global-Typography-Size-Headings-Heading-L',
+      class: 'pdpx-product-title global-Typography-Size-Headings-Heading-L tracking-header',
       id: 'pdpx-product-title',
       'data-skeleton': 'true',
     },
@@ -100,7 +100,7 @@ function createInfoTooltipContent(productDetails) {
     role: 'tooltip',
   });
   const infoTooltipContentTitle = createTag(
-    'h6',
+    'p',
     {
       class: 'pdpx-info-tooltip-content-title',
       id: 'pdpx-info-tooltip-content-title',

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
@@ -123,13 +123,9 @@ export default async function createMiniPillOptionsSelector(argumentObject) {
       await updateAllDynamicElements(productDetails.id);
       trackPrintAddonInteraction({
         action_type: 'button',
-        productId: productDetails.id,
-        templateId: productDetails.templateId,
+        action_name: attributeName,
+        action_value: customizationOptions[i].name,
         productType: productDetails.productType,
-        attributeName,
-        optionName: customizationOptions[i].title,
-        optionId: customizationOptions[i].name,
-        interactionType: 'click',
       }).catch(() => {});
     });
     miniPillTextContainer.appendChild(miniPillPrice);

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
@@ -2,7 +2,7 @@ import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
 import createSimpleCarousel from '../../../../scripts/widgets/simple-carousel.js';
-import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
+import { trackPrintAddonOptionSelect } from '../../../../scripts/instrument.js';
 
 let createTag;
 function positionTooltip(target, tooltipText) {
@@ -121,10 +121,9 @@ export default async function createMiniPillOptionsSelector(argumentObject) {
         input.value = event.currentTarget.getAttribute('data-name');
       });
       await updateAllDynamicElements(productDetails.id);
-      trackPrintAddonInteraction({
-        action_type: 'button',
-        action_name: attributeName,
-        action_value: customizationOptions[i].name,
+      trackPrintAddonOptionSelect({
+        attributeName,
+        actionValue: customizationOptions[i].name,
         productType: productDetails.productType,
       }).catch(() => {});
     });

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
@@ -2,6 +2,7 @@ import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
 import createSimpleCarousel from '../../../../scripts/widgets/simple-carousel.js';
+import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
 
 let createTag;
 function positionTooltip(target, tooltipText) {
@@ -120,6 +121,16 @@ export default async function createMiniPillOptionsSelector(argumentObject) {
         input.value = event.currentTarget.getAttribute('data-name');
       });
       await updateAllDynamicElements(productDetails.id);
+      trackPrintAddonInteraction({
+        action_type: 'button',
+        productId: productDetails.id,
+        templateId: productDetails.templateId,
+        productType: productDetails.productType,
+        attributeName,
+        optionName: customizationOptions[i].title,
+        optionId: customizationOptions[i].name,
+        interactionType: 'click',
+      }).catch(() => {});
     });
     miniPillTextContainer.appendChild(miniPillPrice);
     miniPillContainer.append(

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
@@ -124,12 +124,12 @@ export default async function createMiniPillOptionsSelector(argumentObject) {
       allInputs.forEach((input) => {
         input.value = event.currentTarget.getAttribute('data-name');
       });
-      await updateAllDynamicElements(productDetails.id);
       debouncedTrackPrintAddonOptionSelect({
         attributeName,
         actionValue: customizationOptions[i].name,
         productType: productDetails.productType,
       });
+      await updateAllDynamicElements(productDetails.id);
     });
     miniPillTextContainer.appendChild(miniPillPrice);
     miniPillContainer.append(

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createMiniPillOptionsSelector.js
@@ -3,6 +3,7 @@ import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
 import createSimpleCarousel from '../../../../scripts/widgets/simple-carousel.js';
 import { trackPrintAddonOptionSelect } from '../../../../scripts/instrument.js';
+import { debounce } from '../../../../scripts/utils/hofs.js';
 
 let createTag;
 function positionTooltip(target, tooltipText) {
@@ -74,6 +75,9 @@ export default async function createMiniPillOptionsSelector(argumentObject) {
     name: attributeName,
     id: `pdpx-hidden-input-${attributeName}`,
   });
+  const debouncedTrackPrintAddonOptionSelect = debounce((payload) => {
+    trackPrintAddonOptionSelect(payload).catch(() => {});
+  }, 250);
   for (let i = 0; i < customizationOptions?.length; i += 1) {
     const hiddenSelectInputOption = createTag(
       'option',
@@ -121,11 +125,11 @@ export default async function createMiniPillOptionsSelector(argumentObject) {
         input.value = event.currentTarget.getAttribute('data-name');
       });
       await updateAllDynamicElements(productDetails.id);
-      trackPrintAddonOptionSelect({
+      debouncedTrackPrintAddonOptionSelect({
         attributeName,
         actionValue: customizationOptions[i].name,
         productType: productDetails.productType,
-      }).catch(() => {});
+      });
     });
     miniPillTextContainer.appendChild(miniPillPrice);
     miniPillContainer.append(

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
@@ -1,6 +1,6 @@
 import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
-import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
+import { trackPrintAddonOptionSelect } from '../../../../scripts/instrument.js';
 
 let createTag;
 
@@ -80,10 +80,9 @@ export default async function createPillOptionsSelector(argumentObject) {
     optionPill.addEventListener('click', async () => {
       hiddenSelectInput.value = customizationOptions[i].name;
       await updateAllDynamicElements(productDetails.id);
-      trackPrintAddonInteraction({
-        action_type: 'button',
-        action_name: attributeName,
-        action_value: customizationOptions[i].name,
+      trackPrintAddonOptionSelect({
+        attributeName,
+        actionValue: customizationOptions[i].name,
         productType: productDetails.productType,
       }).catch(() => {});
     });

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
@@ -82,13 +82,9 @@ export default async function createPillOptionsSelector(argumentObject) {
       await updateAllDynamicElements(productDetails.id);
       trackPrintAddonInteraction({
         action_type: 'button',
-        productId: productDetails.id,
-        templateId: productDetails.templateId,
+        action_name: attributeName,
+        action_value: customizationOptions[i].name,
         productType: productDetails.productType,
-        attributeName,
-        optionName: customizationOptions[i].title,
-        optionId: customizationOptions[i].name,
-        interactionType: 'click',
       }).catch(() => {});
     });
     optionPill.append(optionPillImageContainer, inputPillTextContainer);

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
@@ -1,5 +1,6 @@
 import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
+import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
 
 let createTag;
 
@@ -79,6 +80,16 @@ export default async function createPillOptionsSelector(argumentObject) {
     optionPill.addEventListener('click', async () => {
       hiddenSelectInput.value = customizationOptions[i].name;
       await updateAllDynamicElements(productDetails.id);
+      trackPrintAddonInteraction({
+        action_type: 'button',
+        productId: productDetails.id,
+        templateId: productDetails.templateId,
+        productType: productDetails.productType,
+        attributeName,
+        optionName: customizationOptions[i].title,
+        optionId: customizationOptions[i].name,
+        interactionType: 'click',
+      }).catch(() => {});
     });
     optionPill.append(optionPillImageContainer, inputPillTextContainer);
     pillOptionsContainer.appendChild(optionPill);

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
@@ -83,12 +83,12 @@ export default async function createPillOptionsSelector(argumentObject) {
     );
     optionPill.addEventListener('click', async (event) => {
       hiddenSelectInput.value = customizationOptions[i].name;
-      await updateAllDynamicElements(productDetails.id);
       debouncedTrackPrintAddonOptionSelect({
         attributeName,
         actionValue: customizationOptions[i].name,
         productType: productDetails.productType,
       });
+      await updateAllDynamicElements(productDetails.id);
     });
     optionPill.append(optionPillImageContainer, inputPillTextContainer);
     pillOptionsContainer.appendChild(optionPill);

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
@@ -1,6 +1,7 @@
 import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import { trackPrintAddonOptionSelect } from '../../../../scripts/instrument.js';
+import { debounce } from '../../../../scripts/utils/hofs.js';
 
 let createTag;
 
@@ -29,6 +30,9 @@ export default async function createPillOptionsSelector(argumentObject) {
     value: defaultValue,
     'aria-hidden': 'true',
   });
+  const debouncedTrackPrintAddonOptionSelect = debounce((payload) => {
+    trackPrintAddonOptionSelect(payload).catch(() => {});
+  }, 250);
   for (let i = 0; i < customizationOptions.length; i += 1) {
     const option = createTag(
       'option',
@@ -77,14 +81,14 @@ export default async function createPillOptionsSelector(argumentObject) {
         customizationOptions[i].priceAdjustment,
       ),
     );
-    optionPill.addEventListener('click', async () => {
+    optionPill.addEventListener('click', async (event) => {
       hiddenSelectInput.value = customizationOptions[i].name;
       await updateAllDynamicElements(productDetails.id);
-      trackPrintAddonOptionSelect({
+      debouncedTrackPrintAddonOptionSelect({
         attributeName,
         actionValue: customizationOptions[i].name,
         productType: productDetails.productType,
-      }).catch(() => {});
+      });
     });
     optionPill.append(optionPillImageContainer, inputPillTextContainer);
     pillOptionsContainer.appendChild(optionPill);

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createPillOptionsSelector.js
@@ -81,7 +81,7 @@ export default async function createPillOptionsSelector(argumentObject) {
         customizationOptions[i].priceAdjustment,
       ),
     );
-    optionPill.addEventListener('click', async (event) => {
+    optionPill.addEventListener('click', async () => {
       hiddenSelectInput.value = customizationOptions[i].name;
       debouncedTrackPrintAddonOptionSelect({
         attributeName,

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
@@ -2,7 +2,7 @@ import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
 import createSimpleCarousel from '../../../../scripts/widgets/simple-carousel.js';
-import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
+import { trackPrintAddonOptionSelect } from '../../../../scripts/instrument.js';
 
 let createTag;
 function positionTooltip(target, tooltipText) {
@@ -150,10 +150,9 @@ export default async function createSegmentedMiniPillOptionsSelector(
       miniPillButton.addEventListener('click', async () => {
         hiddenSelectInput.value = customizationOptions[j].name;
         await updateAllDynamicElements(productDetails.id);
-        trackPrintAddonInteraction({
-          action_type: 'button',
-          action_name: attributeName,
-          action_value: customizationOptions[j].name,
+        trackPrintAddonOptionSelect({
+          attributeName,
+          actionValue: customizationOptions[j].name,
           productType: productDetails.productType,
         }).catch(() => {});
       });

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
@@ -2,6 +2,7 @@ import { getLibs } from '../../../../scripts/utils.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
 import createSimpleCarousel from '../../../../scripts/widgets/simple-carousel.js';
+import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
 
 let createTag;
 function positionTooltip(target, tooltipText) {
@@ -149,6 +150,16 @@ export default async function createSegmentedMiniPillOptionsSelector(
       miniPillButton.addEventListener('click', async () => {
         hiddenSelectInput.value = customizationOptions[j].name;
         await updateAllDynamicElements(productDetails.id);
+        trackPrintAddonInteraction({
+          action_type: 'button',
+          productId: productDetails.id,
+          templateId: productDetails.templateId,
+          productType: productDetails.productType,
+          attributeName,
+          optionName: customizationOptions[j].title,
+          optionId: customizationOptions[j].name,
+          interactionType: 'click',
+        }).catch(() => {});
       });
       const miniPillTextContainer = createTag('div', {
         class: 'pdpx-mini-pill-text-container',

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
@@ -152,13 +152,9 @@ export default async function createSegmentedMiniPillOptionsSelector(
         await updateAllDynamicElements(productDetails.id);
         trackPrintAddonInteraction({
           action_type: 'button',
-          productId: productDetails.id,
-          templateId: productDetails.templateId,
+          action_name: attributeName,
+          action_value: customizationOptions[j].name,
           productType: productDetails.productType,
-          attributeName,
-          optionName: customizationOptions[j].title,
-          optionId: customizationOptions[j].name,
-          interactionType: 'click',
         }).catch(() => {});
       });
       const miniPillTextContainer = createTag('div', {

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
@@ -3,6 +3,7 @@ import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
 import createSimpleCarousel from '../../../../scripts/widgets/simple-carousel.js';
 import { trackPrintAddonOptionSelect } from '../../../../scripts/instrument.js';
+import { debounce } from '../../../../scripts/utils/hofs.js';
 
 let createTag;
 function positionTooltip(target, tooltipText) {
@@ -95,6 +96,9 @@ export default async function createSegmentedMiniPillOptionsSelector(
     name: attributeName,
     id: `pdpx-hidden-input-${attributeName}`,
   });
+  const debouncedTrackPrintAddonOptionSelect = debounce((payload) => {
+    trackPrintAddonOptionSelect(payload).catch(() => {});
+  }, 250);
   for (let i = 0; i < filteredOptions.length; i += 1) {
     const sectionContainer = createTag('div', {
       class: 'pdpx-mini-pill-section-container',
@@ -147,14 +151,14 @@ export default async function createSegmentedMiniPillOptionsSelector(
         src: customizationOptions[j].thumbnail,
       });
       miniPillButton.appendChild(miniPillImage);
-      miniPillButton.addEventListener('click', async () => {
+      miniPillButton.addEventListener('click', async (event) => {
         hiddenSelectInput.value = customizationOptions[j].name;
         await updateAllDynamicElements(productDetails.id);
-        trackPrintAddonOptionSelect({
+        debouncedTrackPrintAddonOptionSelect({
           attributeName,
           actionValue: customizationOptions[j].name,
           productType: productDetails.productType,
-        }).catch(() => {});
+        });
       });
       const miniPillTextContainer = createTag('div', {
         class: 'pdpx-mini-pill-text-container',

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
@@ -151,7 +151,7 @@ export default async function createSegmentedMiniPillOptionsSelector(
         src: customizationOptions[j].thumbnail,
       });
       miniPillButton.appendChild(miniPillImage);
-      miniPillButton.addEventListener('click', async (event) => {
+      miniPillButton.addEventListener('click', async () => {
         hiddenSelectInput.value = customizationOptions[j].name;
         debouncedTrackPrintAddonOptionSelect({
           attributeName,

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createSegmentedMiniPillOptionsSelector.js
@@ -153,12 +153,12 @@ export default async function createSegmentedMiniPillOptionsSelector(
       miniPillButton.appendChild(miniPillImage);
       miniPillButton.addEventListener('click', async (event) => {
         hiddenSelectInput.value = customizationOptions[j].name;
-        await updateAllDynamicElements(productDetails.id);
         debouncedTrackPrintAddonOptionSelect({
           attributeName,
           actionValue: customizationOptions[j].name,
           productType: productDetails.productType,
         });
+        await updateAllDynamicElements(productDetails.id);
       });
       const miniPillTextContainer = createTag('div', {
         class: 'pdpx-mini-pill-text-container',

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createStandardSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createStandardSelector.js
@@ -31,15 +31,11 @@ export default async function createStandardSelector(argumentObject) {
       await updateAllDynamicElements(productDetails.id);
       const selectedOption = customizationOptions.find((o) => o.name === value);
       trackPrintAddonInteraction({
-        action_type: 'dropdown',
-        productId: productDetails.id,
-        templateId: productDetails.templateId,
+        action_type: 'button',
+        action_name: attributeName,
+        action_value: selectedOption?.title || value,
         productType: productDetails.productType,
-        attributeName,
-        optionName: selectedOption?.title || value,
-        optionId: value,
-        interactionType: 'change',
-      });
+      }).catch(() => {});
     },
   });
 

--- a/express/code/blocks/print-product-detail/createComponents/customizationInputs/createStandardSelector.js
+++ b/express/code/blocks/print-product-detail/createComponents/customizationInputs/createStandardSelector.js
@@ -2,6 +2,7 @@ import { getLibs } from '../../../../scripts/utils.js';
 import { createPicker } from '../../../../scripts/widgets/picker.js';
 import updateAllDynamicElements from '../../utilities/event-handlers.js';
 import openDrawer from '../drawerContent/openDrawer.js';
+import { trackPrintAddonInteraction } from '../../../../scripts/instrument.js';
 
 let createTag;
 
@@ -26,8 +27,19 @@ export default async function createStandardSelector(argumentObject) {
     labelPosition: 'side',
     options,
     defaultValue,
-    onChange: () => {
-      updateAllDynamicElements(productDetails.id);
+    onChange: async (value) => {
+      await updateAllDynamicElements(productDetails.id);
+      const selectedOption = customizationOptions.find((o) => o.name === value);
+      trackPrintAddonInteraction({
+        action_type: 'dropdown',
+        productId: productDetails.id,
+        templateId: productDetails.templateId,
+        productType: productDetails.productType,
+        attributeName,
+        optionName: selectedOption?.title || value,
+        optionId: value,
+        interactionType: 'change',
+      });
     },
   });
 

--- a/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
+++ b/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
@@ -24,8 +24,7 @@ export default async function fetchAPIData(productId, parameters, endpoint, idTy
   try {
     apiDataFetch = await fetch(formatUrlForEnvironment(url));
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.info(error);
+    window.lana.log('Error fetching product details: ', { error });
   }
   const apiDataJSON = await apiDataFetch.json();
   const apiData = apiDataJSON.data;

--- a/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
+++ b/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
@@ -24,7 +24,7 @@ export default async function fetchAPIData(productId, parameters, endpoint, idTy
   try {
     apiDataFetch = await fetch(formatUrlForEnvironment(url));
   } catch (error) {
-    window.lana.log('Error fetching product details: ', { error });
+    window.lana.log('Error fetching product details: ', { error }, { tags: 'print-product-detail', severity: 'error' });
   }
   const apiDataJSON = await apiDataFetch.json();
   const apiData = apiDataJSON.data;

--- a/express/code/blocks/print-product-detail/print-product-detail.css
+++ b/express/code/blocks/print-product-detail/print-product-detail.css
@@ -170,6 +170,7 @@
         font-size: var(--ax-body-xs-size);
         font-weight: var(--ax-detail-weight);
         color: var(--color-white);
+        margin: 0;
       }
       .pdpx-info-tooltip-content-description {
         font-size: var(--ax-body-xxs-size);

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -160,6 +160,13 @@ function updatePageWithUIStrings(productDetails) {
   compareValueTooltipContent.querySelector('#pdpx-info-tooltip-content-description-2').innerHTML = productDetails.compareValueTooltipDescription2;
 }
 
+async function upsertProductJsonLdFromData(apiData) {
+  const canonicalUrlCurrent = getCanonicalUrl();
+  const overridesCurrent = getAuthoredOverrides(document);
+  const jsonLd = await buildProductJsonLd(apiData, overridesCurrent, canonicalUrlCurrent);
+  upsertLdJson('pdp-product-jsonld', jsonLd);
+}
+
 export default async function decorate(block) {
   await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
     ({ createTag, getConfig, loadStyle } = utils);
@@ -180,83 +187,82 @@ export default async function decorate(block) {
   const productIdFinal = productIdFromUrl || templateId;
   const idTypeFinal = productIdFromUrl ? 'productId' : 'templateId';
   const endpoint = productIdFromUrl ? 'getproduct' : 'getproductfromtemplate';
-
-  const productDetails = fetchAPIData(productIdFinal, null, endpoint, idTypeFinal);
-
-  async function upsertProductJsonLdFromData(apiData) {
-    const canonicalUrlCurrent = getCanonicalUrl();
-    const overridesCurrent = getAuthoredOverrides(document);
-    const jsonLd = await buildProductJsonLd(apiData, overridesCurrent, canonicalUrlCurrent);
-    upsertLdJson('pdp-product-jsonld', jsonLd);
+  const productDetailsResponse = await fetchAPIData(productIdFinal, null, endpoint, idTypeFinal);
+  dataObject = await updateDataObjectProductDetails(dataObject, productDetailsResponse);
+  try {
+    const head = document.head || document.getElementsByTagName('head')[0];
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'image';
+    link.href = convertImageSize(dataObject.heroImage, '750');
+    link.fetchPriority = 'high';
+    link.setAttribute('imagesrcset', createHeroImageSrcset(dataObject.heroImage));
+    link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
+    head.appendChild(link);
+  } catch (e) {
+    /* no-op */
   }
+  try {
+    document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
+  } catch (e) {
+    /* no-op */
+  }
+  await updatePageWithProductDetails(dataObject, globalContainer);
+  // SEO: title/description (respect authored), initial Product JSON-LD
+  // (updated later when price arrives)
+  upsertTitleAndDescriptionRespectingAuthored(dataObject);
+  await upsertProductJsonLdFromData(dataObject);
+  const breadcrumbsLd = buildBreadcrumbsJsonLdFromDom();
+  if (breadcrumbsLd) upsertLdJson('pdp-breadcrumbs-jsonld', breadcrumbsLd);
+  const productId = productDetailsResponse.product.id;
+  const quantity = 1;
+  const sampleShippingParameters = { qty: quantity };
 
-  productDetails.then(async (productDetailsResponse) => {
-    dataObject = await updateDataObjectProductDetails(dataObject, productDetailsResponse);
-    try {
-      const head = document.head || document.getElementsByTagName('head')[0];
-      const link = document.createElement('link');
-      link.rel = 'preload';
-      link.as = 'image';
-      link.href = convertImageSize(dataObject.heroImage, '750');
-      link.fetchPriority = 'high';
-      link.setAttribute('imagesrcset', createHeroImageSrcset(dataObject.heroImage));
-      link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
-      head.appendChild(link);
-    } catch (e) {
-      /* no-op */
-    }
-    try {
-      document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
-    } catch (e) {
-      /* no-op */
-    }
-    updatePageWithProductDetails(dataObject, globalContainer);
-    // SEO: title/description (respect authored), initial Product JSON-LD
-    // (updated later when price arrives)
-    upsertTitleAndDescriptionRespectingAuthored(dataObject);
-    await upsertProductJsonLdFromData(dataObject);
-    const breadcrumbsLd = buildBreadcrumbsJsonLdFromDom();
-    if (breadcrumbsLd) upsertLdJson('pdp-breadcrumbs-jsonld', breadcrumbsLd);
-    const productId = productDetailsResponse.product.id;
-    const productRenditions = fetchAPIData(productId, null, 'getproductrenditions');
-    productRenditions.then(async (productRenditionsResponse) => {
+  const productRenditions = fetchAPIData(productId, null, 'getproductrenditions')
+    .then(async (productRenditionsResponse) => {
       dataObject = updateDataObjectProductRenditions(dataObject, productRenditionsResponse);
       await updatePageWithProductImages(dataObject);
     });
-    const quantity = 1;
-    const productPrice = fetchAPIData(productId, null, 'getproductpricing');
-    productPrice.then(async (productPriceResponse) => {
+
+  const productPrice = fetchAPIData(productId, null, 'getproductpricing')
+    .then(async (productPriceResponse) => {
       dataObject = updateDataObjectProductPrice(dataObject, productPriceResponse, quantity);
       await updatePageWithProductPrice(dataObject);
       // SEO: Update Product JSON-LD with pricing/offer once available
       await upsertProductJsonLdFromData(dataObject);
     });
-    const productReviews = fetchAPIData(productId, null, 'getreviews');
-    productReviews.then(async (productReviewsResponse) => {
+
+  const productReviews = fetchAPIData(productId, null, 'getreviews')
+    .then(async (productReviewsResponse) => {
       dataObject = updateDataObjectProductReviews(dataObject, productReviewsResponse);
       updatePageWithProductReviews(dataObject);
       await upsertProductJsonLdFromData(dataObject);
     });
 
-    const sampleShippingParameters = { qty: quantity };
-    const productShippingEstimates = fetchAPIData(
-      productId,
-      sampleShippingParameters,
-      'getshippingestimates',
+  const productShippingEstimates = fetchAPIData(
+    productId,
+    sampleShippingParameters,
+    'getshippingestimates',
+  ).then((productShippingEstimatesResponse) => {
+    dataObject = updateDataObjectProductShippingEstimates(
+      dataObject,
+      productShippingEstimatesResponse,
     );
-    productShippingEstimates.then((productShippingEstimatesResponse) => {
-      dataObject = updateDataObjectProductShippingEstimates(
-        dataObject,
-        productShippingEstimatesResponse,
-      );
-      updatePageWithProductShippingEstimates(dataObject);
-    });
-
-    const UIStrings = fetchUIStrings();
-    UIStrings.then((UIStringsResponse) => {
-      dataObject = updateDataObjectUIStrings(dataObject, UIStringsResponse);
-      updatePageWithUIStrings(dataObject);
-    });
-    setupCheckoutGradientToggle();
+    updatePageWithProductShippingEstimates(dataObject);
   });
+
+  const uiStrings = fetchUIStrings().then((uiStringsResponse) => {
+    dataObject = updateDataObjectUIStrings(dataObject, uiStringsResponse);
+    updatePageWithUIStrings(dataObject);
+  });
+
+  await Promise.allSettled([
+    productRenditions,
+    productPrice,
+    productReviews,
+    productShippingEstimates,
+    uiStrings,
+  ]);
+
+  setupCheckoutGradientToggle();
 }

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -188,36 +188,8 @@ export default async function decorate(block) {
   const productIdFinal = productIdFromUrl || templateId;
   const idTypeFinal = productIdFromUrl ? 'productId' : 'templateId';
   const endpoint = productIdFromUrl ? 'getproduct' : 'getproductfromtemplate';
-  const productDetailsResponse = await fetchAPIData(productIdFinal, null, endpoint, idTypeFinal);
-  dataObject = await updateDataObjectProductDetails(dataObject, productDetailsResponse);
-  try {
-    const head = document.head || document.getElementsByTagName('head')[0];
-    const link = document.createElement('link');
-    link.rel = 'preload';
-    link.as = 'image';
-    link.href = convertImageSize(dataObject.heroImage, '750');
-    link.fetchPriority = 'high';
-    link.setAttribute('imagesrcset', createHeroImageSrcset(dataObject.heroImage));
-    link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
-    head.appendChild(link);
-  } catch (e) {
-    /* no-op */
-  }
-  try {
-    document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
-  } catch (e) {
-    /* no-op */
-  }
-  await updatePageWithProductDetails(dataObject, globalContainer);
-  // SEO: title/description (respect authored), initial Product JSON-LD
-  // (updated later when price arrives)
-  upsertTitleAndDescriptionRespectingAuthored(dataObject);
-  await upsertProductJsonLdFromData(dataObject);
-  const breadcrumbsLd = buildBreadcrumbsJsonLdFromDom();
-  if (breadcrumbsLd) upsertLdJson('pdp-breadcrumbs-jsonld', breadcrumbsLd);
-  const productId = productDetailsResponse.product.id;
-  const quantity = 1;
-  const sampleShippingParameters = { qty: quantity };
+
+  const productDetails = fetchAPIData(productIdFinal, null, endpoint, idTypeFinal);
 
   productDetails.then(async (productDetailsResponse) => {
     dataObject = await updateDataObjectProductDetails(dataObject, productDetailsResponse);
@@ -258,33 +230,34 @@ export default async function decorate(block) {
       dataObject = updateDataObjectProductRenditions(dataObject, productRenditionsResponse);
       await updatePageWithProductImages(dataObject);
     });
-
-  const productPrice = fetchAPIData(productId, null, 'getproductpricing')
-    .then(async (productPriceResponse) => {
+    const quantity = 1;
+    const productPrice = fetchAPIData(productId, null, 'getproductpricing');
+    productPrice.then(async (productPriceResponse) => {
       dataObject = updateDataObjectProductPrice(dataObject, productPriceResponse, quantity);
       await updatePageWithProductPrice(dataObject);
       // SEO: Update Product JSON-LD with pricing/offer once available
       await upsertProductJsonLdFromData(dataObject);
     });
-
-  const productReviews = fetchAPIData(productId, null, 'getreviews')
-    .then(async (productReviewsResponse) => {
+    const productReviews = fetchAPIData(productId, null, 'getreviews');
+    productReviews.then(async (productReviewsResponse) => {
       dataObject = updateDataObjectProductReviews(dataObject, productReviewsResponse);
       updatePageWithProductReviews(dataObject);
       await upsertProductJsonLdFromData(dataObject);
     });
 
-  const productShippingEstimates = fetchAPIData(
-    productId,
-    sampleShippingParameters,
-    'getshippingestimates',
-  ).then((productShippingEstimatesResponse) => {
-    dataObject = updateDataObjectProductShippingEstimates(
-      dataObject,
-      productShippingEstimatesResponse,
+    const sampleShippingParameters = { qty: quantity };
+    const productShippingEstimates = fetchAPIData(
+      productId,
+      sampleShippingParameters,
+      'getshippingestimates',
     );
-    updatePageWithProductShippingEstimates(dataObject);
-  });
+    productShippingEstimates.then((productShippingEstimatesResponse) => {
+      dataObject = updateDataObjectProductShippingEstimates(
+        dataObject,
+        productShippingEstimatesResponse,
+      );
+      updatePageWithProductShippingEstimates(dataObject);
+    });
 
     const UIStrings = fetchUIStrings();
     UIStrings.then((UIStringsResponse) => {
@@ -312,14 +285,4 @@ export default async function decorate(block) {
       });
     }
   });
-
-  await Promise.allSettled([
-    productRenditions,
-    productPrice,
-    productReviews,
-    productShippingEstimates,
-    uiStrings,
-  ]);
-
-  setupCheckoutGradientToggle();
 }

--- a/express/code/blocks/print-product-detail/utilities/event-handlers.js
+++ b/express/code/blocks/print-product-detail/utilities/event-handlers.js
@@ -1,3 +1,4 @@
+import { getLibs } from '../../../scripts/utils.js';
 import fetchAPIData, {
   fetchUIStrings,
 } from '../fetchData/fetchProductDetails.js';
@@ -133,9 +134,8 @@ function createUpdatedSelectedValuesObject(
 }
 
 export default async function updateAllDynamicElements(productId) {
-  const { templateId } = document.querySelector(
-    '.pdpx-global-container',
-  ).dataset;
+  const containerElement = document.querySelector('.print-product-detail');
+  const { templateId } = containerElement.dataset;
   const form = document.querySelector('#pdpx-customization-inputs-form');
   const formData = new FormData(form);
   const formDataObject = Object.fromEntries(formData.entries());
@@ -205,4 +205,8 @@ export default async function updateAllDynamicElements(productId) {
     attributes: updatedConfigurationOptions.product.attributes,
     formData: formDataObject,
   });
+  const { decorateDefaultLinkAnalytics } = await import(`${getLibs()}/martech/attributes.js`);
+  const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
+  const config = getConfig();
+  decorateDefaultLinkAnalytics(containerElement, config);
 }

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -507,3 +507,12 @@ export async function trackPrintAddonInteraction(metadata = {}) {
     // do not surface errors to page
   }
 }
+
+export function trackPrintAddonOptionSelect({ attributeName, actionValue, productType }) {
+  return trackPrintAddonInteraction({
+    action_type: 'button',
+    action_name: attributeName,
+    action_value: actionValue,
+    productType,
+  });
+}

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -463,3 +463,49 @@ export default async function martechLoadedCB() {
   }
   // end of section to be removed after Jingle finishes adding xlg to old express Repo
 }
+
+export async function trackPrintAddonInteraction(metadata = {}) {
+  try {
+    const fireEvent = () => {
+      const payload = {
+        xdm: {},
+        data: {
+          eventType: 'web.webinteraction.linkClicks',
+          web: {
+            webInteraction: {
+              name: 'print-addon-interaction',
+              linkClicks: { value: 1 },
+              type: 'other',
+            },
+          },
+          _adobe_corpnew: {
+            sdm: {
+              event: {
+                pagename: 'print-addon-interaction',
+              },
+              custom: {
+                print_addon: {
+                  experience_type: 'guest-mode',
+                  page_type: 'product-configuration',
+                  action_type: metadata.action_type,
+                  action_name: `product-option-${metadata.optionName}`,
+                  action_value: metadata.optionName,
+                },
+                task: {
+                  name: metadata.productType,
+                },
+                addon: {
+                  is_authenticated: 'false',
+                },
+              },
+            },
+          },
+        },
+      };
+      _satellite.track('event', payload);
+    };
+    safelyFireAnalyticsEvent(fireEvent);
+  } catch (e) {
+    // do not surface errors to page
+  }
+}

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -485,17 +485,13 @@ export async function trackPrintAddonInteraction(metadata = {}) {
               },
               custom: {
                 print_addon: {
-                  experience_type: 'guest-mode',
                   page_type: 'product-configuration',
                   action_type: metadata.action_type,
-                  action_name: `product-option-${metadata.optionName}`,
-                  action_value: metadata.optionName,
+                  action_name: `product-option-${metadata.action_name}`,
+                  action_value: metadata.action_value,
                 },
                 task: {
                   name: metadata.productType,
-                },
-                addon: {
-                  is_authenticated: 'false',
                 },
               },
             },

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -498,7 +498,9 @@ export async function trackPrintAddonInteraction(metadata = {}) {
           },
         },
       };
-      _satellite.track('event', payload);
+      if (typeof _satellite !== 'undefined' && _satellite.track) {
+        _satellite.track('event', payload);
+      }
     };
     safelyFireAnalyticsEvent(fireEvent);
   } catch (e) {


### PR DESCRIPTION
## Summary

Added print-addon-interaction event to all customization input buttons

---

## Jira Ticket

Resolves: [MWPW-186217](https://jira.corp.adobe.com/browse/MWPW-186217)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage-da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card |
| **After**   | https://mwpw-186217--da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card |

---

## Verification Steps

- In order to observe the analytics event object that gets sent, start by navigating to the Page and opening the 'Network tab'
- Clear the Network log and then click a configuration option (any of the thumbnail buttons, or dropdown menu options).
- Observe the event with a name like 'collect?configId=###', you can also filter the results on the name 'collect' to reduce the clutter (see attached screenshot). 
- With the request selected, select the 'Payload' tab and then expand the following object properties:
events > 0 > data > _adobe_corpnew > sdm > custom > print_addon

- Verify the data is being sent properly.

<img width="1382" height="931" alt="analytics_screenshot" src="https://github.com/user-attachments/assets/6bf11877-e129-47f7-a1b1-5daa63b54138" />

---

## Potential Regressions

This is simply adding analytics; chance of regression is low. That said this update affects all PDP pages (pages using the 'print-product-detail' component). i.e. 

- https://mwpw-186064--da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card
- https://mwpw-186064--da-express-milo--adobecom.aem.page/express/create/print/business-card/green-and-white-personal-business-card
- https://mwpw-186064--da-express-milo--adobecom.aem.page/express/create/print/t-shirt/black-and-red-keeping-it-100-t-shirt

---

## Additional Notes

This ticket is an attempt to de-couple the bot detection logic presented in (https://github.com/adobecom/da-express-milo/pull/143) from the interaction tracking logic requested in (https://jira.corp.adobe.com/browse/MWPW-186217). Since the bot detection logic requires some tehcnical / strategy conversation between Engineering and Analytics. Hoping we can push this ticket separately as it excludes the bot detection logic and simply includes the interaction events requested from Analytics
