### PR TITLE
Removed sticky-promo-bar treatment for print-product-detail checkout button on mobile, enabling checkout button

### DIFF
--- a/express/code/blocks/print-product-detail/createComponents/createProductDetailsSection.js
+++ b/express/code/blocks/print-product-detail/createComponents/createProductDetailsSection.js
@@ -166,7 +166,7 @@ export async function createCheckoutButton(productDetails) {
   const outOfRegion = !validRegions.includes(productDetails.region);
   const isMobile = detectMobile();
   let CTAText;
-  const CTATextMobile = "Print with Adobe Express isn't available on mobile. Open on desktop to get started.";
+  const CTATextMobile = 'Customize and print it';
   const CTATextDesktop = 'Customize and print it';
   const CTATextOutOfRegion = 'Print with Adobe Express isn’t available yet in your region. Check back soon!';
   if (outOfRegion) {
@@ -181,7 +181,7 @@ export async function createCheckoutButton(productDetails) {
     { class: 'pdpx-checkout-button-cta-text-container' },
     CTAText,
   );
-  const buttonDisabled = outOfRegion || isMobile;
+  const buttonDisabled = outOfRegion;
   const checkoutButtonContainer = createTag('div', {
     class: 'pdpx-checkout-button-container',
     id: 'pdpx-checkout-button-container',

--- a/express/code/blocks/print-product-detail/print-product-detail.css
+++ b/express/code/blocks/print-product-detail/print-product-detail.css
@@ -332,14 +332,19 @@
 
 /* CHECKOUT BUTTON */
 .pdpx-checkout-button-container {
-  position: sticky;
-  bottom: 0;
+  position: fixed;
+  bottom: -1px;
+  left: 0;
   background: var(--color-white);
-  margin-top: var(--spacing-200);
   width: 100%;
+  margin-top: var(--spacing-200);
   order: 4;
-  z-index: 1;
+  z-index: 18;
   a.pdpx-checkout-button {
+    width: calc(100% - (var(--global-container-margin) * 2));
+    margin-left: auto;
+    margin-right: auto;
+    box-sizing: border-box;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -360,13 +365,14 @@
   font-weight: var(--ax-detail-weight);
 }
 .pdpx-checkout-button-subhead {
-  display: none;
+  display: flex;
   flex-direction: row;
   align-items: end;
   flex-wrap: wrap;
   justify-content: center;
   gap: var(--spacing-75);
   font-size: var(--ax-body-xs-size);
+  margin-bottom: var(--spacing-300);
 }
 .pdpx-checkout-button-subhead-image {
   margin-bottom: 1px;
@@ -1003,6 +1009,13 @@ main .section .pdpx-drawer-description {
   }
   .pdpx-drawer-body {
     padding: var(--spacing-500);
+  }
+  .pdpx-checkout-button-container {
+    position: sticky;
+    width: 100%;
+    a.pdpx-checkout-button {
+      width: 100%;
+    }
   }
 }
 /*DESKTOP*/

--- a/express/code/blocks/print-product-detail/print-product-detail.css
+++ b/express/code/blocks/print-product-detail/print-product-detail.css
@@ -365,6 +365,9 @@
   font-weight: var(--ax-detail-weight);
 }
 .pdpx-checkout-button-subhead {
+  width: calc(100% - (var(--global-container-margin) * 2));
+  margin-left: auto;
+  margin-right: auto;
   display: flex;
   flex-direction: row;
   align-items: end;

--- a/express/code/blocks/print-product-detail/print-product-detail.css
+++ b/express/code/blocks/print-product-detail/print-product-detail.css
@@ -932,6 +932,16 @@ main .section .pdpx-drawer-description {
   line-height: 130%;
   margin: 0;
 }
+.pdpx-checkout-button-container:not(.hide-gradient)::before {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  height: var(--spacing-900);
+  pointer-events: none;
+  background: linear-gradient(to top, white 20%, rgba(255, 255, 255, 0) 100%);
+}
 
 /*TABLET*/
 @media (min-width: 600px) {
@@ -993,16 +1003,6 @@ main .section .pdpx-drawer-description {
   }
   .pdpx-drawer-body {
     padding: var(--spacing-500);
-  }
-  .pdpx-checkout-button-container:not(.hide-gradient)::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
-    left: 0;
-    right: 0;
-    height: var(--spacing-900);
-    pointer-events: none;
-    background: linear-gradient(to top, white 20%, rgba(255, 255, 255, 0) 100%);
   }
 }
 /*DESKTOP*/


### PR DESCRIPTION
## Summary

Removed sticky-promo-bar treatment for print-product-detail checkout button on mobile, enabling checkout button

---

## Jira Ticket

Resolves: [MWPW-188451](https://jira.corp.adobe.com/browse/MWPW-188451)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/create/print/business-card/green-and-white-personal-business-card/ |
| **After**   | https://mwpw-188451--da-express-milo--adobecom.aem.page/express/create/print/business-card/green-and-white-personal-business-card?martech=off |

---

## Verification Steps

- Navigate to the Before link, either on a mobile device, or by using the Chrome devtools to reduce the browser width to below 600px, simply resizing the Chrome browser to below 600px manually will also suffice to emulate the mobile experience.
- Notice the disabled treatment of the checkout button, notifying user that checkout is not available.
- Navigate to the After link in the same way, emulating mobile device
- Notice that the checkout button appears normally, and functions correctly

---

## Potential Regressions

This change affects the print-product-detail block, so all print-product-detail pages are affected, i.e. 

https://mwpw-188451--da-express-milo--adobecom.aem.page/express/create/print/business-card/multicolor-curator-business-card

---

## Additional Notes


