### PR TITLE
Fixed issue with social icon svgs rendering incorrectly in toc-seo component

### DIFF
--- a/express/code/blocks/toc-seo/toc-seo.css
+++ b/express/code/blocks/toc-seo/toc-seo.css
@@ -95,7 +95,7 @@
 
   .toc-social-icons {
     display: flex;
-    gap: var(--spacing-300);
+    gap: var(--spacing-100);
     padding: var(--spacing-300) var(--spacing-350);
   }
   
@@ -115,7 +115,7 @@
   .toc-social-icons svg {
     width: 20px;
     height: 20px;
-    fill: var(--color-dark-gray);
+    fill: var(--color-gray-800-variant);
     transition: fill 0.2s ease;
   }
   

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -166,6 +166,33 @@ function createContentList(config) {
 }
 
 /**
+ * Facebook icon path (inlined so CSS fill applies; <use href="external.svg"> does not inherit).
+ */
+const FACEBOOK_ICON_PATH_D = 'M9.99088 2.47955e-05C4.47063 2.47955e-05 0 4.50533 0 10.0671C0 15.014 3.58205 19.2286 8.43587 20V12.9681H5.89789V10.0615H8.43587V7.82561C8.43587 5.29907 9.92979 3.91282 12.2123 3.91282C12.9565 3.91841 13.7007 3.98549 14.4337 4.10846V6.5847H13.1897C12.4011 6.4785 11.6736 7.03747 11.5681 7.83121C11.5514 7.93741 11.5514 8.0492 11.5681 8.15541V10.0615H14.3449L13.9006 12.9681H11.5625V20C17.0161 19.1336 20.737 13.9799 19.8762 8.49079C19.1098 3.59421 14.9113 -0.0111542 9.99088 2.47955e-05Z';
+const LINKEDIN_ICON_PATH_D = 'M0 1.44321V18.5565C0.0111888 19.3621 0.671329 20.011 1.47692 19.9999H18.5231C19.3287 20.011 19.9888 19.3621 20 18.5565V1.44321C19.9888 0.637621 19.3287 -0.0113316 18.5231 -0.000143051H1.47692C0.671329 -0.0113316 0.0111888 0.637621 0 1.44321ZM5.93007 17.046H2.96503V7.50196H5.93007V17.046ZM7.79301 7.50196H10.6294V8.80545H10.6685C11.2448 7.81524 12.3189 7.22223 13.4657 7.2614C16.4699 7.2614 17.0238 9.24182 17.0238 11.8096V17.046H14.0811V12.4027C14.0811 11.2838 14.0811 9.87398 12.5371 9.87398C10.993 9.87398 10.758 11.0768 10.758 12.3075V17.0292H7.79301V7.50196ZM4.47552 2.7579C5.42657 2.77468 6.18741 3.5579 6.17063 4.50895C6.15385 5.46 5.37063 6.22084 4.41958 6.20405C3.47413 6.18727 2.71888 5.42084 2.72448 4.47538C2.72448 3.52433 3.49091 2.7579 4.44196 2.7579C4.45315 2.7579 4.46434 2.7579 4.47552 2.7579Z';
+const TWITTER_ICON_PATH_D = 'M10 20C15.5228 20 20 15.5228 20 10C20 4.47715 15.5228 0 10 0C4.47715 0 0 4.47715 0 10C0 15.5228 4.47715 20 10 20ZM4.44434 15.5557L8.78223 10.6221L4.44434 4.44434H7.75293L10.6221 8.5293L14.2129 4.44434H15.1934L11.0566 9.14941L15.5557 15.5557H12.2471L9.21777 11.2412L5.4248 15.5557H4.44434ZM14.2139 14.8662L10.5449 9.73145L10.1055 9.11621L7.2832 5.16602H5.77832L9.27539 10.0615L9.71484 10.6768L12.708 14.8662H14.2139Z';
+const COPYLINK_ICON_PATH_D = 'M10 0C15.5228 0 20 4.47715 20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0ZM11.7676 7.52539C10.4008 6.15857 8.1852 6.15859 6.81836 7.52539L3.98926 10.3535C2.62257 11.7204 2.62247 13.9369 3.98926 15.3037L4.69629 16.0107C6.06307 17.3775 8.27964 17.3774 9.64648 16.0107C10.0369 15.6203 10.0367 14.9872 9.64648 14.5967C9.25596 14.2062 8.62295 14.2062 8.23242 14.5967C7.64677 15.1822 6.6971 15.182 6.11133 14.5967L5.4043 13.8887C4.81851 13.3029 4.81851 12.3534 5.4043 11.7676L8.23242 8.93945C8.81821 8.3537 9.76774 8.35368 10.3535 8.93945L10.707 9.29297C11.0975 9.68344 11.7306 9.68334 12.1211 9.29297C12.5116 8.90244 12.5116 8.26943 12.1211 7.87891L11.7676 7.52539ZM15.3037 3.98926C13.9369 2.62247 11.7204 2.62257 10.3535 3.98926C9.96308 4.37969 9.96325 5.01277 10.3535 5.40332C10.744 5.79384 11.3771 5.79384 11.7676 5.40332C12.3532 4.81783 13.3029 4.81803 13.8887 5.40332L14.5967 6.11133C15.182 6.6971 15.1822 7.64677 14.5967 8.23242L11.7676 11.0605C11.1818 11.6463 10.2323 11.6463 9.64648 11.0605L9.29297 10.707C8.90249 10.3166 8.26944 10.3167 7.87891 10.707C7.48838 11.0976 7.48838 11.7306 7.87891 12.1211L8.23242 12.4746C9.59924 13.8414 11.8148 13.8414 13.1816 12.4746L16.0107 9.64648C17.3774 8.27964 17.3775 6.06308 16.0107 4.69629L15.3037 3.98926Z';
+/**
+ * Creates an inline SVG icon so CSS fill applies (external <use> does not inherit in browsers).
+ * @param {string} iconClass - Class name for the icon (e.g. 'icon-social_icon_facebook_toc-seo')
+ * @param {string} pathD - SVG path d attribute
+ * @param {number} size - Width/height in pixels
+ * @returns {SVGSVGElement}
+ */
+function createInlineSocialIcon(iconClass, pathD, size = 20) {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.classList.add('icon', iconClass);
+  svg.setAttribute('aria-hidden', 'true');
+  svg.setAttribute('viewBox', '0 0 20 20');
+  svg.setAttribute('width', String(size));
+  svg.setAttribute('height', String(size));
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', pathD);
+  svg.appendChild(path);
+  return svg;
+}
+
+/**
  * Creates social sharing icons section
  * @returns {HTMLElement} Social icons container
  */
@@ -175,38 +202,45 @@ function createSocialIcons() {
   const description = encodeURIComponent(getMetadata('description') || '');
 
   const platformMap = {
-    x: {
+    'social_icon_twitter_toc-seo': {
       'data-href': `https://www.twitter.com/share?&url=${url}&text=${title}`,
       'aria-label': 'Share on Twitter',
       tabindex: '0',
       role: 'link',
+      useInlineIcon: TWITTER_ICON_PATH_D,
     },
-    linkedin: {
-      'data-type': 'LinkedIn',
-      'data-href': `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}&summary=${description}`,
-      'aria-label': 'Share on LinkedIn',
-      tabindex: '0',
-      role: 'link',
-    },
-    facebook: {
+    'social_icon_facebook_toc-seo': {
       'data-type': 'Facebook',
       'data-href': `https://www.facebook.com/sharer/sharer.php?u=${url}`,
       'aria-label': 'Share on Facebook',
       tabindex: '0',
       role: 'link',
+      useInlineIcon: FACEBOOK_ICON_PATH_D,
     },
-    link: {
+    'social_icon_linkedin_toc-seo': {
+      'data-type': 'LinkedIn',
+      'data-href': `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}&summary=${description}`,
+      'aria-label': 'Share on LinkedIn',
+      tabindex: '0',
+      role: 'link',
+      useInlineIcon: LINKEDIN_ICON_PATH_D,
+    },
+    'social_icon_copylink_toc-seo': {
       id: 'toc-copy-link',
       'aria-label': 'Copy link to clipboard',
       tabindex: '0',
       role: 'link',
+      useInlineIcon: COPYLINK_ICON_PATH_D,
+      title: 'Copy link to clipboard',
     },
   };
 
   const socialContainer = createTag('div', { class: 'toc-social-icons' });
 
   Object.entries(platformMap).forEach(([platform, attrs]) => {
-    const icon = getIconElementDeprecated(platform);
+    const icon = attrs.useInlineIcon
+      ? createInlineSocialIcon(`icon-${platform}`, attrs.useInlineIcon, 20)
+      : getIconElementDeprecated(platform, 20, '', '');
     const link = createTag('a', attrs);
     link.appendChild(icon);
     socialContainer.appendChild(link);


### PR DESCRIPTION
## Summary

Fixed issue with social icon svgs rendering incorrectly in toc-seo component

---

## Jira Ticket

Resolves: [MWPW-187660](https://jira.corp.adobe.com/browse/MWPW-187660)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/discover/ideas/social-media-marketing |
| **After**   | https://mwpw-187660--da-express-milo--adobecom.aem.page/express/discover/ideas/social-media-marketing?martech=off |

---

## Verification Steps

- Navigate to the Before and After pages, on each page scroll down to the bottom of the page so that the table of contents sidebar also scrolls down to the bottom of the sidebar content, revealing the social icons. 
- Observer the size, placement and color of the social icons being incorrect in the Before link, and correct in the After link

---

## Potential Regressions

This affects all pages with the 'toc-seo' block, i.e.

- https://mwpw-187660--da-express-milo--adobecom.aem.page/express/discover/ideas/social-media-marketing?martech=off
- https://mwpw-187660--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/video/boomerang?martech=off
- https://mwpw-187660--da-express-milo--adobecom.aem.live/fr/express/discover/quotes/fall?martech=off

---

## Additional Notes

-
