### PR TITLE
[NO-JIRA] - Fixed upload issue for immediately signed in users

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -309,6 +309,8 @@ async function performStorageUpload(files, block, quickAction) {
       showErrorToast(block, error.message);
     }
 
+    if (progressBar) resetUploadUI();
+
     // Log video upload failure for analytics
     if (file && file.type.startsWith('video/')) {
       const uploadDuration = Date.now() - uploadStartTime;

--- a/express/code/scripts/upload-service/dist/Logging-C8fOZKOL.min.js
+++ b/express/code/scripts/upload-service/dist/Logging-C8fOZKOL.min.js
@@ -1,4 +1,4 @@
-import { E as a } from "./index-CBsgbXDI.min.js";
+import { E as a } from "./index-hlD7V_Qu.min.js";
 const n = {
   LOG_UPLOAD_START: "LOG_UPLOAD_START",
   LOG_UPLOAD_RESPONSE: "LOG_UPLOAD_RESPONSE",
@@ -145,4 +145,4 @@ export {
   s as LogMarkers,
   g as LogService
 };
-//# sourceMappingURL=Logging-VoBCga4r.min.js.map
+//# sourceMappingURL=Logging-C8fOZKOL.min.js.map

--- a/express/code/scripts/upload-service/dist/index-hlD7V_Qu.min.js
+++ b/express/code/scripts/upload-service/dist/index-hlD7V_Qu.min.js
@@ -5114,7 +5114,7 @@ class kd {
    * Initialize logging service
    */
   async initializeLogging() {
-    const { LogService: e } = await import("./Logging-VoBCga4r.min.js");
+    const { LogService: e } = await import("./Logging-C8fOZKOL.min.js");
     this.logService = new e(), await this.logService.initialize(this.config.environment);
   }
   /**
@@ -5136,9 +5136,10 @@ class kd {
    * This function does a couple of things:
    * 1. Gets the index document for the user
    * 2. Gets the children of the index document
-   * 3. If there is only one child, that is the repository
-   * 4. If there are multiple children, it finds the temp folder. If there is no temp folder, it uses the first child as the repository
-   * 5. Returns the repository ID and path
+   * 3. If there are no children (new user), falls back to the index repo itself
+   * 4. If there is only one child, that is the repository
+   * 5. If there are multiple children, it finds the temp folder. If there is no temp folder, it uses the first child as the repository
+   * 6. Returns the repository ID and path
    * @returns Promise resolving to the repository
    */
   async setupUserRepository() {
@@ -5148,6 +5149,11 @@ class kd {
     const o = await this.config.directory.getPagedChildren();
     if (o != null && o.result) {
       const d = o.result.children;
+      if (!d || d.length === 0)
+        return {
+          repositoryId: r,
+          path: "/"
+        };
       if (d.length === 1) {
         const h = d[0];
         return {
@@ -5480,4 +5486,4 @@ export {
   md as U,
   Ud as i
 };
-//# sourceMappingURL=index-CBsgbXDI.min.js.map
+//# sourceMappingURL=index-hlD7V_Qu.min.js.map

--- a/express/code/scripts/upload-service/dist/upload-service.min.es.js
+++ b/express/code/scripts/upload-service/dist/upload-service.min.es.js
@@ -1,4 +1,4 @@
-import { U as e, i as o } from "./index-CBsgbXDI.min.js";
+import { U as e, i as o } from "./index-hlD7V_Qu.min.js";
 export {
   e as UPLOAD_EVENTS,
   o as initUploadService

--- a/express/code/scripts/upload-service/src/upload-service/UploadService.ts
+++ b/express/code/scripts/upload-service/src/upload-service/UploadService.ts
@@ -77,9 +77,10 @@ export class UploadService {
    * This function does a couple of things:
    * 1. Gets the index document for the user
    * 2. Gets the children of the index document
-   * 3. If there is only one child, that is the repository
-   * 4. If there are multiple children, it finds the temp folder. If there is no temp folder, it uses the first child as the repository
-   * 5. Returns the repository ID and path
+   * 3. If there are no children (new user), falls back to the index repo itself
+   * 4. If there is only one child, that is the repository
+   * 5. If there are multiple children, it finds the temp folder. If there is no temp folder, it uses the first child as the repository
+   * 6. Returns the repository ID and path
    * @returns Promise resolving to the repository
    */
   private async setupUserRepository(): Promise<AdobeMinimalAsset | null> {
@@ -93,6 +94,14 @@ export class UploadService {
 
     if(children?.result) {
       const directoryChildren = children.result.children;
+
+      if(!directoryChildren || directoryChildren.length === 0) {
+        return {
+          repositoryId: indexRepoId,
+          path: "/"
+        };
+      }
+
       if(directoryChildren.length === 1) {
         const repository = directoryChildren[0];
         return {


### PR DESCRIPTION
# Fix upload UI reset on error and handle new user repository setup

## Summary

- Fixed a bug where the upload progress bar UI was not reset when `performStorageUpload` encountered an error, leaving users stuck on the progress bar with no way to re-upload.
- Updated `setupUserRepository` in the upload service to gracefully handle new users who have no children in their index document, falling back to the index repo itself instead of erroring out.


---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://new-user-fix--da-express-milo--adobecom.aem.page/express/experiments/frictionless-upload/editor?martech=off |

---

## Verification Steps

- **Upload UI reset:**
  1. Navigate to any frictionless quick action page (e.g., remove-background).
  2. Upload a file and simulate/trigger an upload failure (e.g., network error, invalid asset).
  3. **Before:** The progress bar remains visible and the upload dropzone is hidden — the user is stuck.
  4. **After:** The progress bar is removed and the upload dropzone is restored, allowing the user to retry.

- **New user repository setup:**
  1. Sign in as a brand-new user with no existing assets/repositories.
  2. Trigger an upload.
  3. **Before:** The upload service errors out because `directoryChildren` is empty/undefined.
  4. **After:** The service falls back to the index repo and the upload completes successfully.

---

## Potential Regressions

- https://new-user-fix--da-express-milo--adobecom.aem.page/express/experiments/frictionless-upload/editor?martech=off

---

## Additional Notes

The `resetUploadUI()` call in the catch block is guarded by `if (progressBar)` to avoid errors if `setupUploadUI` itself was the source of the failure. This is safe to call alongside the existing upload status listener's `'failed'` handler since `Element.remove()` on a detached element is a no-op.