### PR TITLE
Parallelizing express_delayed and preconnecting to scripts.js in order to reduce 'critical path' in network dependency tree

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -412,15 +412,17 @@ async function loadPage() {
       meta.remove();
     }
   });
-
+  document.querySelectorAll('span.icon').forEach((icon) => {
+    icon.dataset.svgInjected = 'true';
+  });
+  const delayedPromise = import('./express-delayed.js');
   await loadArea();
 
   const { fixIcons } = await import('./utils.js');
   document.querySelectorAll('.section>.text').forEach((block) => fixIcons(block));
 
-  import('./express-delayed.js').then((mod) => {
-    mod.default();
-  });
+  const delayedModule = await delayedPromise;
+  delayedModule.default();
 }
 
 loadPage();

--- a/head.html
+++ b/head.html
@@ -1,5 +1,6 @@
 <!-- Modifying this file will impact your performance -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preconnect" href="https://main--milo--adobecom.aem.live" crossorigin>
 <script src="/express/code/scripts/fallback.js" nomodule></script>
 <script src="/express/code/scripts/scripts.js" type="module"></script>
 <style>body { display: none; }</style>


### PR DESCRIPTION
## Summary

Parallelizing express_delayed and preconnecting to scripts.js in order to reduce 'critical path' in network dependency tree

---

## Jira Ticket

Resolves: [MWPW-188772](https://jira.corp.adobe.com/browse/MWPW-188772)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-188772--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps
By declaring the import statement for 'express_delayed' above the call to 'loadArea()' function, we allow the browser to begin fetching this resource in parallel, while loadArea() runs (which is a large blocking request), once it's completed running, we call the express delayed default function as normal. 

While this doesnt seem like it would necessarily improve performance, since it adds another resource to the list of  network calls being made before loadArea() runs, it does satisfy the CWV of eliminating the 'critical path' that arises from having a 'critical resource' (in this case express_delayed.js, since it is accessed using an import statement), being imported after a long blocking function (i.e. loadArea()).

The easiest way to observe this is by running a lighthouse test on each of the links provided above and noticing the Network Dependency Tree warning for the 'After' link does not contain the large Network Dependency Graph that the 'Before' link suffers from. 

---

## Potential Regressions

- Since this affects the loading pattern of some of our boilerplate scripts this has the potential to affect any page.

---

## Additional Notes

I included the change from https://github.com/adobecom/da-express-milo/pull/171 here as well, since these superfluous requests also form a 'critical path', removing them here allows us to see the affects of this change more clearly.

Before:
<img width="1407" height="844" alt="network_dependency_tree" src="https://github.com/user-attachments/assets/785b374d-560a-43e2-a9fe-f8490d6a0f78" />

After:
<img width="1405" height="846" alt="network_dependency_tree_after" src="https://github.com/user-attachments/assets/c30f42bd-c65a-4308-a45c-44851edf5dba" />
