### PR TITLE
Adjusted default font-color for paragrah and heading tags in .long-form content (discover pages)

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1301,6 +1301,7 @@ main .section.long-form .content h4,
 main .section.long-form .content h5,
 main .section.long-form .content h6 {
   font-size: var(--heading-font-size-s);
+  color: var(--heading-color);
 }
 
 main .section.long-form .content,
@@ -1312,18 +1313,20 @@ main .section.long-form .content h4,
 main .section.long-form .content h5,
 main .section.long-form .content h6 {
   text-align: left;
-  color: var(--color-gray-700);
 }
 
 main .section.long-form .content h1,
 main .section.long-form .content h2,
 main .section.long-form .content h3,
 main .section.long-form .content h4 {
+
   margin-top: 0;
+  color: var(--heading-color);
 }
 
 main .section.long-form .content p {
   margin-top: 16px;
+  color: var(--body-color);
 }
 
 @media (min-width: 768px) {

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1301,7 +1301,7 @@ main .section.long-form .content h4,
 main .section.long-form .content h5,
 main .section.long-form .content h6 {
   font-size: var(--heading-font-size-s);
-  color: var(--heading-color);
+  color: var(--color-gray-950);
 }
 
 main .section.long-form .content,
@@ -1319,14 +1319,13 @@ main .section.long-form .content h1,
 main .section.long-form .content h2,
 main .section.long-form .content h3,
 main .section.long-form .content h4 {
-
   margin-top: 0;
-  color: var(--heading-color);
+  color: var(--color-gray-950);
 }
 
 main .section.long-form .content p {
   margin-top: 16px;
-  color: var(--body-color);
+  color: var(--color-dark-gray);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary

Adjusted default font-color for paragrah and heading tags in .long-form content (discover pages)

---

## Jira Ticket

Resolves: [MWPW-187659](https://jira.corp.adobe.com/browse/MWPW-187659)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/facebook/review |
| **After**   | https://mwpw-187659--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/facebook/review?martech=off |

---

## Verification Steps

- Navigate to the Before and After links and observe the font-color for both heading and paragraph text in .long-form sections of the page. 
- The 'After' page text should be slightly darker. Hard to notice but can use devtools to check that the font-color being rendered is the same as requested in the ticket / figma. 

---

## Potential Regressions

This change affects any content with a className of 'long-form' i.e. all /discover/ pages:
- https://mwpw-187655--da-express-milo--adobecom.aem.live/uk/express/discover/how-to/facebook/review?martech=off
- https://mwpw-187655--da-express-milo--adobecom.aem.live/uk/express/discover/ideas/card/christmas/school?martech=off
- https://mwpw-187655--da-express-milo--adobecom.aem.live/fr/express/discover/quotes/fall?martech=off


---

## Additional Notes
