### PR TITLE
Removed tabnavigation attribute from highlight block items in order to remove them from tab-navigation

### DIFF
--- a/express/code/blocks/highlight/highlight.css
+++ b/express/code/blocks/highlight/highlight.css
@@ -16,13 +16,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  outline: none;
   padding: 6px 4px;
-}
-
-.highlight .icon-row:focus-visible {
-  outline: 2px solid #007bff;
-  outline-offset: 2px;
 }
 
 .highlight .icon-row .text {

--- a/express/code/blocks/highlight/highlight.js
+++ b/express/code/blocks/highlight/highlight.js
@@ -10,7 +10,6 @@ export default async function decorate(block) {
       const textElement = textDiv.firstElementChild || textDiv;
       textElement?.classList.add('text');
       textElement?.setAttribute('aria-label', textElement?.textContent.trim());
-      textElement?.setAttribute('tabindex', '0');
 
       const img = row.querySelector('img');
       if (img) {


### PR DESCRIPTION
## Summary

Removed tabnavigation attribute from highlight block items in order to remove them from tab-navigation

---

## Jira Ticket

Resolves: [MWPW-187551](https://jira.corp.adobe.com/browse/MWPW-187551)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card |
| **After**   | https://mwpw-187551--da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card?martech=off |

---

## Verification Steps

- Navigate to the page and begin pressing the tab button in order to begin cycling through the tab-navigable elements 
- You can optionally click the page anywhere above the highlight blade in order to begin the navigation from that point in the page, in order to skip the preceding navigable elements.
- Notice that the items in the highlight blade appear in tab navigation in the Before link, but no longer appear in tab navigation in the After link.

---

## Potential Regressions

This affects all pages that use the 'highlight' block. I wasnt sure which pages use this block, searching for them in DA is difficult since the term 'highlight' appears often in our web content. So listing a few of the PDP pages, which use this block,  below instead.

- https://mwpw-187551--da-express-milo--adobecom.aem.page/express/create/print/t-shirt/black-and-red-keeping-it-100-t-shirt?martech=off
- https://mwpw-187551--da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card?martech=off


---

## Additional Notes

-
