### PR TITLE
Gen AI Cards CTA Label

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.js
@@ -5,6 +5,12 @@ import buildCarousel from '../../scripts/widgets/carousel.js';
 let createTag; let getConfig;
 const promptTokenRegex = /(?:\{\{|%7B%7B)?prompt(?:-|\+|%20|\s)text(?:\}\}|%7D%7D)?/;
 
+function getCtaAriaLabel(title, ctaText) {
+  const cleanTitle = title?.trim();
+  const cleanCtaText = ctaText?.trim();
+  return [cleanCtaText, cleanTitle].filter(Boolean).join(' - ');
+}
+
 function addBetaTag(card, title, betaPlaceholder) {
   const betaTag = createTag('span', { class: 'beta-tag' });
   betaTag.textContent = betaPlaceholder;
@@ -92,7 +98,11 @@ function buildGenAIForm({ title, ctaLinks, subtext }) {
 
   });
 
-  genAISubmit.setAttribute('aria-label', `${title}`);
+  const submitAriaLabel = getCtaAriaLabel(title, ctaLinks[0]?.textContent)
+    || title?.trim()
+    || ctaLinks[0]?.textContent?.trim()
+    || 'Submit';
+  genAISubmit.setAttribute('aria-label', submitAriaLabel);
 
   genAIForm.append(genAIInput, genAISubmit);
 
@@ -182,6 +192,8 @@ async function decorateCards(block, { actions }) {
         }
         a.classList.add('con-button');
         a.removeAttribute('title');
+        const ctaAriaLabel = getCtaAriaLabel(title, a.textContent);
+        if (ctaAriaLabel) a.setAttribute('aria-label', ctaAriaLabel);
         linksWrapper.append(a);
       }
     }

--- a/test/blocks/gen-ai-cards/gen-ai-cards.test.js
+++ b/test/blocks/gen-ai-cards/gen-ai-cards.test.js
@@ -47,9 +47,12 @@ describe('Gen AI Cards', () => {
       }
       const ctaCard = cards[1];
       const cta = ctaCard.querySelector('.links-wrapper a');
+      const ctaTitle = ctaCard.querySelector('.cta-card-title')?.textContent?.trim();
+      const ctaText = cta.textContent?.trim();
       expect(cta).to.exist;
       expect(cta.textContent).to.exist;
       expect(cta.href).to.exist;
+      expect(cta.getAttribute('aria-label')).to.equal(`${ctaText} - ${ctaTitle}`);
 
       const form = cards[0].querySelector('.gen-ai-input-form');
       expect(form).to.exist;
@@ -60,6 +63,9 @@ describe('Gen AI Cards', () => {
       expect(input.placeholder).to.exist;
       expect(button.textContent).to.exist;
       expect(button.classList.contains('gen-ai-submit')).to.be.true;
+      const formCardTitle = cards[0].querySelector('.cta-card-title')?.textContent?.trim();
+      const formCtaText = button.textContent?.trim();
+      expect(button.getAttribute('aria-label')).to.equal(`${formCtaText} - ${formCardTitle}`);
     }
   });
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Adds aria labels to the gen ai cards, label is 'button-content' + 'card-title'.

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-187460

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://gen-ai-cards-cta--da-express-milo--adobecom.aem.page/express/why-choose-express-video |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page and verify the gen ai cards cta's have aria labels.
---

## Potential Regressions

- https://gen-ai-cards-cta-da-express-milo--adobecom.aem.page/express/why-choose-express-video
- https://gen-ai-cards-cta-da-express-milo--adobecom.aem.page/express/

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
