### PR TITLE
Fixed PDP Regression Issue

### DIFF
--- a/express/code/blocks/print-product-detail/utilities/event-handlers.js
+++ b/express/code/blocks/print-product-detail/utilities/event-handlers.js
@@ -134,7 +134,7 @@ function createUpdatedSelectedValuesObject(
 }
 
 export default async function updateAllDynamicElements(productId) {
-  const containerElement = document.querySelector('.print-product-detail');
+  const containerElement = document.querySelector('.pdpx-global-container');
   const { templateId } = containerElement.dataset;
   const form = document.querySelector('#pdpx-customization-inputs-form');
   const formData = new FormData(form);


### PR DESCRIPTION
## Summary

Fixed PDP Regression Issue.

---

## Jira Ticket

https://jira.corp.adobe.com/browse/MWPW-189779

Here is the issue description, since this PR was created before the JIRA was created:

Bit of an urgent ask here - seems like with the latest release of our CTA updates for print caused some regressions/bugs. The team tested one of the pdp pages ( [url](https://www.adobe.com/express/create/print/card/glitter-polaroid-frame-birthday-card) ), it seems that there is a bug when configuring your product. The “Customize and print button” does not open the express editor with the correct template after the user edits the product configuration.

As you can see in the recording the url …template/urn... changes to …template/undefined.. when updating the product config. :confused:

This also happens on desktop web (edited)

Let me know if there's anything on my end to help

Also no need to stress (if you are). Once we ID a timeline for the fix I'll share it with the team - we should aim to move fast but I've let them know we're on it and will provide updates as we're able to


---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/express/create/print/card/glitter-polaroid-frame-birthday-card |
| **After**   | https://pdp-hotfix-01--da-express-milo--adobecom.aem.page/express/create/print/card/glitter-polaroid-frame-birthday-card?martech=off |

---

## Verification Steps

- Navigate to the 'Before' page and select one of the configuration options (any one should do it).
- Click the Checkout button and notice that it does not bring you to the correct template within the Express product.
- Navigate to the 'After' page and select one of the configuration options (any one should do it).
- Click the Checkout button and notice that it does bring you to the correct template within the Express product.

---

## Potential Regressions

This fix affects all print-product-detail pages.

---

## Additional Notes


