### PR TITLE
Adding svgInjected data-attribute to all icons to prevent milo from attempting to fetch them from /federated repo, causing 404 errors

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -413,6 +413,10 @@ async function loadPage() {
     }
   });
 
+  document.querySelectorAll('span.icon').forEach((icon) => {
+    icon.dataset.svgInjected = 'true';
+  });
+
   await loadArea();
 
   const { fixIcons } = await import('./utils.js');


### PR DESCRIPTION
## Summary

Adding svgInjected data-attribute to all icons to prevent milo from attempting to fetch them from /federated repo, causing 404 errors.

---

## Jira Ticket

Resolves: [MWPW-188686](https://jira.corp.adobe.com/browse/MWPW-188686)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-188686--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Open the Before and After pages above and open the Chrome developer tools in each one in order to observe the Network requests.
- Observe the After link no longer containing the 404 errors caused by missing icons.

---

## Potential Regressions

This change affects the default formatting that occurs on all icons, so all pages with icons could be affected. 

---

## Additional Notes

This uses the same approach as was implemented in https://jira.corp.adobe.com/browse/MWPW-182453, however this time we add the .svgInjected data attribute to the icons, which causes milo's fetching behavior to ignore them, while retaining the 'icon' class which components rely on and reference often.