### PR TITLE
[COLOR][Service Layer][MWPW-187455] Auth Middleware

### DIFF
--- a/express/code/libs/services/config.js
+++ b/express/code/libs/services/config.js
@@ -18,24 +18,21 @@ const PROD_CONFIG = {
   environment: 'production',
   services: {
     kuler: {
-      baseSearchUrl: 'https://search.adobe.io/api/v2',
-      exploreBaseUrl: 'https://themesb3.adobe.io',
-      themeBaseUrl: 'https://themes.adobe.io',
-      likeBaseUrl: 'https://asset.adobe.io',
-      gradientBaseUrl: 'https://gradient.adobe.io',
+      baseUrl: 'https://search.adobe.io/api/v2',
       apiKey: 'KulerBackendClientId',
       endpoints: {
         search: '/search',
         api: '/api/v2',
         themePath: '/themes',
         gradientPath: '/gradient',
-        tagsPath: '/tags',
+        themeBaseUrl: 'https://themes.adobe.io',
+        likeBaseUrl: 'https://asset.adobe.io',
+        gradientBaseUrl: 'https://gradient.adobe.io',
       },
     },
     stock: {
       baseUrl: 'https://stock.adobe.io/Rest/Media/1',
       apiKey: 'ColorWeb',
-      productId: 'AdobeColor/4.0',
       endpoints: {
         search: '/Search/Files',
         redirect: 'https://stock.adobe.com',
@@ -44,20 +41,17 @@ const PROD_CONFIG = {
     },
     behance: {
       baseUrl: 'https://cc-api-behance.adobe.io/v2',
-      graphqlUrl: 'https://cc-api-behance.adobe.io/v3/graphql',
       apiKey: 'ColorWeb',
       endpoints: {
         projects: '/projects',
-        galleries: '/galleries',
       },
     },
     cclibrary: {
       baseUrl: 'https://cc-api-assets.adobe.io',
       melvilleBasePath: 'https://libraries.adobe.io/api/v1',
-      melvilleDomainPath: 'https://libraries.adobe.io',
       apiKey: 'ColorWeb',
       assetAclDirectoryKey: 'http://ns.adobe.com/adobecloud/rel/directory',
-      middleware: ['error', 'logging', { name: 'auth', topics: ['cclibrary.theme.*'] }],
+      middleware: ['error', 'logging', { name: 'auth', topics: ['cclibrary.theme.*', 'cclibrary.library.*'] }],
       endpoints: {
         libraries: '/libraries',
         themes: '/elements',
@@ -71,8 +65,6 @@ const PROD_CONFIG = {
     universal: {
       baseUrl: 'https://adobesearch.adobe.io/universal-search/v2',
       apiKey: 'ColorWeb',
-      xProduct: 'Color',
-      xProductLocation: 'Color Website',
       endpoints: {
         similarity: '/similarity-search',
         anonymousImageSearch: 'https://search.adobe.io/imageSearch',
@@ -102,49 +94,21 @@ const STAGE_CONFIG = {
     ...PROD_CONFIG.services,
     kuler: {
       ...PROD_CONFIG.services.kuler,
-      baseSearchUrl: 'https://search-stage.adobe.io/api/v2',
-      exploreBaseUrl: 'https://themesb3-stage.adobe.io',
-      themeBaseUrl: 'https://themes-stage.adobe.io',
-      likeBaseUrl: 'https://asset-stage.adobe.io',
-      gradientBaseUrl: 'https://gradient-stage.adobe.io',
-    },
-    stock: {
-      ...PROD_CONFIG.services.stock,
-      baseUrl: 'https://stock-stage.adobe.io/Rest/Media/1',
+      baseUrl: 'https://search-stage.adobe.io/api/v2',
       endpoints: {
-        ...PROD_CONFIG.services.stock.endpoints,
-        redirect: 'https://primary.stock.stage.adobe.com',
+        ...PROD_CONFIG.services.kuler.endpoints,
+        themeBaseUrl: 'https://themes-stage.adobe.io',
+        likeBaseUrl: 'https://asset-stage.adobe.io',
+        gradientBaseUrl: 'https://gradient-stage.adobe.io',
       },
     },
     behance: {
       ...PROD_CONFIG.services.behance,
       baseUrl: 'https://cc-api-behance-stage.adobe.io/v2',
-      graphqlUrl: 'https://cc-api-behance-stage.adobe.io/v3/graphql',
     },
     cclibrary: {
       ...PROD_CONFIG.services.cclibrary,
-      baseUrl: 'https://cc-api-assets-stage.adobe.io',
       melvilleBasePath: 'https://ccx-melville-stage.adobe.io/api/v1',
-      melvilleDomainPath: 'https://ccx-melville-stage.adobe.io',
-    },
-    universal: {
-      ...PROD_CONFIG.services.universal,
-      baseUrl: 'https://adobesearch-stage.adobe.io/universal-search/v2',
-      endpoints: {
-        ...PROD_CONFIG.services.universal.endpoints,
-        anonymousImageSearch: 'https://search-stage.adobe.io/imageSearch',
-      },
-    },
-    autotag: {
-      ...PROD_CONFIG.services.autotag,
-      baseUrl: 'https://kulerautotag-stage.adobe.io',
-    },
-    vader: {
-      ...PROD_CONFIG.services.vader,
-      baseUrl: 'https://d005vu55s3.execute-api.us-east-1.amazonaws.com',
-      endpoints: {
-        api: '/stage',
-      },
     },
   },
 };

--- a/express/code/libs/services/core/Errors.js
+++ b/express/code/libs/services/core/Errors.js
@@ -38,7 +38,7 @@ export class AuthenticationError extends ServiceError {
    * @param {Object} [options]
    */
   constructor(message = 'Authentication required', options = {}) {
-    super(message, { ...options, code: 'AUTH_REQUIRED' });
+    super(message, { code: 'AUTH_REQUIRED', ...options });
     this.name = 'AuthenticationError';
   }
 }
@@ -82,6 +82,25 @@ export class NotFoundError extends ServiceError {
   }
 }
 
+/**
+ * Storage Full Error
+ * Thrown when a CC Libraries operation fails due to full cloud storage (HTTP 507).
+ */
+export class StorageFullError extends ApiError {
+  /**
+   * @param {string} [message] - Error message
+   * @param {Object} [options] - Additional error context
+   */
+  constructor(message = 'Cloud storage is full', options = {}) {
+    super(message, { ...options, statusCode: 507, code: 'STORAGE_FULL' });
+    this.name = 'StorageFullError';
+  }
+}
+
+/**
+ * Plugin Registration Error
+ * Thrown when there's an issue with plugin registration.
+ */
 export class PluginRegistrationError extends ServiceError {
   /**
    * @param {string} message

--- a/express/code/libs/services/docs/ERRORS.md
+++ b/express/code/libs/services/docs/ERRORS.md
@@ -30,7 +30,7 @@ Properties included: `name`, `message`, `code`, `serviceName`, `topic`, `timesta
 - `BasePlugin.dispatch()` throws `NotFoundError` if a topic is missing.
 - `BaseApiService.handleResponse()` throws `ApiError` for non-OK responses.
   Returns `{}` for `204 No Content` (no error thrown).
-- `auth.middleware.js` throws `AuthenticationError` if not signed in.
+- `auth.middleware.js` throws `AuthenticationError` if not signed in. When a `susi-target` metadata tag is present on the page, the middleware first opens a SUSI-light sign-in modal before throwing.
 - `config.js` throws `ConfigError` when Milo libs are not initialized.
 - `ServiceManager` throws `PluginRegistrationError` on duplicate plugin registration.
 - `ServiceManager` throws `ProviderRegistrationError` on duplicate provider registration.

--- a/express/code/libs/services/docs/PROVIDERS.md
+++ b/express/code/libs/services/docs/PROVIDERS.md
@@ -112,6 +112,26 @@ Key differences from plugin-backed providers:
 - Registered via `registerProvider(name, provider)` instead of manifest `providerLoader`
 - Duplicate registration throws `ProviderRegistrationError` (same as plugins)
 
+### Cleanup with `destroy()`
+
+`AuthStateProvider` registers event listeners on both `window` (for the
+`service:ims:ready` event from the auth middleware) and the IMS SDK instance
+(for `onAccessToken`, `onAccessTokenHasExpired`, `onLogout`). Call `destroy()`
+when the provider is no longer needed to remove all listeners and clear
+subscribers, preventing memory leaks:
+
+```javascript
+const auth = await serviceManager.getProvider('authState');
+const unsub = auth.subscribe(handleStateChange);
+
+// When done (e.g. block cleanup):
+unsub();        // remove individual subscriber
+auth.destroy(); // remove all listeners + clear all subscribers
+```
+
+`destroy()` is safe to call multiple times and handles missing
+`removeEventListener` on the IMS SDK gracefully.
+
 ### Transforms
 Providers can use common transforms from
 `services/providers/transforms.js` to normalize inputs:

--- a/express/code/libs/services/docs/TESTING.md
+++ b/express/code/libs/services/docs/TESTING.md
@@ -14,7 +14,7 @@ The service layer has three distinct plugin patterns. Each guide below notes whi
 |---------|-----------|----------|---------|--------------|
 | **A — Action Groups** | `BaseApiService` | Topic-based via `BaseActionGroup` | kuler, stock | Yes |
 | **B — Direct Handlers** | `BaseApiService` | Topic-based via `registerHandlers` | curated | No |
-| **C — Direct Methods** | `BaseApiService` | No dispatch; methods called directly | behance, cclibrary, reportAbuse, universal, userFeedback, userSettings | No |
+| **C — Direct Methods** | `BaseApiService` | No dispatch; methods called directly | behance, reportAbuse, universal, userFeedback, userSettings | No |
 
 - **Providers** exist only for Pattern A plugins (kuler, stock).
 - **Action Groups** (`getHandlers()`) exist only for Pattern A plugins.

--- a/express/code/libs/services/docs/testing/test-plugins.md
+++ b/express/code/libs/services/docs/testing/test-plugins.md
@@ -72,7 +72,7 @@ describe('handler registration', () => {
 
 ## Testing Direct-Method Plugins
 
-> **Applies to:** Pattern C plugins that extend `BaseApiService` and expose methods directly without topic dispatch (currently behance, cclibrary, reportAbuse, universal, userFeedback, userSettings)
+> **Applies to:** Pattern C plugins that extend `BaseApiService` and expose methods directly without topic dispatch (currently behance, reportAbuse, universal, userFeedback, userSettings)
 
 These plugins call HTTP endpoints via inherited `get()` / `post()` / `put()` / `delete()` methods from `BaseApiService`. Testing focuses on HTTP interactions rather than topic routing.
 

--- a/express/code/libs/services/index.js
+++ b/express/code/libs/services/index.js
@@ -12,6 +12,13 @@ export {
   ProviderRegistrationError,
 } from './core/Errors.js';
 
+// Auth middleware helpers
+export { resetImsState, ensureIms, IMS_READY_EVENT } from './middlewares/auth.middleware.js';
+
+// Standalone providers
+export { default as AuthStateProvider } from './providers/AuthStateProvider.js';
+
+// Base classes (for creating new plugins)
 export { default as BasePlugin } from './core/BasePlugin.js';
 export { default as BaseApiService } from './core/BaseApiService.js';
 export { default as BaseActionGroup } from './core/BaseActionGroup.js';

--- a/express/code/libs/services/middlewares/auth.middleware.js
+++ b/express/code/libs/services/middlewares/auth.middleware.js
@@ -1,21 +1,176 @@
 import { AuthenticationError } from '../core/Errors.js';
+import { getMetadata } from '../../../scripts/utils.js';
+
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const DEFAULT_IMS_TIMEOUT_MS = 10_000;
 
 /**
- * @param {string} topic
- * @param {Array} args
- * @param {Function} next
- * @param {Object} [context]
- * @returns {Promise<any>}
- * @throws {AuthenticationError}
+ * Custom event name dispatched on `window` when IMS becomes ready.
+ * Fired exactly once per page lifecycle by `ensureIms()`.
+ * Standalone providers (e.g. AuthStateProvider) listen for this
+ * to learn when the IMS SDK is available without polling.
+ * @type {string}
+ */
+export const IMS_READY_EVENT = 'service:ims:ready';
+
+/** @type {Promise<Object>|null} Cached IMS ready promise */
+let imsReadyPromise = null;
+
+/** @type {(() => Promise<void>)|null} Optional loader override (used by tests) */
+let imsLoader = null;
+
+/** @type {boolean} Whether the IMS ready event has been dispatched */
+let imsReadyDispatched = false;
+
+/**
+ * Register an IMS loader override.
+ * In production this is **not** needed — ensureIms() auto-discovers
+ * milo's loadIms via getLibs(). Use this in tests to inject a mock loader.
+ *
+ * @param {() => Promise<void>} loader - Function that triggers IMS SDK loading
+ */
+export function setImsLoader(loader) {
+  imsLoader = loader;
+}
+
+/**
+ * Reset internal IMS state. Intended for tests only.
+ * Clears the cached promise, registered loader, and dispatched flag
+ * so each test starts clean.
+ */
+export function resetImsState() {
+  imsReadyPromise = null;
+  imsLoader = null;
+  imsReadyDispatched = false;
+}
+
+/**
+ * Dispatch the `service:ims:ready` event on `window` (at most once).
+ * Called internally by `ensureIms()` once the IMS SDK is available.
+ */
+function notifyImsReady() {
+  if (!imsReadyDispatched) {
+    imsReadyDispatched = true;
+    window.dispatchEvent(new CustomEvent(IMS_READY_EVENT));
+  }
+}
+
+/**
+ * Load IMS via milo's loadIms utility.
+ * Dynamically imports getLibs to avoid a static dependency on the scripts layer.
+ * @returns {Promise<void>}
+ */
+async function loadImsFromMilo() {
+  const { getLibs } = await import('../../../scripts/utils.js');
+  const { loadIms } = await import(`${getLibs()}/utils/utils.js`);
+  return loadIms();
+}
+
+/**
+ * Ensure the IMS SDK is loaded and ready.
+ * - Returns immediately if `window.adobeIMS` already exists
+ * - Otherwise triggers loading (via registered override or milo's loadIms)
+ * - Dispatches a `service:ims:ready` event on `window` once the SDK is
+ *   available (at most once per page lifecycle)
+ * - Caches the promise so IMS is only loaded once
+ *
+ * @param {number} [timeoutMs=10000] - Max time to wait for IMS to become ready
+ * @returns {Promise<Object>} Resolves with the `window.adobeIMS` instance
+ * @throws {AuthenticationError} If IMS times out or the loader fails
+ */
+export function ensureIms(timeoutMs = DEFAULT_IMS_TIMEOUT_MS) {
+  if (window.adobeIMS) {
+    notifyImsReady();
+    return Promise.resolve(window.adobeIMS);
+  }
+
+  if (!imsReadyPromise) {
+    imsReadyPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        imsReadyPromise = null;
+        reject(new AuthenticationError('IMS SDK load timed out', {
+          code: 'IMS_TIMEOUT',
+        }));
+      }, timeoutMs);
+
+      const loader = typeof imsLoader === 'function' ? imsLoader : loadImsFromMilo;
+      loader().then(() => {
+        if (window.adobeIMS) {
+          clearTimeout(timeout);
+          notifyImsReady();
+          resolve(window.adobeIMS);
+        }
+      }).catch((err) => {
+        clearTimeout(timeout);
+        imsReadyPromise = null;
+        reject(new AuthenticationError('IMS SDK failed to load', {
+          code: 'IMS_LOAD_FAILED',
+          originalError: err,
+        }));
+      });
+    });
+  }
+
+  return imsReadyPromise;
+}
+
+/**
+ * Check if a token is expiring within the buffer window.
+ * @param {number} expireTimestamp - Token expiry time (ms since epoch)
+ * @param {number} [bufferMs=300000] - Buffer window in milliseconds
+ * @returns {boolean} True if token expires within buffer
+ */
+export function isExpiringSoon(expireTimestamp, bufferMs = TOKEN_REFRESH_BUFFER_MS) {
+  if (!expireTimestamp || typeof expireTimestamp !== 'number') return false;
+  return Date.now() > expireTimestamp - bufferMs;
+}
+
+/**
+ * Authentication middleware with proactive token refresh.
+ *
+ * Waits for the IMS SDK to become available (triggering its load on demand
+ * via the registered loader), then gates unauthenticated users and
+ * proactively refreshes tokens nearing expiry.
+ *
+ * 1. Ensures IMS is loaded (with timeout) — triggers loading if needed
+ * 2. Gates unauthenticated users with AuthenticationError
+ *    - When a `susi-target` metadata tag is present on the page, opens
+ *      a SUSI-light sign-in modal via milo's `getModal()` before throwing
+ * 3. Proactively refreshes tokens nearing expiry (5-min buffer)
+ *    to avoid disruptive page reloads from scripts.js onTokenExpired
+ *
+ * @param {string} topic - Action topic
+ * @param {Array} args - Action arguments
+ * @param {Function} next - Next middleware/handler
+ * @param {Object} [context] - Middleware context
+ * @returns {Promise<any>} Action result
+ * @throws {AuthenticationError} When IMS fails to load or user is not logged in
  */
 export default async function authMiddleware(topic, args, next, context = {}) {
-  const isSignedInUser = window?.adobeIMS?.isSignedInUser() || false;
+  const ims = await ensureIms();
 
-  if (!isSignedInUser) {
-    throw new AuthenticationError('User is not logged in, requires login', {
+  if (!ims.isSignedInUser()) {
+    const susiTarget = getMetadata('susi-target');
+    if (susiTarget) {
+      const [path, hash] = susiTarget.split('#');
+      const id = hash;
+      const { getLibs } = await import('../../../scripts/utils.js');
+      const { getModal } = await import(`${getLibs()}/blocks/modal/modal.js`);
+      await getModal({ id, path });
+    }
+    throw new AuthenticationError('User is not logged in, start login process', {
       topic,
       serviceName: context.serviceName,
     });
+  }
+
+  const tokenInfo = ims.getAccessToken();
+  if (tokenInfo?.expire && isExpiringSoon(tokenInfo.expire)) {
+    try {
+      await ims.refreshToken();
+    } catch {
+      // Refresh failed — token might still be valid, proceed and let API decide
+    }
   }
 
   return next();

--- a/express/code/libs/services/providers/AuthStateProvider.js
+++ b/express/code/libs/services/providers/AuthStateProvider.js
@@ -1,0 +1,132 @@
+import BaseProvider from './BaseProvider.js';
+import { IMS_READY_EVENT } from '../middlewares/auth.middleware.js';
+
+export default class AuthStateProvider extends BaseProvider {
+  /** @type {{ isLoggedIn: boolean, token: string|null, imsReady: boolean }} */
+  #state = { isLoggedIn: false, token: null, imsReady: false };
+
+  /** @type {Set<Function>} */
+  #listeners = new Set();
+
+  /** @type {Function|null} Bound handler for window IMS ready event */
+  #windowHandler = null;
+
+  /** @type {Function|null} Bound handler shared across IMS SDK events */
+  #imsHandler = null;
+
+  /** @type {string[]} */
+  static IMS_EVENTS = ['onAccessToken', 'onAccessTokenHasExpired', 'onLogout'];
+
+  constructor() {
+    super(null);
+
+    if (window.adobeIMS) {
+      this.#onImsReady();
+    } else {
+      this.#windowHandler = () => this.#onImsReady();
+      window.addEventListener(IMS_READY_EVENT, this.#windowHandler, { once: true });
+    }
+  }
+
+  /** @returns {{ isLoggedIn: boolean, token: string|null, imsReady: boolean }} */
+  getState() {
+    return { ...this.#state };
+  }
+
+  /** @returns {boolean} */
+  get isLoggedIn() {
+    return this.#state.isLoggedIn;
+  }
+
+  /** @returns {boolean} */
+  get imsReady() {
+    return this.#state.imsReady;
+  }
+
+  /**
+   * @param {(state: { isLoggedIn: boolean, token: string|null, imsReady: boolean }) => void} cb
+   * @returns {() => void} Unsubscribe function
+   */
+  subscribe(callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('subscribe() requires a function callback');
+    }
+    this.#listeners.add(callback);
+    return () => this.#listeners.delete(callback);
+  }
+
+  /** @private — called once when IMS SDK becomes available */
+  #onImsReady() {
+    this.#windowHandler = null;
+    this.#state.imsReady = true;
+    this.#syncState();
+    this.#bridgeImsEvents();
+    this.#notify();
+  }
+
+  /** @private */
+  #syncState(ims = window?.adobeIMS) {
+    this.#state = {
+      ...this.#state,
+      isLoggedIn: ims?.isSignedInUser?.() || false,
+      token: ims?.getAccessToken?.()?.token || null,
+    };
+  }
+
+  /** @private */
+  #bridgeImsEvents(ims = window?.adobeIMS) {
+    if (!ims?.addEventListener) return;
+
+    this.#imsHandler = () => this.#handleImsEvent();
+
+    AuthStateProvider.IMS_EVENTS.forEach((event) => {
+      ims.addEventListener(event, this.#imsHandler);
+    });
+  }
+
+  /** @private */
+  #handleImsEvent() {
+    const prevLoggedIn = this.#state.isLoggedIn;
+    this.#syncState();
+
+    if (this.#state.isLoggedIn !== prevLoggedIn) {
+      this.#notify();
+    }
+  }
+
+  /** @private */
+  #notify() {
+    const snapshot = this.getState();
+    this.#listeners.forEach((cb) => {
+      try {
+        cb(snapshot);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('AuthStateProvider subscriber error:', error);
+      }
+    });
+  }
+
+  /**
+   * Clean up all event listeners and subscribers.
+   * Call this when the provider is no longer needed to prevent memory leaks.
+   */
+  destroy() {
+    if (this.#windowHandler) {
+      window.removeEventListener(IMS_READY_EVENT, this.#windowHandler);
+      this.#windowHandler = null;
+    }
+
+    if (this.#imsHandler) {
+      const ims = window?.adobeIMS;
+      if (ims?.removeEventListener) {
+        AuthStateProvider.IMS_EVENTS.forEach((event) => {
+          ims.removeEventListener(event, this.#imsHandler);
+        });
+      }
+      this.#imsHandler = null;
+    }
+
+    this.#listeners.clear();
+  }
+}

--- a/express/code/libs/services/providers/index.js
+++ b/express/code/libs/services/providers/index.js
@@ -1,2 +1,3 @@
 export { default as BaseProvider } from './BaseProvider.js';
+export { default as AuthStateProvider } from './AuthStateProvider.js';
 export { default as CCLibraryProvider, createCCLibraryProvider } from './CCLibraryProvider.js';

--- a/test/services/middlewares/auth.middleware.test.js
+++ b/test/services/middlewares/auth.middleware.test.js
@@ -1,33 +1,27 @@
+/* global globalThis */
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import authMiddleware from '../../../express/code/libs/services/middlewares/auth.middleware.js';
+import { setLibs } from '../../../express/code/scripts/utils.js';
+import authMiddleware, {
+  isExpiringSoon,
+  setImsLoader,
+  resetImsState,
+  ensureIms,
+  IMS_READY_EVENT,
+} from '../../../express/code/libs/services/middlewares/auth.middleware.js';
 import { AuthenticationError } from '../../../express/code/libs/services/core/Errors.js';
 
 describe('authMiddleware', () => {
   afterEach(() => {
     sinon.restore();
-    delete window.adobeIMS;
+    resetImsState();
+    delete globalThis.adobeIMS;
   });
 
-  it('throws AuthenticationError when user is not signed in', async () => {
-    window.adobeIMS = {
-      isSignedInUser: sinon.stub().returns(false),
-    };
-
-    try {
-      await authMiddleware('topic.test', [], sinon.stub().resolves('ok'), { serviceName: 'Stock' });
-      expect.fail('Expected AuthenticationError');
-    } catch (error) {
-      expect(error).to.be.instanceOf(AuthenticationError);
-      expect(error.message).to.equal('User is not logged in, requires login');
-      expect(error.serviceName).to.equal('Stock');
-      expect(error.topic).to.equal('topic.test');
-    }
-  });
-
-  it('calls next and returns result when user is signed in', async () => {
-    window.adobeIMS = {
+  it('resolves immediately when IMS is already on window', async () => {
+    globalThis.adobeIMS = {
       isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'abc', expire: Date.now() + 30 * 60_000 }),
     };
     const next = sinon.stub().resolves('handler-result');
 
@@ -37,8 +31,432 @@ describe('authMiddleware', () => {
     expect(result).to.equal('handler-result');
   });
 
+  it('waits for loader to set adobeIMS when IMS is not yet on window', async () => {
+    delete globalThis.adobeIMS;
+
+    const imsStub = {
+      isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'abc', expire: Date.now() + 30 * 60_000 }),
+    };
+
+    setImsLoader(() => {
+      globalThis.adobeIMS = imsStub;
+      return Promise.resolve();
+    });
+
+    const next = sinon.stub().resolves('ok');
+    const result = await authMiddleware('topic.test', [], next, { serviceName: 'CCLibrary' });
+
+    expect(next.calledOnce).to.be.true;
+    expect(result).to.equal('ok');
+  });
+
+  it('throws IMS_TIMEOUT when IMS never becomes ready', async () => {
+    delete globalThis.adobeIMS;
+    setImsLoader(() => Promise.resolve());
+
+    try {
+      await ensureIms(50);
+      expect.fail('Expected AuthenticationError');
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthenticationError);
+      expect(error.code).to.equal('IMS_TIMEOUT');
+    }
+  });
+
+  it('throws IMS_LOAD_FAILED when the loader rejects', async () => {
+    delete globalThis.adobeIMS;
+    setImsLoader(() => Promise.reject(new Error('network error')));
+
+    try {
+      await ensureIms(5000);
+      expect.fail('Expected AuthenticationError');
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthenticationError);
+      expect(error.code).to.equal('IMS_LOAD_FAILED');
+      expect(error.originalError.message).to.equal('network error');
+    }
+  });
+
+  it('throws AuthenticationError when user is not signed in', async () => {
+    globalThis.adobeIMS = {
+      isSignedInUser: sinon.stub().returns(false),
+    };
+
+    try {
+      await authMiddleware('topic.test', [], sinon.stub().resolves('ok'), { serviceName: 'Stock' });
+      expect.fail('Expected AuthenticationError');
+    } catch (error) {
+      expect(error).to.be.instanceOf(AuthenticationError);
+      expect(error.message).to.equal('User is not logged in, start login process');
+      expect(error.serviceName).to.equal('Stock');
+      expect(error.topic).to.equal('topic.test');
+    }
+  });
+
   it('buildContext returns service and topic metadata', () => {
     const context = authMiddleware.buildContext({ serviceName: 'Kuler', topic: 'kuler.search' });
     expect(context).to.deep.equal({ serviceName: 'Kuler', topic: 'kuler.search' });
+  });
+
+  describe('proactive token refresh', () => {
+    it('attempts token refresh when token is expiring soon', async () => {
+      const refreshToken = sinon.stub().resolves();
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({
+          token: 'abc',
+          expire: Date.now() + 60_000,
+        }),
+        refreshToken,
+      };
+      const next = sinon.stub().resolves('ok');
+
+      const result = await authMiddleware('topic.test', [], next, { serviceName: 'CCLibrary' });
+
+      expect(refreshToken.calledOnce).to.be.true;
+      expect(next.calledOnce).to.be.true;
+      expect(result).to.equal('ok');
+    });
+
+    it('skips token refresh when token has ample time remaining', async () => {
+      const refreshToken = sinon.stub().resolves();
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({
+          token: 'abc',
+          expire: Date.now() + 30 * 60_000,
+        }),
+        refreshToken,
+      };
+      const next = sinon.stub().resolves('ok');
+
+      await authMiddleware('topic.test', [], next, { serviceName: 'CCLibrary' });
+
+      expect(refreshToken.called).to.be.false;
+      expect(next.calledOnce).to.be.true;
+    });
+
+    it('still calls next when token refresh fails', async () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({
+          token: 'abc',
+          expire: Date.now() + 60_000,
+        }),
+        refreshToken: sinon.stub().rejects(new Error('refresh failed')),
+      };
+      const next = sinon.stub().resolves('ok');
+
+      const result = await authMiddleware('topic.test', [], next, { serviceName: 'CCLibrary' });
+
+      expect(next.calledOnce).to.be.true;
+      expect(result).to.equal('ok');
+    });
+
+    it('skips refresh when getAccessToken returns no expire field', async () => {
+      const refreshToken = sinon.stub().resolves();
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        refreshToken,
+      };
+      const next = sinon.stub().resolves('ok');
+
+      await authMiddleware('topic.test', [], next, { serviceName: 'CCLibrary' });
+
+      expect(refreshToken.called).to.be.false;
+      expect(next.calledOnce).to.be.true;
+    });
+  });
+
+  describe('SUSI modal login redirection', () => {
+    let metaTag;
+
+    beforeEach(() => {
+      setLibs('/test/services/mocks', { hostname: 'prod.example.com', search: '' });
+    });
+
+    afterEach(() => {
+      if (metaTag) {
+        metaTag.remove();
+        metaTag = null;
+      }
+      delete globalThis.mockGetModalCalls;
+    });
+
+    it('opens SUSI modal before throwing when susi-target metadata is present', async () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+      };
+
+      metaTag = document.createElement('meta');
+      metaTag.setAttribute('name', 'susi-target');
+      metaTag.setAttribute('content', '/express/fragments/susi-light#susi-light');
+      document.head.appendChild(metaTag);
+
+      try {
+        await authMiddleware('topic.test', [], sinon.stub(), { serviceName: 'Stock' });
+        expect.fail('Expected AuthenticationError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(AuthenticationError);
+        expect(error.message).to.equal('User is not logged in, start login process');
+      }
+
+      expect(globalThis.mockGetModalCalls).to.have.lengthOf(1);
+      expect(globalThis.mockGetModalCalls[0]).to.deep.equal({
+        id: 'susi-light',
+        path: '/express/fragments/susi-light',
+      });
+    });
+
+    it('passes correct path and id from susi-target metadata', async () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+      };
+
+      metaTag = document.createElement('meta');
+      metaTag.setAttribute('name', 'susi-target');
+      metaTag.setAttribute('content', '/express/fragments/custom-login#my-login-form');
+      document.head.appendChild(metaTag);
+
+      try {
+        await authMiddleware('topic.test', [], sinon.stub(), { serviceName: 'Kuler' });
+        expect.fail('Expected AuthenticationError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(AuthenticationError);
+      }
+
+      expect(globalThis.mockGetModalCalls[0]).to.deep.equal({
+        id: 'my-login-form',
+        path: '/express/fragments/custom-login',
+      });
+    });
+
+    it('skips modal and throws directly when susi-target metadata is absent', async () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+      };
+
+      try {
+        await authMiddleware('topic.test', [], sinon.stub(), { serviceName: 'Stock' });
+        expect.fail('Expected AuthenticationError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(AuthenticationError);
+        expect(error.message).to.equal('User is not logged in, start login process');
+      }
+
+      expect(globalThis.mockGetModalCalls).to.be.undefined;
+    });
+  });
+});
+
+describe('ensureIms', () => {
+  afterEach(() => {
+    sinon.restore();
+    resetImsState();
+    delete globalThis.adobeIMS;
+  });
+
+  it('returns window.adobeIMS immediately when already present', async () => {
+    const imsStub = { isSignedInUser: () => true };
+    globalThis.adobeIMS = imsStub;
+
+    const result = await ensureIms();
+    expect(result).to.equal(imsStub);
+  });
+
+  it('caches the promise so IMS is only loaded once', async () => {
+    const imsStub = {
+      isSignedInUser: sinon.stub().returns(true),
+      getAccessToken: sinon.stub().returns({ token: 'abc', expire: Date.now() + 30 * 60_000 }),
+    };
+    const loader = sinon.stub().callsFake(() => {
+      globalThis.adobeIMS = imsStub;
+      return Promise.resolve();
+    });
+    setImsLoader(loader);
+
+    const [result1, result2] = await Promise.all([ensureIms(), ensureIms()]);
+
+    expect(result1).to.equal(result2);
+    expect(loader.calledOnce).to.be.true;
+  });
+
+  it('resolves via loader .then() when loader sets adobeIMS', async () => {
+    delete globalThis.adobeIMS;
+
+    const imsStub = { isSignedInUser: () => true };
+    setImsLoader(() => {
+      globalThis.adobeIMS = imsStub;
+      return Promise.resolve();
+    });
+
+    const result = await ensureIms();
+    expect(result).to.equal(imsStub);
+  });
+
+  it('resets cached promise after timeout so retry can succeed', async () => {
+    delete globalThis.adobeIMS;
+    setImsLoader(() => Promise.resolve());
+
+    try {
+      await ensureIms(50);
+      expect.fail('Expected AuthenticationError');
+    } catch (error) {
+      expect(error.code).to.equal('IMS_TIMEOUT');
+    }
+
+    // After timeout, ensureIms should start fresh and succeed with a new loader
+    const imsStub = { isSignedInUser: () => true };
+    setImsLoader(() => {
+      globalThis.adobeIMS = imsStub;
+      return Promise.resolve();
+    });
+
+    const result = await ensureIms();
+    expect(result).to.equal(imsStub);
+  });
+
+  it('resets cached promise after load failure so retry can succeed', async () => {
+    delete globalThis.adobeIMS;
+    setImsLoader(() => Promise.reject(new Error('network error')));
+
+    try {
+      await ensureIms(5000);
+      expect.fail('Expected AuthenticationError');
+    } catch (error) {
+      expect(error.code).to.equal('IMS_LOAD_FAILED');
+    }
+
+    // After failure, ensureIms should start fresh
+    const imsStub = { isSignedInUser: () => true };
+    setImsLoader(() => {
+      globalThis.adobeIMS = imsStub;
+      return Promise.resolve();
+    });
+
+    const result = await ensureIms();
+    expect(result).to.equal(imsStub);
+  });
+});
+
+describe('resetImsState', () => {
+  afterEach(() => {
+    resetImsState();
+    delete globalThis.adobeIMS;
+  });
+
+  it('clears cached promise so ensureIms starts fresh', async () => {
+    const imsStub = { isSignedInUser: () => true };
+    globalThis.adobeIMS = imsStub;
+
+    const first = await ensureIms();
+    expect(first).to.equal(imsStub);
+
+    resetImsState();
+    delete globalThis.adobeIMS;
+
+    const imsStub2 = { isSignedInUser: () => false };
+    setImsLoader(() => {
+      globalThis.adobeIMS = imsStub2;
+      return Promise.resolve();
+    });
+
+    const second = await ensureIms();
+    expect(second).to.equal(imsStub2);
+  });
+});
+
+describe('IMS_READY_EVENT dispatch', () => {
+  afterEach(() => {
+    sinon.restore();
+    resetImsState();
+    delete globalThis.adobeIMS;
+  });
+
+  it('dispatches service:ims:ready when adobeIMS is already present', async () => {
+    globalThis.adobeIMS = { isSignedInUser: () => true };
+    const spy = sinon.spy();
+    globalThis.addEventListener(IMS_READY_EVENT, spy, { once: true });
+
+    await ensureIms();
+
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('dispatches service:ims:ready after loader sets adobeIMS', async () => {
+    delete globalThis.adobeIMS;
+    const imsStub = { isSignedInUser: () => true };
+    setImsLoader(() => {
+      globalThis.adobeIMS = imsStub;
+      return Promise.resolve();
+    });
+
+    const spy = sinon.spy();
+    globalThis.addEventListener(IMS_READY_EVENT, spy, { once: true });
+
+    await ensureIms();
+
+    expect(spy.calledOnce).to.be.true;
+  });
+
+  it('dispatches the event at most once across multiple ensureIms calls', async () => {
+    globalThis.adobeIMS = { isSignedInUser: () => true };
+    const spy = sinon.spy();
+    globalThis.addEventListener(IMS_READY_EVENT, spy);
+
+    await ensureIms();
+    await ensureIms();
+    await ensureIms();
+
+    expect(spy.callCount).to.equal(1);
+
+    globalThis.removeEventListener(IMS_READY_EVENT, spy);
+  });
+
+  it('can dispatch again after resetImsState', async () => {
+    globalThis.adobeIMS = { isSignedInUser: () => true };
+    const spy = sinon.spy();
+    globalThis.addEventListener(IMS_READY_EVENT, spy);
+
+    await ensureIms();
+    expect(spy.callCount).to.equal(1);
+
+    resetImsState();
+
+    await ensureIms();
+    expect(spy.callCount).to.equal(2);
+
+    globalThis.removeEventListener(IMS_READY_EVENT, spy);
+  });
+});
+
+describe('isExpiringSoon', () => {
+  it('returns true when token expires within default buffer (5 min)', () => {
+    expect(isExpiringSoon(Date.now() + 60_000)).to.be.true;
+  });
+
+  it('returns false when token has ample time remaining', () => {
+    expect(isExpiringSoon(Date.now() + 10 * 60_000)).to.be.false;
+  });
+
+  it('returns true when token is already expired', () => {
+    expect(isExpiringSoon(Date.now() - 60_000)).to.be.true;
+  });
+
+  it('returns false for null or undefined input', () => {
+    expect(isExpiringSoon(null)).to.be.false;
+    expect(isExpiringSoon(undefined)).to.be.false;
+  });
+
+  it('returns false for non-number input', () => {
+    expect(isExpiringSoon('not-a-number')).to.be.false;
+  });
+
+  it('respects custom buffer parameter', () => {
+    const expire = Date.now() + 2 * 60_000;
+    expect(isExpiringSoon(expire, 60_000)).to.be.false;
+    expect(isExpiringSoon(expire, 3 * 60_000)).to.be.true;
   });
 });

--- a/test/services/mocks/blocks/modal/modal.js
+++ b/test/services/mocks/blocks/modal/modal.js
@@ -1,0 +1,13 @@
+/* global globalThis */
+
+/**
+ * Mock modal module for auth middleware tests.
+ * Tracks calls via globalThis.mockGetModalCalls so tests can assert
+ * the SUSI-light modal was opened with the expected parameters.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function getModal(opts) {
+  globalThis.mockGetModalCalls = globalThis.mockGetModalCalls || [];
+  globalThis.mockGetModalCalls.push(opts);
+  return Promise.resolve();
+}

--- a/test/services/providers/AuthStateProvider.test.js
+++ b/test/services/providers/AuthStateProvider.test.js
@@ -1,0 +1,442 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import AuthStateProvider from '../../../express/code/libs/services/providers/AuthStateProvider.js';
+import { IMS_READY_EVENT } from '../../../express/code/libs/services/middlewares/auth.middleware.js';
+
+/** Dispatch the service:ims:ready event to simulate middleware IMS initialization */
+function dispatchImsReady() {
+  globalThis.dispatchEvent(new CustomEvent(IMS_READY_EVENT));
+}
+
+describe('AuthStateProvider', () => {
+  let provider;
+
+  afterEach(() => {
+    if (provider) provider.destroy();
+    sinon.restore();
+    delete globalThis.adobeIMS;
+  });
+
+  describe('getState / isLoggedIn / imsReady', () => {
+    it('returns logged-out state when IMS is not available', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      expect(provider.getState()).to.deep.equal({
+        isLoggedIn: false,
+        token: null,
+        imsReady: false,
+      });
+      expect(provider.isLoggedIn).to.be.false;
+      expect(provider.imsReady).to.be.false;
+    });
+
+    it('returns logged-in state when IMS reports signed-in user', () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc-123' }),
+        addEventListener: sinon.stub(),
+      };
+      provider = new AuthStateProvider();
+
+      expect(provider.getState()).to.deep.equal({
+        isLoggedIn: true,
+        token: 'abc-123',
+        imsReady: true,
+      });
+      expect(provider.isLoggedIn).to.be.true;
+      expect(provider.imsReady).to.be.true;
+    });
+
+    it('returns a defensive copy (mutations do not affect internal state)', () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: sinon.stub(),
+      };
+      provider = new AuthStateProvider();
+
+      const state = provider.getState();
+      state.isLoggedIn = false;
+      state.token = 'tampered';
+      state.imsReady = false;
+
+      expect(provider.getState()).to.deep.equal({
+        isLoggedIn: true,
+        token: 'abc',
+        imsReady: true,
+      });
+    });
+  });
+
+  describe('subscribe / unsubscribe', () => {
+    it('throws TypeError for non-function callback', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      expect(() => provider.subscribe('not-a-function')).to.throw(TypeError);
+      expect(() => provider.subscribe(null)).to.throw(TypeError);
+    });
+
+    it('returns an unsubscribe function', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      const unsub = provider.subscribe(() => {});
+      expect(unsub).to.be.a('function');
+    });
+
+    it('prevents duplicate subscriptions (Set-based)', () => {
+      const listeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: (event, handler) => listeners.push({ event, handler }),
+      };
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+      provider.subscribe(spy);
+
+      // Simulate login event
+      globalThis.adobeIMS.isSignedInUser.returns(true);
+      globalThis.adobeIMS.getAccessToken.returns({ token: 'new' });
+      listeners[0].handler();
+
+      expect(spy.callCount).to.equal(1);
+    });
+
+    it('unsubscribe removes listener', () => {
+      const listeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: (event, handler) => listeners.push({ event, handler }),
+      };
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      const unsub = provider.subscribe(spy);
+      unsub();
+
+      // Simulate login event
+      globalThis.adobeIMS.isSignedInUser.returns(true);
+      globalThis.adobeIMS.getAccessToken.returns({ token: 'new' });
+      listeners[0].handler();
+
+      expect(spy.called).to.be.false;
+    });
+  });
+
+  describe('IMS event bridging', () => {
+    it('registers listeners for all IMS lifecycle events', () => {
+      const addSpy = sinon.spy();
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: addSpy,
+      };
+      provider = new AuthStateProvider();
+
+      const registeredEvents = addSpy.args.map(([event]) => event);
+      expect(registeredEvents).to.include('onAccessToken');
+      expect(registeredEvents).to.include('onAccessTokenHasExpired');
+      expect(registeredEvents).to.include('onLogout');
+    });
+
+    it('notifies subscribers when login status changes (logged-out → logged-in)', () => {
+      const listeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: (event, handler) => listeners.push({ event, handler }),
+      };
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+
+      // Simulate login
+      globalThis.adobeIMS.isSignedInUser.returns(true);
+      globalThis.adobeIMS.getAccessToken.returns({ token: 'fresh-token' });
+      listeners.find((l) => l.event === 'onAccessToken').handler();
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0]).to.deep.equal({
+        isLoggedIn: true,
+        token: 'fresh-token',
+        imsReady: true,
+      });
+    });
+
+    it('notifies subscribers when login status changes (logged-in → logged-out)', () => {
+      const capturedListeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: (event, handler) => capturedListeners.push({ event, handler }),
+      };
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+
+      // Simulate logout
+      globalThis.adobeIMS.isSignedInUser.returns(false);
+      globalThis.adobeIMS.getAccessToken.returns(null);
+      capturedListeners.find((l) => l.event === 'onLogout').handler();
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0]).to.deep.equal({
+        isLoggedIn: false,
+        token: null,
+        imsReady: true,
+      });
+    });
+
+    it('does NOT notify when IMS event fires but login status is unchanged', () => {
+      const capturedListeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: (event, handler) => capturedListeners.push({ event, handler }),
+      };
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+
+      // Token refreshed but still logged in — no state change
+      globalThis.adobeIMS.getAccessToken.returns({ token: 'refreshed-token' });
+      capturedListeners.find((l) => l.event === 'onAccessToken').handler();
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('skips IMS bridging when addEventListener is not available', () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        // No addEventListener
+      };
+
+      // Should not throw
+      provider = new AuthStateProvider();
+      expect(provider.isLoggedIn).to.be.true;
+    });
+
+    it('catches and logs subscriber errors without affecting other subscribers', () => {
+      const capturedListeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: (event, handler) => capturedListeners.push({ event, handler }),
+      };
+      provider = new AuthStateProvider();
+
+      const errorSpy = sinon.stub(console, 'error');
+      const badSubscriber = sinon.stub().throws(new Error('subscriber boom'));
+      const goodSubscriber = sinon.spy();
+
+      provider.subscribe(badSubscriber);
+      provider.subscribe(goodSubscriber);
+
+      // Simulate login
+      globalThis.adobeIMS.isSignedInUser.returns(true);
+      globalThis.adobeIMS.getAccessToken.returns({ token: 'new' });
+      capturedListeners[0].handler();
+
+      expect(badSubscriber.calledOnce).to.be.true;
+      expect(goodSubscriber.calledOnce).to.be.true;
+      expect(errorSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('deferred IMS initialization (service:ims:ready event)', () => {
+    it('recovers state when service:ims:ready fires after construction', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      expect(provider.isLoggedIn).to.be.false;
+      expect(provider.imsReady).to.be.false;
+
+      // Simulate IMS loading later
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'late-token' }),
+        addEventListener: sinon.stub(),
+      };
+      dispatchImsReady();
+
+      expect(provider.isLoggedIn).to.be.true;
+      expect(provider.imsReady).to.be.true;
+      expect(provider.getState()).to.deep.equal({
+        isLoggedIn: true,
+        token: 'late-token',
+        imsReady: true,
+      });
+    });
+
+    it('notifies subscribers when service:ims:ready fires and user is signed in', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'late-token' }),
+        addEventListener: sinon.stub(),
+      };
+      dispatchImsReady();
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0]).to.deep.equal({
+        isLoggedIn: true,
+        token: 'late-token',
+        imsReady: true,
+      });
+    });
+
+    it('notifies subscribers of imsReady even when user is not signed in', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: sinon.stub(),
+      };
+      dispatchImsReady();
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0]).to.deep.equal({
+        isLoggedIn: false,
+        token: null,
+        imsReady: true,
+      });
+    });
+
+    it('bridges IMS lifecycle events after service:ims:ready fires', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      const capturedListeners = [];
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+        getAccessToken: sinon.stub().returns(null),
+        addEventListener: (event, handler) => capturedListeners.push({ event, handler }),
+      };
+      dispatchImsReady();
+
+      const registeredEvents = capturedListeners.map(({ event }) => event);
+      expect(registeredEvents).to.include('onAccessToken');
+      expect(registeredEvents).to.include('onAccessTokenHasExpired');
+      expect(registeredEvents).to.include('onLogout');
+
+      // Verify events work after deferred bridging
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+
+      globalThis.adobeIMS.isSignedInUser.returns(true);
+      globalThis.adobeIMS.getAccessToken.returns({ token: 'deferred-token' });
+      capturedListeners.find((l) => l.event === 'onAccessToken').handler();
+
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.firstCall.args[0]).to.deep.equal({
+        isLoggedIn: true,
+        token: 'deferred-token',
+        imsReady: true,
+      });
+    });
+  });
+
+  describe('standalone provider semantics', () => {
+    it('has isAvailable = false (no backing plugin)', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+      expect(provider.isAvailable).to.be.false;
+    });
+  });
+
+  describe('destroy()', () => {
+    it('removes window listener when IMS was not yet ready', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      const removeSpy = sinon.spy(globalThis, 'removeEventListener');
+      provider.destroy();
+
+      const removed = removeSpy.args.find(([event]) => event === IMS_READY_EVENT);
+      expect(removed).to.exist;
+    });
+
+    it('removes IMS SDK event listeners after bridging', () => {
+      const removeSpy = sinon.spy();
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: sinon.stub(),
+        removeEventListener: removeSpy,
+      };
+      provider = new AuthStateProvider();
+
+      provider.destroy();
+
+      const removedEvents = removeSpy.args.map(([event]) => event);
+      expect(removedEvents).to.include('onAccessToken');
+      expect(removedEvents).to.include('onAccessTokenHasExpired');
+      expect(removedEvents).to.include('onLogout');
+    });
+
+    it('clears all subscribers', () => {
+      delete globalThis.adobeIMS;
+      provider = new AuthStateProvider();
+
+      const spy = sinon.spy();
+      provider.subscribe(spy);
+      provider.destroy();
+
+      // Simulate IMS ready after destroy — subscriber should NOT be called
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: sinon.stub(),
+      };
+      dispatchImsReady();
+
+      expect(spy.called).to.be.false;
+    });
+
+    it('is safe to call multiple times', () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: sinon.stub(),
+        removeEventListener: sinon.stub(),
+      };
+      provider = new AuthStateProvider();
+
+      expect(() => {
+        provider.destroy();
+        provider.destroy();
+      }).to.not.throw();
+    });
+
+    it('does not call removeEventListener when IMS has no removeEventListener', () => {
+      globalThis.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+        getAccessToken: sinon.stub().returns({ token: 'abc' }),
+        addEventListener: sinon.stub(),
+      };
+      provider = new AuthStateProvider();
+
+      expect(() => provider.destroy()).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Enhances the authentication middleware with proactive token refresh to prevent disruptive page reloads. Adds an `isExpiringSoon` utility that checks if the IMS access token expires within a configurable buffer window (default 5 minutes). When the token is nearing expiry, the middleware silently attempts `ims.refreshToken()` before proceeding — if the refresh fails, execution continues and lets the downstream API decide. Includes comprehensive unit tests covering auth gating, token refresh scenarios, and edge cases.

---

## Jira Ticket

Resolves: [MWPW-187455](https://jira.corp.adobe.com/browse/MWPW-187455)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/dhananjay/color-poc |
| **After**   | https://dhansingh-authentication-setup--da-express-milo--adobecom.aem.page/drafts/dhananjay/color-poc?martech=off |

---

## Verification Steps

- Verify that unauthenticated users are blocked with an `AuthenticationError` when invoking service actions that require auth (e.g., CC Library operations).
- Log in and trigger a service action — confirm the middleware passes through and returns the expected result.
- Simulate a token nearing expiry (within 5 minutes) and confirm `refreshToken()` is called proactively before the action proceeds.
- Confirm that if token refresh fails, the action still proceeds without throwing.

---

## Potential Regressions

- https://dhansingh-authentication-setup--da-express-milo--adobecom.aem.live/drafts/dhananjay/color-poc?martech=off

---

## Additional Notes

- The auth middleware is applied per-service via the config's `middleware` array (e.g., `cclibrary` specifies `['error', 'logging', 'auth']`).
- Global middleware (`error`, `logging`) runs on all plugins by default; `auth` is opt-in per service.
- The `guardMiddleware` utility and `matchTopic` helper support conditional middleware execution with topic-based filtering.