### PR TITLE
Adjusted default topPosition of toc-seo block

### DIFF
--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -514,8 +514,8 @@ function updateDesktopPosition(tocContainer) {
   // Calculate and cache the initial absolute position if not already stored
   if (!tocContainer.dataset.initialTop) {
     const highlightRect = highlightElement.getBoundingClientRect();
-    const highlightBottom = window.pageYOffset + highlightRect.bottom + 40; // 40px below highlight
-    tocContainer.dataset.initialTop = highlightBottom + 30; // additional 40px buffer
+    const highlightBottom = window.pageYOffset + highlightRect.bottom; // 40px below highlight
+    tocContainer.dataset.initialTop = highlightBottom + 34; // additional 40px buffer
   }
 
   const initialTop = parseFloat(tocContainer.dataset.initialTop);


### PR DESCRIPTION
## Summary

Adjusted default topPosition of toc-seo block

---

## Jira Ticket

Resolves: [MWPW-187657](https://jira.corp.adobe.com/browse/MWPW-187657)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/discover/ideas/social-media-marketing/ |
| **After**   | https://mwpw-187657--da-express-milo--adobecom.aem.page/express/discover/ideas/social-media-marketing?martech=off |

---

## Verification Steps

- Navigate to the 'Before' and 'After' pages and observe the starting position of the table of contents index bar relative to the first headline.

---

## Potential Regressions

This affects all pages with the 'toc-seo' block, i.e.

https://mwpw-187657--da-express-milo--adobecom.aem.page/express/discover/ideas/social-media-marketing?martech=off
https://mwpw-187657--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/video/boomerang?martech=off
https://mwpw-187657--da-express-milo--adobecom.aem.live/fr/express/discover/quotes/fall?martech=off

---

## Additional Notes

-
