### PR TITLE
Added selector to include 'ol' in declaration controlling main element font-sizes

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1087,7 +1087,7 @@ main .section.blog-content>.content>p {
     margin-bottom: 16px;
   }
 
-  main p, main ul {
+  main p, main ul, main ol {
     font-size: var(--body-font-size-l);
   }
 


### PR DESCRIPTION
## Summary

Added selector to include 'ol' in declaration controlling main element font-sizes

---

## Jira Ticket

Resolves: [MWPW-187768](https://jira.corp.adobe.com/browse/MWPW-187768)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/discover/quotes/spring |
| **After**   | https://mwpw-187768--da-express-milo--adobecom.aem.page/express/discover/quotes/spring?martech=off |

---

## Verification Steps

- Navigate to the bottom of the before and after pages to observe the font-size in the ordered list at the bottom of the page. 
- In the 'Before' link it is larger than the font of the text surrounding it, in the 'After' link it should be the same size.

---

## Potential Regressions

This is a change to the default font-size for ordered lists, it affects all unordered lists not being explicitly styled by their parent block code. 

---

## Additional Notes

This is a bug left over from the fix implemented towards https://jira.corp.adobe.com/browse/MWPW-183464.

where it looks like we simply missed including this in the ruleset that controls the font-size for this experience. Including it now will achieve consistency.
