### PR TITLE
Adjusting structure of toggle label content in order to pass accessibility test

### DIFF
--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -215,6 +215,9 @@ function createToggle({ toggleText, toggleActive, toggleBypassParam }) {
   const bypassParam = toggleBypassParam.querySelector('div:nth-child(2)').innerText;
   const toggleLabels = toggleText.querySelectorAll('li');
   const isChecked = toggleActive.querySelector('div:nth-child(2)')?.innerText || 1;
+  const toggleId = `grid-marquee-toggle-${Math.random().toString(36).slice(2, 10)}`;
+  const uncheckedLabelId = `${toggleId}-unchecked-label`;
+  const checkedLabelId = `${toggleId}-checked-label`;
 
   toggleText.remove();
   toggleBypassParam.remove();
@@ -225,16 +228,22 @@ function createToggle({ toggleText, toggleActive, toggleBypassParam }) {
     'div',
     { class: 'toggle-wrapper' },
     `
-    <span class="toggle_label_unchecked" daa-ll="Individual vs Business toggle">${toggleLabels[0]?.innerText}</span>
-    <label class="toggle" daa-ll="Individual vs Business toggle">
-      <input daa-ll="Individual vs Business toggle" type="checkbox" ${isChecked ? 'checked' : ''}>
+    <span id="${uncheckedLabelId}" class="toggle_label_unchecked" daa-ll="Individual vs Business toggle">${toggleLabels[0]?.innerText}</span>
+    <label class="toggle" daa-ll="Individual vs Business toggle" for="${toggleId}">
+      <input
+        id="${toggleId}"
+        daa-ll="Individual vs Business toggle"
+        type="checkbox"
+        role="switch"
+        aria-labelledby="${uncheckedLabelId} ${checkedLabelId}"
+        ${isChecked ? 'checked' : ''}>
       <span class="slider round"></span>
     </label>
-    <span class="toggle_label_checked">${toggleLabels[1]?.innerText}</span>
+    <span id="${checkedLabelId}" class="toggle_label_checked">${toggleLabels[1]?.innerText}</span>
     `,
   );
 
-  toggleWrapper.querySelector('.toggle_label_unchecked')?.addEventListener('click', () => {
+  toggleWrapper.querySelector(`.${uncheckedLabelId}`)?.addEventListener('click', () => {
     toggleWrapper.querySelector('input')?.click();
   });
   toggleWrapper.querySelector('input')?.addEventListener('click', (e) => {

--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -243,7 +243,7 @@ function createToggle({ toggleText, toggleActive, toggleBypassParam }) {
     `,
   );
 
-  toggleWrapper.querySelector(`.${uncheckedLabelId}`)?.addEventListener('click', () => {
+  toggleWrapper.querySelector(`#${uncheckedLabelId}`)?.addEventListener('click', () => {
     toggleWrapper.querySelector('input')?.click();
   });
   toggleWrapper.querySelector('input')?.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary

Adjusting structure of toggle label content in order to pass accessibility test

---

## Jira Ticket

Resolves: [MWPW-185170](https://jira.corp.adobe.com/browse/MWPW-185170)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-185170--da-express-milo--adobecom.aem.page/express/ |

---

## Verification Steps

- Navigate to the 'Before' link, open Chrome Devtools, and open the 'Axe DevTools' plugin tab in Chrome devtools.
- Click the 'Full Page Scan' button, then make sure that 'Best Practices' toggle is switched to 'On'
- Observe the warning that mentions 'Form Elements should have a visible label'
- Navigate to the 'After' link and complete the first 2 steps listed above.
- Observe that the error is no longer present. Verify that checkbox functionality is still working.

---

## Potential Regressions

This change only affects the toggle in the grid-marquee component (only featured on the homepage).

---

## Additional Notes

<img width="1412" height="842" alt="best_practices_option" src="https://github.com/user-attachments/assets/4315602f-6165-4ae3-b40a-a1db379fe03f" />
