### PR TITLE
Adjusting the position of the play/pause button in the quick-action-hub block

### DIFF
--- a/express/code/blocks/quick-action-hub/quick-action-hub.css
+++ b/express/code/blocks/quick-action-hub/quick-action-hub.css
@@ -1,3 +1,6 @@
+main .section:has(div.quick-action-hub-wrapper) {
+  text-align: center;
+}
 main .quick-action-hub .video-container {
   position: relative;
 }
@@ -5,7 +8,6 @@ main .quick-action-hub .video-controls-wrapper {
   right: 0px;
   bottom: 0px;
 }
-
 main .section > div.quick-action-hub-wrapper {
   padding: 88px 16px;
   margin: auto;

--- a/express/code/blocks/quick-action-hub/quick-action-hub.css
+++ b/express/code/blocks/quick-action-hub/quick-action-hub.css
@@ -1,5 +1,9 @@
-main .section:has(div.quick-action-hub-wrapper) {
-  text-align: center;
+main .quick-action-hub .video-container {
+  position: relative;
+}
+main .quick-action-hub .video-controls-wrapper {
+  right: 0px;
+  bottom: 0px;
 }
 
 main .section > div.quick-action-hub-wrapper {


### PR DESCRIPTION
## Summary

Adjusting the position of the play/pause button in the quick-action-hub block.

---

## Jira Ticket

Resolves: [MWPW-188535](https://jira.corp.adobe.com/browse/MWPW-188535)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/uk/express/feature |
| **After**   | https://mwpw-188535--da-express-milo--adobecom.aem.page/uk/express/feature?martech=off |

---

## Verification Steps

- Navigate to the Before page and adjust the browser width to above 1400px to notice the play/pause button becoming out of alignment with it's container. 
- Navigate to the After page with the same browser width and observe the button staying in the correct placement

---

## Potential Regressions

This block is only featured on the /express/feature page in certain languages, i.e.
- https://mwpw-188535--da-express-milo--adobecom.aem.page/uk/express/feature?martech=off
- https://mwpw-188535--da-express-milo--adobecom.aem.page/in/express/feature?martech=off
- https://mwpw-188535--da-express-milo--adobecom.aem.page/jp/express/feature?martech=off

---

## Additional Notes
