### PR TITLE
Add HEIC format support and conversion actions for heic-to-jpg and heic-to-png

### DIFF
--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -84,8 +84,14 @@ const getMergeVideosCfg = () => ({
 
 // Shared QA configurations
 export const QA_CONFIGS = {
-  'convert-to-jpg': { ...getBaseImgCfg(PNG, WEBP) },
-  'convert-to-png': { ...getBaseImgCfg(JPG, JPEG, WEBP) },
+  'convert-to-jpg': {
+    ...getBaseImgCfg(PNG, WEBP, HEIC),
+    input_check: (input) => getBaseImgCfg(PNG, WEBP, HEIC).input_check(input) || input === `image/${HEIC}`,
+  },
+  'convert-to-png': {
+    ...getBaseImgCfg(JPG, JPEG, WEBP, HEIC),
+    input_check: (input) => getBaseImgCfg(JPG, JPEG, WEBP, HEIC).input_check(input) || input === `image/${HEIC}`,
+  },
   'convert-to-svg': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'crop-image': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'resize-image': { ...getBaseImgCfg(JPG, JPEG, PNG, WEBP) },
@@ -107,8 +113,14 @@ export const QA_CONFIGS = {
   'caption-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'edit-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'edit-image': { ...getBaseImgCfg(JPG, JPEG, PNG, WEBP) },
-  'heic-to-jpg': { ...getBaseImgCfg(PNG, WEBP, HEIC), input_check: () => true },
-  'heic-to-png': { ...getBaseImgCfg(JPG, JPEG, WEBP, HEIC), input_check: () => true },
+  'heic-to-jpg': {
+    ...getBaseImgCfg(PNG, WEBP, HEIC),
+    input_check: (input) => getBaseImgCfg(PNG, WEBP, HEIC).input_check(input) || input === `image/${HEIC}`,
+  },
+  'heic-to-png': {
+    ...getBaseImgCfg(JPG, JPEG, WEBP, HEIC),
+    input_check: (input) => getBaseImgCfg(JPG, JPEG, WEBP, HEIC).input_check(input) || input === `image/${HEIC}`,
+  },
 };
 
 // Experimental variants

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -5,6 +5,7 @@ const JPG = 'jpg';
 const JPEG = 'jpeg';
 const PNG = 'png';
 const WEBP = 'webp';
+const HEIC = 'heic';
 
 const VIDEO_FORMATS = [
   'mov',
@@ -106,6 +107,8 @@ export const QA_CONFIGS = {
   'caption-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'edit-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'edit-image': { ...getBaseImgCfg(JPG, JPEG, PNG, WEBP) },
+  'heic-to-jpg': { ...getBaseImgCfg(PNG, WEBP, HEIC), input_check: () => true },
+  'heic-to-png': { ...getBaseImgCfg(JPG, JPEG, WEBP, HEIC), input_check: () => true },
 };
 
 // Experimental variants
@@ -392,6 +395,18 @@ export function executeQuickAction(
     ),
     'caption-video': () => ccEverywhere.quickAction.captionVideo(
       videoDocConfig,
+      appConfig,
+      exportConfig,
+      contConfig,
+    ),
+    'heic-to-jpg': () => ccEverywhere.quickAction.convertToJPEG(
+      docConfig,
+      appConfig,
+      exportConfig,
+      contConfig,
+    ),
+    'heic-to-png': () => ccEverywhere.quickAction.convertToPNG(
+      docConfig,
       appConfig,
       exportConfig,
       contConfig,


### PR DESCRIPTION
## Summary

Added HEIC as a supported image format and introduced two new quick actions — `heic-to-jpg` and `heic-to-png` — enabling users to convert HEIC images to JPG or PNG directly through the frictionless quick action flow.

---

## Jira Ticket

Resolves: [MWPW-188880](https://jira.corp.adobe.com/browse/MWPW-188880)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before (heic-to-jpg)** | https://main--da-express-milo--adobecom.aem.page/express/feature/image/convert/heic-to-jpg|
| **After (heic-to-jpg)** | https://heic-inclusion-quick-actions--da-express-milo--adobecom.aem.page/express/feature/image/convert/heic-to-jpg?martech=off |
| **Before (heic-to-png)** | https://main--da-express-milo--adobecom.aem.page/express/feature/image/convert/heic-to-png |
| **After (heic-to-png)** | https://heic-inclusion-quick-actions--da-express-milo--adobecom.aem.page/express/feature/image/convert/heic-to-png?martech=off |
| **Before (convert-to-jpg)** | https://main--da-express-milo--adobecom.aem.page/express/feature/image/convert/png-to-jpg |
| **After (convert-to-jpg)** | https://heic-inclusion-quick-actions--da-express-milo--adobecom.aem.page/express/feature/image/convert/png-to-jpg?martech=off |
| **Before (convert-to-png)** | https://main--da-express-milo--adobecom.aem.page/express/feature/image/convert/jpg-to-png |
| **After (convert-to-png)** | https://heic-inclusion-quick-actions--da-express-milo--adobecom.aem.page/express/feature/image/convert/jpg-to-png?martech=off |

---

## Verification Steps

1. Navigate to the **After** test URLs above.
2. Upload a `.heic` image file to the quick action widget.
3. **heic-to-jpg**: Verify the uploaded HEIC image is converted and exported as a JPG file.
4. **heic-to-png**: Verify the uploaded HEIC image is converted and exported as a PNG file.
5. Confirm that other supported formats (PNG, WEBP for heic-to-jpg; JPG, JPEG, WEBP for heic-to-png, ) are also accepted as input.
6. On the **Before** URLs, confirm these quick actions are not available (pages should not resolve or the actions should not exist).

---

## Potential Regressions

- https://heic-inclusion-quick-actions--da-express-milo--adobecom.aem.page/express/feature/image/convert/heic-to-png?martech=off
- https://heic-inclusion-quick-actions--da-express-milo--adobecom.aem.page/express/feature/image/convert/heic-to-jpg?martech=off

---

## Additional Notes

- Changes are limited to a single file: `express/code/scripts/utils/frictionless-utils.js`.
- A new `HEIC` constant was added alongside the existing format constants (JPG, JPEG, PNG, WEBP).
- Both new `QA_CONFIGS` entries include `input_check: () => true` to bypass the default input validation.
- The `executeQuickAction` function maps `heic-to-jpg` to `ccEverywhere.quickAction.convertToJPEG` and `heic-to-png` to `ccEverywhere.quickAction.convertToPNG`.