### PR TITLE
[MWPW-189830][COLOR] Color Edit Design QA

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -27,6 +27,7 @@ export default async function decorate(block) {
     baseColor.color = '#FF0000';
     baseColor.colorMode = 'HEX';
     baseColor.showHeader = true;
+    baseColor.style.width = '319px';
     baseColorDemo.appendChild(baseColorLabel);
     baseColorDemo.appendChild(baseColor);
 

--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -27,7 +27,7 @@ export default async function decorate(block) {
     baseColor.color = '#FF0000';
     baseColor.colorMode = 'HEX';
     baseColor.showHeader = true;
-    baseColor.style.width = '319px';
+    baseColor.style.width = mobileMQ.matches ? '268px' : '319px';
     baseColorDemo.appendChild(baseColorLabel);
     baseColorDemo.appendChild(baseColor);
 
@@ -69,7 +69,8 @@ export default async function decorate(block) {
       if (trigger) trigger.focus();
     }
 
-    mobileMQ.addEventListener('change', () => {
+    mobileMQ.addEventListener('change', (e) => {
+      baseColor.style.width = e.matches ? '268px' : '319px';
       if (!activeEditor) return;
       const trigger = activeTrigger;
       const showPalette = activeShowPalette;

--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -109,7 +109,7 @@ export default async function decorate(block) {
       const colorEdit = document.createElement('color-edit');
       colorEdit.palette = showPalette ? [...SAMPLE_PALETTE] : [];
       colorEdit.showPalette = showPalette;
-      colorEdit.colorMode = 'RGB';
+      colorEdit.colorMode = 'HEX';
 
       const mobile = mobileMQ.matches;
       colorEdit.mobile = mobile;

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -509,44 +509,40 @@ class BaseColor extends LitElement {
               <span class="bc-mode-chevron"><img src="/express/code/icons/S2_Icon_ChevronDown_20_N.svg" alt="" width="14" height="14" aria-hidden="true" /></span>
             </button>
             ${this._modeMenuOpen ? html`
-              <sp-theme system="spectrum-two" color="light" scale="medium">
-                <sp-menu
-                  id="bc-mode-menu"
-                  role="listbox"
-                  selects="single"
-                  size="s"
-                  label="Color mode"
-                  @change=${this._onModeMenuChange}
-                  @keydown=${this._onModeMenuKeyDown}
-                >
-                  ${COLOR_MODES.map((m) => html`
-                    <sp-menu-item
-                      value=${m}
-                      ?selected=${m === this.colorMode}
-                    >${m}</sp-menu-item>
-                  `)}
-                </sp-menu>
-              </sp-theme>
+              <sp-menu
+                id="bc-mode-menu"
+                role="listbox"
+                selects="single"
+                size="s"
+                label="Color mode"
+                @change=${this._onModeMenuChange}
+                @keydown=${this._onModeMenuKeyDown}
+              >
+                ${COLOR_MODES.map((m) => html`
+                  <sp-menu-item
+                    value=${m}
+                    ?selected=${m === this.colorMode}
+                  >${m}</sp-menu-item>
+                `)}
+              </sp-menu>
             ` : nothing}
           </div>
         </div>
         ${this.colorMode === 'HEX' ? html`
           <div class="bc-color-value-wrapper ${this._hexError ? 'has-error' : ''}">
             <div class="bc-color-swatch" style="background-color: ${this._hex}" aria-hidden="true"></div>
-            <sp-theme system="spectrum-two" color="light" scale="medium">
-              <sp-textfield
-                class="bc-hex-field"
-                quiet
-                size="m"
-                maxlength="7"
-                .value=${this._colorValue}
-                ?invalid=${this._hexError}
-                label="Color value"
-                label-visibility="none"
-                @input=${this._onColorValueInput}
-                @change=${this._onHexCommit}
-              ></sp-textfield>
-            </sp-theme>
+            <sp-textfield
+              id="bc-hex-input"
+              class="bc-hex-field"
+              quiet
+              size="l"
+              maxlength="7"
+              .value=${this._colorValue}
+              ?invalid=${this._hexError}
+              label="Base color"
+              @input=${this._onColorValueInput}
+              @change=${this._onHexCommit}
+            ></sp-textfield>
             <span
               class="bc-lock-icon"
               aria-label="${this._isLocked ? 'Color locked' : 'Color unlocked'}"
@@ -586,19 +582,17 @@ class BaseColor extends LitElement {
             @input=${(e) => this._onHSBChannelSliderInput(e, 'b')}
           ></color-channel-slider>
         </div>
-        <sp-theme system="spectrum-two" color="light" scale="medium">
-          <sp-textfield
-            class="bc-channel-input"
-            type="number"
-            size="s"
-            maxlength="3"
-            .value=${String(value)}
-            label="Brightness/Contrast"
-            label-visibility="none"
-            @keydown=${(e) => this._onChannelKeyDown(e)}
-            @input=${(e) => this._onHSBChannelTextInput(e, 'b')}
-          ></sp-textfield>
-        </sp-theme>
+        <sp-textfield
+          class="bc-channel-input"
+          type="number"
+          size="s"
+          maxlength="3"
+          .value=${String(value)}
+          label="Brightness/Contrast"
+          label-visibility="none"
+          @keydown=${(e) => this._onChannelKeyDown(e)}
+          @input=${(e) => this._onHSBChannelTextInput(e, 'b')}
+        ></sp-textfield>
       </div>
     `;
   }
@@ -643,19 +637,17 @@ class BaseColor extends LitElement {
                 @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelSliderInput(e, 'b') : this._onRGBChannelSliderInput(e, ch.key)}
               ></color-channel-slider>
             </div>
-            <sp-theme system="spectrum-two" color="light" scale="medium">
-              <sp-textfield
-                class="bc-channel-input"
-                type="number"
-                size="s"
-                maxlength=${ch.maxlength}
-                .value=${String(ch.value)}
-                label=${ch.isIcon ? 'Brightness/Contrast' : ch.ariaLabel}
-                label-visibility="none"
-                @keydown=${(e) => this._onChannelKeyDown(e)}
-                @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelTextInput(e, 'b') : this._onRGBChannelTextInput(e, ch.key)}
-              ></sp-textfield>
-            </sp-theme>
+            <sp-textfield
+              class="bc-channel-input"
+              type="number"
+              size="s"
+              maxlength=${ch.maxlength}
+              .value=${String(ch.value)}
+              label=${ch.isIcon ? 'Brightness/Contrast' : ch.ariaLabel}
+              label-visibility="none"
+              @keydown=${(e) => this._onChannelKeyDown(e)}
+              @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelTextInput(e, 'b') : this._onRGBChannelTextInput(e, ch.key)}
+            ></sp-textfield>
           </div>
         `)}
       `;
@@ -683,19 +675,17 @@ class BaseColor extends LitElement {
                 @input=${(e) => this._onHSBChannelSliderInput(e, ch.key)}
               ></color-channel-slider>
             </div>
-            <sp-theme system="spectrum-two" color="light" scale="medium">
-              <sp-textfield
-                class="bc-channel-input"
-                type="number"
-                size="s"
-                maxlength=${ch.maxlength}
-                .value=${String(ch.value)}
-                label=${ch.ariaLabel}
-                label-visibility="none"
-                @keydown=${(e) => this._onChannelKeyDown(e)}
-                @input=${(e) => this._onHSBChannelTextInput(e, ch.key)}
-              ></sp-textfield>
-            </sp-theme>
+            <sp-textfield
+              class="bc-channel-input"
+              type="number"
+              size="s"
+              maxlength=${ch.maxlength}
+              .value=${String(ch.value)}
+              label=${ch.ariaLabel}
+              label-visibility="none"
+              @keydown=${(e) => this._onChannelKeyDown(e)}
+              @input=${(e) => this._onHSBChannelTextInput(e, ch.key)}
+            ></sp-textfield>
           </div>
         `)}
       `;
@@ -724,19 +714,17 @@ class BaseColor extends LitElement {
                 @input=${(e) => this._onLabChannelSliderInput(e, ch.key)}
               ></color-channel-slider>
             </div>
-            <sp-theme system="spectrum-two" color="light" scale="medium">
-              <sp-textfield
-                class="bc-channel-input"
-                type="number"
-                size="s"
-                maxlength=${ch.maxlength}
-                .value=${String(ch.value)}
-                label=${ch.ariaLabel}
-                label-visibility="none"
-                @keydown=${(e) => this._onChannelKeyDown(e, ch.allowNegative)}
-                @input=${(e) => this._onLabChannelTextInput(e, ch.key)}
-              ></sp-textfield>
-            </sp-theme>
+            <sp-textfield
+              class="bc-channel-input"
+              type="number"
+              size="s"
+              maxlength=${ch.maxlength}
+              .value=${String(ch.value)}
+              label=${ch.ariaLabel}
+              label-visibility="none"
+              @keydown=${(e) => this._onChannelKeyDown(e, ch.allowNegative)}
+              @input=${(e) => this._onLabChannelTextInput(e, ch.key)}
+            ></sp-textfield>
           </div>
         `)}
       `;
@@ -751,22 +739,20 @@ class BaseColor extends LitElement {
     return html`
       <div class="bc-color-control">
         <div class="bc-color-area-wrapper ${this.colorMode !== 'HEX' || this.showBrightnessControl ? 'has-sliders' : ''}">
-          <sp-theme system="spectrum-two" color="light" scale="medium">
-            <sp-color-area
-              .x=${this._saturation / 100}
-              .y=${this._brightness / 100}
-              .hue=${this._hue}
-              @pointerdown=${this._onPointerDown}
-              @change=${this._onColorAreaInput}
-            ></sp-color-area>
-            <sp-color-slider
-              gradient="hue"
-              color=${currentColor}
-              @pointerdown=${this._onPointerDown}
-              @input=${this._onHueInput}
-              @change=${this._onHueInput}
-            ></sp-color-slider>
-          </sp-theme>
+          <sp-color-area
+            .x=${this._saturation / 100}
+            .y=${this._brightness / 100}
+            .hue=${this._hue}
+            @pointerdown=${this._onPointerDown}
+            @change=${this._onColorAreaInput}
+          ></sp-color-area>
+          <sp-color-slider
+            gradient="hue"
+            color=${currentColor}
+            @pointerdown=${this._onPointerDown}
+            @input=${this._onHueInput}
+            @change=${this._onHueInput}
+          ></sp-color-slider>
         </div>
         ${this._renderAdditionalSliders()}
       </div>
@@ -775,11 +761,13 @@ class BaseColor extends LitElement {
 
   _renderPanel() {
     return html`
-      <div class="base-color-panel">
-        ${this._renderHeader()}
-        ${this._renderColorPicker()}
-        <div class="bc-sr-only" role="status" aria-live="polite" aria-atomic="true">${this._liveRegionText}</div>
-      </div>
+      <sp-theme system="spectrum-two" color="light" scale="medium">
+        <div class="base-color-panel">
+          ${this._renderHeader()}
+          ${this._renderColorPicker()}
+          <div class="bc-sr-only" role="status" aria-live="polite" aria-atomic="true">${this._liveRegionText}</div>
+        </div>
+      </sp-theme>
     `;
   }
 

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -44,6 +44,9 @@ class BaseColor extends LitElement {
       _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
       _colorUpdatedFromPicker: { type: Boolean, state: true },
+      _showOriginalDot: { type: Boolean, state: true },
+      _originalSaturation: { type: Number, state: true },
+      _originalBrightness: { type: Number, state: true },
     };
   }
 
@@ -63,6 +66,9 @@ class BaseColor extends LitElement {
     this._liveRegionText = '';
     this._announceTimer = null;
     this._labCache = null;
+    this._showOriginalDot = false;
+    this._originalSaturation = 0;
+    this._originalBrightness = 0;
   }
 
   get _rgb() {
@@ -155,9 +161,11 @@ class BaseColor extends LitElement {
     this._brightness = hsb.brightness;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
+    this._showOriginalDot = false;
   }
 
-  _emitColorChange() {
+  _emitColorChange({ fromColorArea = false } = {}) {
+    if (!fromColorArea) this._showOriginalDot = false;
     const rgb = this._rgb;
     this.dispatchEvent(new CustomEvent('color-change', {
       bubbles: true,
@@ -319,6 +327,12 @@ class BaseColor extends LitElement {
 
   // --- Color area (Saturation/Brightness) ---
 
+  _onColorAreaPointerDown(e) {
+    this._lastPointerType = e.pointerType;
+    this._originalSaturation = this._saturation;
+    this._originalBrightness = this._brightness;
+  }
+
   _onColorAreaInput(e) {
     const area = e.target;
     if (!area) return;
@@ -328,8 +342,18 @@ class BaseColor extends LitElement {
     this._hexError = false;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
-    this._emitColorChange();
-    this._blurOnTouch(area);
+
+    if (this._saturation !== this._originalSaturation
+      || this._brightness !== this._originalBrightness) {
+      this._showOriginalDot = true;
+    }
+
+    this._emitColorChange({ fromColorArea: true });
+  }
+
+  _onColorAreaChange(e) {
+    this._onColorAreaInput(e);
+    this._blurOnTouch(e.target);
   }
 
   // --- Hue slider ---
@@ -788,17 +812,25 @@ class BaseColor extends LitElement {
 
   _renderColorPicker() {
     const currentColor = this._hex;
-
     return html`
       <div class="bc-color-control">
         <div class="bc-color-area-wrapper ${this.colorMode !== 'HEX' || this.showBrightnessControl ? 'has-sliders' : ''}">
-          <sp-color-area
-            .x=${this._saturation / 100}
-            .y=${this._brightness / 100}
-            .hue=${this._hue}
-            @pointerdown=${this._onPointerDown}
-            @change=${this._onColorAreaInput}
-          ></sp-color-area>
+          <div class="bc-color-area-container">
+            <sp-color-area
+              .x=${this._saturation / 100}
+              .y=${this._brightness / 100}
+              .hue=${this._hue}
+              @pointerdown=${this._onColorAreaPointerDown}
+              @input=${this._onColorAreaInput}
+              @change=${this._onColorAreaChange}
+            ></sp-color-area>
+            ${this._showOriginalDot ? html`
+              <div
+                class="bc-original-dot"
+                style="left: ${this._originalSaturation}%; top: ${100 - this._originalBrightness}%;"
+              ></div>
+            ` : nothing}
+          </div>
           <sp-color-slider
             gradient="hue"
             color=${currentColor}

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -146,12 +146,87 @@ class BaseColor extends LitElement {
     clearTimeout(this._announceTimer);
     document.removeEventListener('click', this._closeMenuOnOutsideClick);
     document.removeEventListener('keydown', this._closeMenuOnEscape);
+    this.renderRoot.querySelector('sp-color-area')?.shadowRoot?.querySelector('.bc-original-dot')?.remove();
+    this.renderRoot.querySelector('sp-color-slider')?.shadowRoot?.querySelector('.bc-original-slider-dot')?.remove();
     super.disconnectedCallback();
   }
 
   updated(changed) {
     if (changed.has('color')) {
       this._syncFromColor();
+    }
+    this._updateOriginalDots();
+  }
+
+  _ensureDotStyles(shadowRoot) {
+    if (shadowRoot.querySelector('style[data-bc-dots]')) return;
+    const sheet = document.createElement('style');
+    sheet.setAttribute('data-bc-dots', '');
+    sheet.textContent = `
+      .bc-original-dot {
+        position: absolute;
+        width: var(--spacing-80);
+        height: var(--spacing-80);
+        border-radius: 50%;
+        background-color: #fff;
+        border: 1px solid rgba(31, 31, 31, 0.3);
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+        z-index: 0;
+        left: clamp(var(--spacing-80), var(--dot-x, 50%), calc(100% - var(--spacing-80)));
+        top: clamp(var(--spacing-80)/2, var(--dot-y, 50%), calc(100% - var(--spacing-80)/2));
+      }
+      .bc-original-slider-dot {
+        position: absolute;
+        width: var(--spacing-75);
+        height: var(--spacing-75);
+        border-radius: 50%;
+        background-color: #fff;
+        border: 1px solid rgba(31, 31, 31, 0.3);
+        top: 50%;
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+        z-index: 0;
+        left: clamp(var(--spacing-75)/2, var(--dot-x, 50%), calc(100% - var(--spacing-75)/2));
+      }
+    `;
+    shadowRoot.appendChild(sheet);
+  }
+
+  _ensureDot(host, cls) {
+    if (!host?.shadowRoot) return null;
+    this._ensureDotStyles(host.shadowRoot);
+    let dot = host.shadowRoot.querySelector(`.${cls}`);
+    if (!dot) {
+      dot = document.createElement('span');
+      dot.className = cls;
+      host.shadowRoot.appendChild(dot);
+    }
+    return dot;
+  }
+
+  _updateOriginalDots() {
+    const area = this.renderRoot.querySelector('sp-color-area');
+    const areaDot = this._ensureDot(area, 'bc-original-dot');
+    if (areaDot) {
+      if (this._showOriginalDot) {
+        areaDot.style.setProperty('--dot-x', `${this._originalSaturation}%`);
+        areaDot.style.setProperty('--dot-y', `${100 - this._originalBrightness}%`);
+        areaDot.style.display = '';
+      } else {
+        areaDot.style.display = 'none';
+      }
+    }
+
+    const slider = this.renderRoot.querySelector('sp-color-slider');
+    const sliderDot = this._ensureDot(slider, 'bc-original-slider-dot');
+    if (sliderDot) {
+      if (this._showOriginalDot) {
+        sliderDot.style.setProperty('--dot-x', `${this._originalHue / 360 * 100}%`);
+        sliderDot.style.display = '';
+      } else {
+        sliderDot.style.display = 'none';
+      }
     }
   }
 
@@ -834,12 +909,6 @@ class BaseColor extends LitElement {
               @input=${this._onColorAreaInput}
               @change=${this._onColorAreaChange}
             ></sp-color-area>
-            ${this._showOriginalDot ? html`
-              <span
-                class="bc-original-dot"
-                style="--dot-x: ${this._originalSaturation}%; --dot-y: ${100 - this._originalBrightness}%;"
-              ></span>
-            ` : nothing}
           </div>
           <div class="bc-color-slider-container">
             <sp-color-slider
@@ -849,12 +918,6 @@ class BaseColor extends LitElement {
               @input=${this._onHueInput}
               @change=${this._onHueInput}
             ></sp-color-slider>
-            ${this._showOriginalDot ? html`
-              <span
-                class="bc-original-slider-dot"
-                style="--dot-x: ${this._originalHue / 360 * 100}%;"
-              ></span>
-            ` : nothing}
           </div>
         </div>
         ${this._renderAdditionalSliders()}

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -900,25 +900,21 @@ class BaseColor extends LitElement {
     return html`
       <div class="bc-color-control">
         <div class="bc-color-area-wrapper ${this.colorMode !== 'HEX' || this.showBrightnessControl ? 'has-sliders' : ''}">
-          <div class="bc-color-area-container">
-            <sp-color-area
-              .x=${this._saturation / 100}
-              .y=${this._brightness / 100}
-              .hue=${this._hue}
-              @pointerdown=${this._onPointerDown}
-              @input=${this._onColorAreaInput}
-              @change=${this._onColorAreaChange}
-            ></sp-color-area>
-          </div>
-          <div class="bc-color-slider-container">
-            <sp-color-slider
-              gradient="hue"
-              color=${currentColor}
-              @pointerdown=${this._onPointerDown}
-              @input=${this._onHueInput}
-              @change=${this._onHueInput}
-            ></sp-color-slider>
-          </div>
+          <sp-color-area
+            .x=${this._saturation / 100}
+            .y=${this._brightness / 100}
+            .hue=${this._hue}
+            @pointerdown=${this._onPointerDown}
+            @input=${this._onColorAreaInput}
+            @change=${this._onColorAreaChange}
+          ></sp-color-area>
+          <sp-color-slider
+            gradient="hue"
+            color=${currentColor}
+            @pointerdown=${this._onPointerDown}
+            @input=${this._onHueInput}
+            @change=${this._onHueInput}
+          ></sp-color-slider>
         </div>
         ${this._renderAdditionalSliders()}
       </div>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -60,6 +60,7 @@ class BaseColor extends LitElement {
     this._hexError = false;
     this._liveRegionText = '';
     this._announceTimer = null;
+    this._labCache = null;
   }
 
   get _rgb() {
@@ -83,6 +84,7 @@ class BaseColor extends LitElement {
   }
 
   get _lab() {
+    if (this._labCache) return { ...this._labCache };
     const rgb = this._rgb;
     return rgbToLab(rgb.red, rgb.green, rgb.blue);
   }
@@ -149,6 +151,7 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._labCache = null;
   }
 
   _emitColorChange() {
@@ -200,6 +203,7 @@ class BaseColor extends LitElement {
   _onModeSelect(mode) {
     this.colorMode = mode;
     this._modeMenuOpen = false;
+    this._labCache = null;
     this.dispatchEvent(new CustomEvent('mode-change', {
       bubbles: true,
       composed: true,
@@ -292,12 +296,10 @@ class BaseColor extends LitElement {
     const area = e.target;
     if (!area) return;
 
-    // Read saturation/brightness directly from sp-color-area's x/y properties
-    // to avoid precision loss from hex round-trip that causes erratic keyboard navigation.
-    // x = saturation (0–1), y = brightness (0–1). Hue is unchanged by the color area.
     this._saturation = area.x * 100;
     this._brightness = area.y * 100;
     this._hexError = false;
+    this._labCache = null;
     this._emitColorChange();
     this._blurOnTouch(area);
   }
@@ -310,6 +312,7 @@ class BaseColor extends LitElement {
 
     this._hue = slider.value;
     this._hexError = false;
+    this._labCache = null;
     this._emitColorChange();
     if (e.type === 'change') {
       this._blurOnTouch(slider);
@@ -334,11 +337,13 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._labCache = null;
     this._emitColorChange();
   }
 
   _onRGBChannelTextInput(e, channel) {
-    const value = Math.max(0, Math.min(255, Math.round(Number(e.target.value))));
+    const parsed = Number(e.target.value);
+    const value = Math.max(0, Math.min(255, Math.round(Number.isNaN(parsed) ? 0 : parsed)));
     const rgb = { ...this._rgb };
     rgb[channel] = value;
 
@@ -346,6 +351,7 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._labCache = null;
     this._emitColorChange();
   }
 
@@ -360,20 +366,33 @@ class BaseColor extends LitElement {
       this._brightness = value;
     }
 
+    this._labCache = null;
     this._emitColorChange();
   }
 
   _onHSBChannelTextInput(e, channel) {
-    const raw = Number(e.target.value);
+    const parsed = Number(e.target.value);
+    const raw = Number.isNaN(parsed) ? 0 : parsed;
 
     if (channel === 'h') {
-      this._hue = Math.max(0, Math.min(360, raw));
+      this._hue = ((raw % 360) + 360) % 360;
     } else if (channel === 's') {
       this._saturation = Math.max(0, Math.min(100, raw));
     } else if (channel === 'b') {
       this._brightness = Math.max(0, Math.min(100, raw));
     }
 
+    this._labCache = null;
+    this._emitColorChange();
+  }
+
+  _updateFromLab(lab) {
+    this._labCache = { l: lab.l, a: lab.a, b: lab.b };
+    const rgb = labToRGB(lab.l, lab.a, lab.b);
+    const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
+    this._hue = hsb.hue;
+    this._saturation = hsb.saturation;
+    this._brightness = hsb.brightness;
     this._emitColorChange();
   }
 
@@ -389,16 +408,12 @@ class BaseColor extends LitElement {
       lab.b = Math.round(sliderValue);
     }
 
-    const rgb = labToRGB(lab.l, lab.a, lab.b);
-    const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
-    this._hue = hsb.hue;
-    this._saturation = hsb.saturation;
-    this._brightness = hsb.brightness;
-    this._emitColorChange();
+    this._updateFromLab(lab);
   }
 
   _onLabChannelTextInput(e, channel) {
-    const raw = Number(e.target.value);
+    const parsed = Number(e.target.value);
+    const raw = Number.isNaN(parsed) ? 0 : parsed;
     const lab = this._lab;
 
     if (channel === 'l') {
@@ -409,12 +424,7 @@ class BaseColor extends LitElement {
       lab.b = Math.max(-128, Math.min(127, Math.round(raw)));
     }
 
-    const rgb = labToRGB(lab.l, lab.a, lab.b);
-    const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
-    this._hue = hsb.hue;
-    this._saturation = hsb.saturation;
-    this._brightness = hsb.brightness;
-    this._emitColorChange();
+    this._updateFromLab(lab);
   }
 
   // --- Slider gradients ---

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -41,6 +41,7 @@ class BaseColor extends LitElement {
       _brightness: { type: Number, state: true },
       _modeMenuOpen: { type: Boolean, state: true },
       _isLocked: { type: Boolean, state: true, reflect: true, attribute: 'locked' },
+      _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
     };
   }
@@ -56,6 +57,7 @@ class BaseColor extends LitElement {
     this._brightness = 100;
     this._modeMenuOpen = false;
     this._isLocked = false;
+    this._hexError = false;
     this._liveRegionText = '';
     this._announceTimer = null;
   }
@@ -140,6 +142,7 @@ class BaseColor extends LitElement {
 
   _syncFromColor() {
     if (!this.color) return;
+    if (this.color.toUpperCase() === this._hex.toUpperCase()) return;
     const rgb = hexToRGB(this.color);
     if (!rgb) return;
     const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
@@ -232,21 +235,33 @@ class BaseColor extends LitElement {
   }
 
   _onColorValueInput(e) {
-    const value = e.target.value.trim();
-    // Parse the input based on current color mode - only HEX mode shows the input
-    if (this.colorMode === 'HEX') {
-      // Match 6-digit hex with or without #
-      if (value.match(/^#?[0-9A-Fa-f]{6}$/)) {
-        const newColor = value.startsWith('#') ? value : `#${value}`;
-        this.color = newColor;
-        this._syncFromColor();
-        this._emitColorChange();
-      }
+    const field = e.target;
+    const value = field.value;
+    if (this.colorMode !== 'HEX') return;
+
+    const hex = value.replace(/#/g, '');
+    const normalized = `#${hex}`;
+    if (value !== normalized) {
+      field.value = normalized;
+    }
+
+    if (hex.match(/^[0-9A-Fa-f]{6}$/)) {
+      this._hexError = false;
+      this.color = `#${hex}`;
+      this._syncFromColor();
+      this._emitColorChange();
     }
   }
 
-  _toggleLock() {
-    this._isLocked = !this._isLocked;
+  _onHexCommit(e) {
+    const hex = e.target.value.replace(/#/g, '').trim();
+    if (!hex.match(/^[0-9A-Fa-f]{6}$/)) {
+      this._hexError = true;
+    }
+  }
+
+  _setLocked(locked) {
+    this._isLocked = locked;
     this.dispatchEvent(new CustomEvent('lock-change', {
       bubbles: true,
       composed: true,
@@ -257,8 +272,6 @@ class BaseColor extends LitElement {
   // --- Color area (Saturation/Brightness) ---
 
   _onColorAreaInput(e) {
-    if (this._isLocked) return;
-
     const area = e.target;
     if (!area) return;
 
@@ -267,26 +280,31 @@ class BaseColor extends LitElement {
     // x = saturation (0–1), y = brightness (0–1). Hue is unchanged by the color area.
     this._saturation = area.x * 100;
     this._brightness = area.y * 100;
+    this._hexError = false;
     this._emitColorChange();
   }
 
   // --- Hue slider ---
 
   _onHueInput(e) {
-    if (this._isLocked) return;
-
     const slider = e.target;
     if (slider.value == null) return;
 
     this._hue = slider.value;
+    this._hexError = false;
     this._emitColorChange();
+  }
+
+  _onChannelKeyDown(e, allowNegative = false) {
+    if (e.ctrlKey || e.metaKey) return;
+    if (e.key.length === 1 && !/[0-9]/.test(e.key) && !(allowNegative && e.key === '-')) {
+      e.preventDefault();
+    }
   }
 
   // --- Additional channel sliders ---
 
   _onRGBChannelSliderInput(e, channel) {
-    if (this._isLocked) return;
-
     const value = Math.round(Number(e.target.value));
     const rgb = { ...this._rgb };
     rgb[channel] = value;
@@ -299,8 +317,6 @@ class BaseColor extends LitElement {
   }
 
   _onRGBChannelTextInput(e, channel) {
-    if (this._isLocked) return;
-
     const value = Math.max(0, Math.min(255, Math.round(Number(e.target.value))));
     const rgb = { ...this._rgb };
     rgb[channel] = value;
@@ -313,8 +329,6 @@ class BaseColor extends LitElement {
   }
 
   _onHSBChannelSliderInput(e, channel) {
-    if (this._isLocked) return;
-
     const value = Number(e.target.value);
 
     if (channel === 'h') {
@@ -329,8 +343,6 @@ class BaseColor extends LitElement {
   }
 
   _onHSBChannelTextInput(e, channel) {
-    if (this._isLocked) return;
-
     const raw = Number(e.target.value);
 
     if (channel === 'h') {
@@ -345,8 +357,6 @@ class BaseColor extends LitElement {
   }
 
   _onLabChannelSliderInput(e, channel) {
-    if (this._isLocked) return;
-
     const sliderValue = Number(e.target.value);
     const lab = this._lab;
 
@@ -367,8 +377,6 @@ class BaseColor extends LitElement {
   }
 
   _onLabChannelTextInput(e, channel) {
-    if (this._isLocked) return;
-
     const raw = Number(e.target.value);
     const lab = this._lab;
 
@@ -502,20 +510,25 @@ class BaseColor extends LitElement {
           </div>
         </div>
         ${this.colorMode === 'HEX' ? html`
-          <div class="bc-color-value-wrapper">
+          <div class="bc-color-value-wrapper ${this._hexError ? 'has-error' : ''}">
             <div class="bc-color-swatch" style="background-color: ${this._hex}" aria-hidden="true"></div>
-            <input
-              type="text"
-              class="bc-color-value"
-              .value=${this._colorValue}
-              ?disabled=${this._isLocked}
-              @input=${this._onColorValueInput}
-              aria-label="Color value"
-            />
-            <button
-              class="bc-lock-button"
-              @click=${this._toggleLock}
-              aria-label="${this._isLocked ? 'Unlock color' : 'Lock color'}"
+            <sp-theme system="spectrum-two" color="light" scale="medium">
+              <sp-textfield
+                class="bc-hex-field"
+                quiet
+                size="m"
+                maxlength="7"
+                .value=${this._colorValue}
+                ?invalid=${this._hexError}
+                label="Color value"
+                label-visibility="none"
+                @input=${this._onColorValueInput}
+                @change=${this._onHexCommit}
+              ></sp-textfield>
+            </sp-theme>
+            <span
+              class="bc-lock-icon"
+              aria-label="${this._isLocked ? 'Color locked' : 'Color unlocked'}"
             >
               <img
                 src="/express/code/icons/${this._isLocked ? 'S2_Icon_Lock_20_N.svg' : 'S2_Icon_LockOpen_20_N.svg'}"
@@ -523,7 +536,7 @@ class BaseColor extends LitElement {
                 width="20"
                 height="20"
               />
-            </button>
+            </span>
           </div>
         ` : nothing}
       </div>
@@ -549,7 +562,6 @@ class BaseColor extends LitElement {
             label="Brightness/Contrast"
             valuetext=${`Brightness: ${value}%`}
             gradient=${gradient}
-            ?disabled=${this._isLocked}
             @input=${(e) => this._onHSBChannelSliderInput(e, 'b')}
           ></color-channel-slider>
         </div>
@@ -558,10 +570,11 @@ class BaseColor extends LitElement {
             class="bc-channel-input"
             type="number"
             size="s"
+            maxlength="3"
             .value=${String(value)}
             label="Brightness/Contrast"
             label-visibility="none"
-            ?disabled=${this._isLocked}
+            @keydown=${(e) => this._onChannelKeyDown(e)}
             @input=${(e) => this._onHSBChannelTextInput(e, 'b')}
           ></sp-textfield>
         </sp-theme>
@@ -575,9 +588,9 @@ class BaseColor extends LitElement {
     if (this.colorMode === 'RGB') {
       const rgb = this._rgb;
       const channels = [
-        { key: 'red', label: 'R', ariaLabel: 'Red', value: Math.round(rgb.red), min: 0, max: 255, unit: '' },
-        { key: 'green', label: 'G', ariaLabel: 'Green', value: Math.round(rgb.green), min: 0, max: 255, unit: '' },
-        { key: 'blue', label: 'B', ariaLabel: 'Blue', value: Math.round(rgb.blue), min: 0, max: 255, unit: '' },
+        { key: 'red', label: 'R', ariaLabel: 'Red', value: Math.round(rgb.red), min: 0, max: 255, unit: '', maxlength: 3 },
+        { key: 'green', label: 'G', ariaLabel: 'Green', value: Math.round(rgb.green), min: 0, max: 255, unit: '', maxlength: 3 },
+        { key: 'blue', label: 'B', ariaLabel: 'Blue', value: Math.round(rgb.blue), min: 0, max: 255, unit: '', maxlength: 3 },
       ];
 
       if (this.showBrightnessControl) {
@@ -590,6 +603,7 @@ class BaseColor extends LitElement {
           max: 100,
           isIcon: true,
           unit: '%',
+          maxlength: 3,
         });
       }
 
@@ -605,7 +619,6 @@ class BaseColor extends LitElement {
                 label=${ch.isIcon ? 'Brightness/Contrast' : ch.ariaLabel}
                 valuetext=${`${ch.ariaLabel}: ${ch.value}${ch.unit}`}
                 gradient=${this._getChannelGradient(ch.key)}
-                ?disabled=${this._isLocked}
                 @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelSliderInput(e, 'b') : this._onRGBChannelSliderInput(e, ch.key)}
               ></color-channel-slider>
             </div>
@@ -614,10 +627,11 @@ class BaseColor extends LitElement {
                 class="bc-channel-input"
                 type="number"
                 size="s"
+                maxlength=${ch.maxlength}
                 .value=${String(ch.value)}
                 label=${ch.isIcon ? 'Brightness/Contrast' : ch.ariaLabel}
                 label-visibility="none"
-                ?disabled=${this._isLocked}
+                @keydown=${(e) => this._onChannelKeyDown(e)}
                 @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelTextInput(e, 'b') : this._onRGBChannelTextInput(e, ch.key)}
               ></sp-textfield>
             </sp-theme>
@@ -628,9 +642,9 @@ class BaseColor extends LitElement {
 
     if (this.colorMode === 'HSB') {
       const channels = [
-        { key: 'h', label: 'H', ariaLabel: 'Hue', value: Math.round(this._hue), min: 0, max: 360, unit: ' degrees' },
-        { key: 's', label: 'S', ariaLabel: 'Saturation', value: Math.round(this._saturation), min: 0, max: 100, unit: '%' },
-        { key: 'b', label: 'B', ariaLabel: 'Brightness', value: Math.round(this._brightness), min: 0, max: 100, unit: '%' },
+        { key: 'h', label: 'H', ariaLabel: 'Hue', value: Math.round(this._hue), min: 0, max: 360, unit: ' degrees', maxlength: 3 },
+        { key: 's', label: 'S', ariaLabel: 'Saturation', value: Math.round(this._saturation), min: 0, max: 100, unit: '%', maxlength: 3 },
+        { key: 'b', label: 'B', ariaLabel: 'Brightness', value: Math.round(this._brightness), min: 0, max: 100, unit: '%', maxlength: 3 },
       ];
 
       return html`
@@ -645,7 +659,6 @@ class BaseColor extends LitElement {
                 label=${ch.ariaLabel}
                 valuetext=${`${ch.ariaLabel}: ${ch.value}${ch.unit}`}
                 gradient=${this._getChannelGradient(ch.key)}
-                ?disabled=${this._isLocked}
                 @input=${(e) => this._onHSBChannelSliderInput(e, ch.key)}
               ></color-channel-slider>
             </div>
@@ -654,10 +667,11 @@ class BaseColor extends LitElement {
                 class="bc-channel-input"
                 type="number"
                 size="s"
+                maxlength=${ch.maxlength}
                 .value=${String(ch.value)}
                 label=${ch.ariaLabel}
                 label-visibility="none"
-                ?disabled=${this._isLocked}
+                @keydown=${(e) => this._onChannelKeyDown(e)}
                 @input=${(e) => this._onHSBChannelTextInput(e, ch.key)}
               ></sp-textfield>
             </sp-theme>
@@ -669,9 +683,9 @@ class BaseColor extends LitElement {
     if (this.colorMode === 'Lab') {
       const lab = this._lab;
       const channels = [
-        { key: 'l', label: 'L', ariaLabel: 'Lightness', value: Math.round(lab.l), min: 0, max: 100, unit: '' },
-        { key: 'a', label: 'a', ariaLabel: 'a (green-red)', value: Math.round(lab.a), min: -128, max: 127, unit: '' },
-        { key: 'b', label: 'b', ariaLabel: 'b (blue-yellow)', value: Math.round(lab.b), min: -128, max: 127, unit: '' },
+        { key: 'l', label: 'L', ariaLabel: 'Lightness', value: Math.round(lab.l), min: 0, max: 100, unit: '', maxlength: 3, allowNegative: false },
+        { key: 'a', label: 'a', ariaLabel: 'a (green-red)', value: Math.round(lab.a), min: -128, max: 127, unit: '', maxlength: 4, allowNegative: true },
+        { key: 'b', label: 'b', ariaLabel: 'b (blue-yellow)', value: Math.round(lab.b), min: -128, max: 127, unit: '', maxlength: 4, allowNegative: true },
       ];
 
       return html`
@@ -686,7 +700,6 @@ class BaseColor extends LitElement {
                 label=${ch.ariaLabel}
                 valuetext=${`${ch.ariaLabel}: ${ch.value}${ch.unit}`}
                 gradient=${this._getChannelGradient(ch.key)}
-                ?disabled=${this._isLocked}
                 @input=${(e) => this._onLabChannelSliderInput(e, ch.key)}
               ></color-channel-slider>
             </div>
@@ -695,10 +708,11 @@ class BaseColor extends LitElement {
                 class="bc-channel-input"
                 type="number"
                 size="s"
+                maxlength=${ch.maxlength}
                 .value=${String(ch.value)}
                 label=${ch.ariaLabel}
                 label-visibility="none"
-                ?disabled=${this._isLocked}
+                @keydown=${(e) => this._onChannelKeyDown(e, ch.allowNegative)}
                 @input=${(e) => this._onLabChannelTextInput(e, ch.key)}
               ></sp-textfield>
             </sp-theme>
@@ -721,13 +735,11 @@ class BaseColor extends LitElement {
               .x=${this._saturation / 100}
               .y=${this._brightness / 100}
               .hue=${this._hue}
-              ?disabled=${this._isLocked}
               @change=${this._onColorAreaInput}
             ></sp-color-area>
             <sp-color-slider
               gradient="hue"
               color=${currentColor}
-              ?disabled=${this._isLocked}
               @input=${this._onHueInput}
               @change=${this._onHueInput}
             ></sp-color-slider>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -257,6 +257,21 @@ class BaseColor extends LitElement {
     }
   }
 
+  _onHexPaste(e) {
+    const pasted = (e.clipboardData && e.clipboardData.getData('text')) || '';
+    const stripped = pasted.replace(/#/g, '');
+    if (stripped === pasted) return;
+    e.preventDefault();
+    const input = e.composedPath().find((el) => el instanceof HTMLInputElement) || document.activeElement;
+    if (!input || !(input instanceof HTMLInputElement)) return;
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? input.value.length;
+    const value = input.value.slice(0, start) + stripped + input.value.slice(end);
+    input.value = value;
+    input.setSelectionRange(start + stripped.length, start + stripped.length);
+    input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+  }
+
   _onHexCommit(e) {
     const hex = e.target.value.replace(/#/g, '').trim();
     if (!hex.match(/^[0-9A-Fa-f]{6}$/)) {
@@ -552,6 +567,7 @@ class BaseColor extends LitElement {
                 ?invalid=${this._hexError}
                 label="Base color"
                 @input=${this._onColorValueInput}
+                @paste=${this._onHexPaste}
                 @change=${this._onHexCommit}
               ></sp-textfield>
               <span

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -269,6 +269,23 @@ class BaseColor extends LitElement {
     }));
   }
 
+  // --- Touch focus fix ---
+  // On mobile, touching the color area/slider gives the handle a [focused]
+  // attribute that increases its size. Because nothing steals focus after
+  // the finger lifts, the handle stays enlarged. Track pointer type and
+  // blur after touch-initiated changes so the handle returns to normal.
+
+  _onPointerDown(e) {
+    this._lastPointerType = e.pointerType;
+  }
+
+  _blurOnTouch(target) {
+    if (this._lastPointerType === 'touch') {
+      this._lastPointerType = null;
+      requestAnimationFrame(() => target?.blur());
+    }
+  }
+
   // --- Color area (Saturation/Brightness) ---
 
   _onColorAreaInput(e) {
@@ -282,6 +299,7 @@ class BaseColor extends LitElement {
     this._brightness = area.y * 100;
     this._hexError = false;
     this._emitColorChange();
+    this._blurOnTouch(area);
   }
 
   // --- Hue slider ---
@@ -293,6 +311,9 @@ class BaseColor extends LitElement {
     this._hue = slider.value;
     this._hexError = false;
     this._emitColorChange();
+    if (e.type === 'change') {
+      this._blurOnTouch(slider);
+    }
   }
 
   _onChannelKeyDown(e, allowNegative = false) {
@@ -735,11 +756,13 @@ class BaseColor extends LitElement {
               .x=${this._saturation / 100}
               .y=${this._brightness / 100}
               .hue=${this._hue}
+              @pointerdown=${this._onPointerDown}
               @change=${this._onColorAreaInput}
             ></sp-color-area>
             <sp-color-slider
               gradient="hue"
               color=${currentColor}
+              @pointerdown=${this._onPointerDown}
               @input=${this._onHueInput}
               @change=${this._onHueInput}
             ></sp-color-slider>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -837,7 +837,7 @@ class BaseColor extends LitElement {
             ${this._showOriginalDot ? html`
               <span
                 class="bc-original-dot"
-                style="left: ${this._originalSaturation}%; top: ${100 - this._originalBrightness}%;"
+                style="--dot-x: ${this._originalSaturation}%; --dot-y: ${100 - this._originalBrightness}%;"
               ></span>
             ` : nothing}
           </div>
@@ -852,7 +852,7 @@ class BaseColor extends LitElement {
             ${this._showOriginalDot ? html`
               <span
                 class="bc-original-slider-dot"
-                style="left: ${this._originalHue / 360 * 100}%;"
+                style="--dot-x: ${this._originalHue / 360 * 100}%;"
               ></span>
             ` : nothing}
           </div>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -529,31 +529,34 @@ class BaseColor extends LitElement {
           </div>
         </div>
         ${this.colorMode === 'HEX' ? html`
-          <div class="bc-color-value-wrapper ${this._hexError ? 'has-error' : ''}">
-            <div class="bc-color-swatch" style="background-color: ${this._hex}" aria-hidden="true"></div>
-            <sp-textfield
-              id="bc-hex-input"
-              class="bc-hex-field"
-              quiet
-              size="l"
-              maxlength="7"
-              .value=${this._colorValue}
-              ?invalid=${this._hexError}
-              label="Base color"
-              @input=${this._onColorValueInput}
-              @change=${this._onHexCommit}
-            ></sp-textfield>
-            <span
-              class="bc-lock-icon"
-              aria-label="${this._isLocked ? 'Color locked' : 'Color unlocked'}"
-            >
-              <img
-                src="/express/code/icons/${this._isLocked ? 'S2_Icon_Lock_20_N.svg' : 'S2_Icon_LockOpen_20_N.svg'}"
-                alt=""
-                width="20"
-                height="20"
-              />
-            </span>
+          <div class="bc-color-value-group">
+            <div class="bc-color-value-wrapper ${this._hexError ? 'has-error' : ''}">
+              <div class="bc-color-swatch" style="background-color: ${this._hex}" aria-hidden="true"></div>
+              <sp-textfield
+                id="bc-hex-input"
+                class="bc-hex-field"
+                quiet
+                size="l"
+                maxlength="7"
+                .value=${this._colorValue}
+                ?invalid=${this._hexError}
+                label="Base color"
+                @input=${this._onColorValueInput}
+                @change=${this._onHexCommit}
+              ></sp-textfield>
+              <span
+                class="bc-lock-icon"
+                aria-label="${this._isLocked ? 'Color locked' : 'Color unlocked'}"
+              >
+                <img
+                  src="/express/code/icons/${this._isLocked ? 'S2_Icon_Lock_20_N.svg' : 'S2_Icon_LockOpen_20_N.svg'}"
+                  alt=""
+                  width="20"
+                  height="20"
+                />
+              </span>
+            </div>
+            ${this._hexError ? html`<span class="bc-hex-error-text">Please enter a valid 6-character HEX code</span>` : nothing}
           </div>
         ` : nothing}
       </div>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -44,9 +44,6 @@ class BaseColor extends LitElement {
       _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
       _colorUpdatedFromPicker: { type: Boolean, state: true },
-      _showOriginalDot: { type: Boolean, state: true },
-      _originalSaturation: { type: Number, state: true },
-      _originalBrightness: { type: Number, state: true },
     };
   }
 
@@ -66,7 +63,8 @@ class BaseColor extends LitElement {
     this._liveRegionText = '';
     this._announceTimer = null;
     this._labCache = null;
-    this._showOriginalDot = false;
+    this._hasOriginal = false;
+    this._originalHue = 0;
     this._originalSaturation = 0;
     this._originalBrightness = 0;
   }
@@ -95,6 +93,13 @@ class BaseColor extends LitElement {
     if (this._labCache) return { ...this._labCache };
     const rgb = this._rgb;
     return rgbToLab(rgb.red, rgb.green, rgb.blue);
+  }
+
+  get _showOriginalDot() {
+    if (!this._hasOriginal) return false;
+    return Math.round(this._hue) !== Math.round(this._originalHue)
+      || Math.round(this._saturation) !== Math.round(this._originalSaturation)
+      || Math.round(this._brightness) !== Math.round(this._originalBrightness);
   }
 
   get _colorValue() {
@@ -152,20 +157,26 @@ class BaseColor extends LitElement {
 
   _syncFromColor() {
     if (!this.color) return;
-    if (this.color.toUpperCase() === this._hex.toUpperCase()) return;
     const rgb = hexToRGB(this.color);
     if (!rgb) return;
     const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
+
+    if (!this._hasOriginal) {
+      this._originalHue = hsb.hue;
+      this._originalSaturation = hsb.saturation;
+      this._originalBrightness = hsb.brightness;
+      this._hasOriginal = true;
+    }
+
+    if (this.color.toUpperCase() === this._hex.toUpperCase()) return;
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
-    this._showOriginalDot = false;
   }
 
-  _emitColorChange({ fromColorArea = false } = {}) {
-    if (!fromColorArea) this._showOriginalDot = false;
+  _emitColorChange() {
     const rgb = this._rgb;
     this.dispatchEvent(new CustomEvent('color-change', {
       bubbles: true,
@@ -308,6 +319,10 @@ class BaseColor extends LitElement {
     }));
   }
 
+  resetOriginalColor() {
+    this._hasOriginal = false;
+  }
+
   // --- Touch focus fix ---
   // On mobile, touching the color area/slider gives the handle a [focused]
   // attribute that increases its size. Because nothing steals focus after
@@ -327,12 +342,6 @@ class BaseColor extends LitElement {
 
   // --- Color area (Saturation/Brightness) ---
 
-  _onColorAreaPointerDown(e) {
-    this._lastPointerType = e.pointerType;
-    this._originalSaturation = this._saturation;
-    this._originalBrightness = this._brightness;
-  }
-
   _onColorAreaInput(e) {
     const area = e.target;
     if (!area) return;
@@ -342,13 +351,7 @@ class BaseColor extends LitElement {
     this._hexError = false;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
-
-    if (this._saturation !== this._originalSaturation
-      || this._brightness !== this._originalBrightness) {
-      this._showOriginalDot = true;
-    }
-
-    this._emitColorChange({ fromColorArea: true });
+    this._emitColorChange();
   }
 
   _onColorAreaChange(e) {
@@ -362,7 +365,14 @@ class BaseColor extends LitElement {
     const slider = e.target;
     if (slider.value == null) return;
 
-    this._hue = slider.value;
+    let hue = slider.value;
+    if (this._hasOriginal) {
+      const diff = Math.abs(hue - this._originalHue);
+      const wrappedDiff = Math.min(diff, 360 - diff);
+      if (wrappedDiff <= 5) hue = this._originalHue;
+    }
+
+    this._hue = hue;
     this._hexError = false;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
@@ -820,24 +830,32 @@ class BaseColor extends LitElement {
               .x=${this._saturation / 100}
               .y=${this._brightness / 100}
               .hue=${this._hue}
-              @pointerdown=${this._onColorAreaPointerDown}
+              @pointerdown=${this._onPointerDown}
               @input=${this._onColorAreaInput}
               @change=${this._onColorAreaChange}
             ></sp-color-area>
             ${this._showOriginalDot ? html`
-              <div
+              <span
                 class="bc-original-dot"
                 style="left: ${this._originalSaturation}%; top: ${100 - this._originalBrightness}%;"
-              ></div>
+              ></span>
             ` : nothing}
           </div>
-          <sp-color-slider
-            gradient="hue"
-            color=${currentColor}
-            @pointerdown=${this._onPointerDown}
-            @input=${this._onHueInput}
-            @change=${this._onHueInput}
-          ></sp-color-slider>
+          <div class="bc-color-slider-container">
+            <sp-color-slider
+              gradient="hue"
+              color=${currentColor}
+              @pointerdown=${this._onPointerDown}
+              @input=${this._onHueInput}
+              @change=${this._onHueInput}
+            ></sp-color-slider>
+            ${this._showOriginalDot ? html`
+              <span
+                class="bc-original-slider-dot"
+                style="left: ${this._originalHue / 360 * 100}%;"
+              ></span>
+            ` : nothing}
+          </div>
         </div>
         ${this._renderAdditionalSliders()}
       </div>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -43,6 +43,7 @@ class BaseColor extends LitElement {
       _isLocked: { type: Boolean, state: true, reflect: true, attribute: 'locked' },
       _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
+      _colorUpdatedFromPicker: { type: Boolean, state: true },
     };
   }
 
@@ -58,6 +59,7 @@ class BaseColor extends LitElement {
     this._modeMenuOpen = false;
     this._isLocked = false;
     this._hexError = false;
+    this._colorUpdatedFromPicker = false;
     this._liveRegionText = '';
     this._announceTimer = null;
     this._labCache = null;
@@ -151,6 +153,7 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
   }
 
@@ -243,6 +246,8 @@ class BaseColor extends LitElement {
     const value = field.value;
     if (this.colorMode !== 'HEX') return;
 
+    this._colorUpdatedFromPicker = false;
+
     const hex = value.replace(/#/g, '');
     const normalized = `#${hex}`;
     if (value !== normalized) {
@@ -273,9 +278,16 @@ class BaseColor extends LitElement {
   }
 
   _onHexCommit(e) {
-    const hex = e.target.value.replace(/#/g, '').trim();
+    const field = e.target;
+    const hex = field.value.replace(/#/g, '').trim();
     if (!hex.match(/^[0-9A-Fa-f]{6}$/)) {
-      this._hexError = true;
+      if (this._colorUpdatedFromPicker) {
+        field.value = this._hex;
+        this._hexError = false;
+        this._colorUpdatedFromPicker = false;
+      } else {
+        this._hexError = true;
+      }
     }
   }
 
@@ -314,6 +326,7 @@ class BaseColor extends LitElement {
     this._saturation = area.x * 100;
     this._brightness = area.y * 100;
     this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
     this._emitColorChange();
     this._blurOnTouch(area);
@@ -327,6 +340,7 @@ class BaseColor extends LitElement {
 
     this._hue = slider.value;
     this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
     this._emitColorChange();
     if (e.type === 'change') {
@@ -352,6 +366,8 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
     this._emitColorChange();
   }
@@ -366,6 +382,8 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
     this._emitColorChange();
   }
@@ -381,6 +399,8 @@ class BaseColor extends LitElement {
       this._brightness = value;
     }
 
+    this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
     this._emitColorChange();
   }
@@ -397,6 +417,8 @@ class BaseColor extends LitElement {
       this._brightness = Math.max(0, Math.min(100, raw));
     }
 
+    this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._labCache = null;
     this._emitColorChange();
   }
@@ -408,6 +430,8 @@ class BaseColor extends LitElement {
     this._hue = hsb.hue;
     this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    this._hexError = false;
+    this._colorUpdatedFromPicker = true;
     this._emitColorChange();
   }
 

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -837,7 +837,7 @@ class BaseColor extends LitElement {
             ${this._showOriginalDot ? html`
               <span
                 class="bc-original-dot"
-                style="--dot-x: ${this._originalSaturation}%; --dot-y: ${100 - this._originalBrightness}%;"
+                style="left: ${this._originalSaturation}%; top: ${100 - this._originalBrightness}%;"
               ></span>
             ` : nothing}
           </div>
@@ -852,7 +852,7 @@ class BaseColor extends LitElement {
             ${this._showOriginalDot ? html`
               <span
                 class="bc-original-slider-dot"
-                style="--dot-x: ${this._originalHue / 360 * 100}%;"
+                style="left: ${this._originalHue / 360 * 100}%;"
               ></span>
             ` : nothing}
           </div>

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -108,8 +108,8 @@ export const style = css`
         gap: var(--spacing-100);
         width: 100%;
         min-height: var(--spacing-600);
-        border: 1px solid var(--color-gray-300-variant);
-        border-radius: var(--Corner-radius-corner-radius-100);
+        border: var(--border-width-2) solid var(--color-gray-300-variant);
+        border-radius: 9px;
         padding: 0 var(--spacing-200);
         background-color: var(--color-white);
     }
@@ -120,49 +120,46 @@ export const style = css`
         border-color: transparent;
     }
 
+    .bc-color-value-wrapper.has-error {
+        border-color: var(--color-error-red);
+    }
+
+    .bc-color-value-wrapper.has-error:focus-within {
+        outline-color: var(--color-error-red);
+        border-color: transparent;
+    }
+
     .bc-color-swatch {
         width: 18px;
         height: 18px;
         border-radius: 50%;
-        border: 1px solid var(--color-gray-300-variant);
+        border: 1px solid #1F1F1F4D;
         flex-shrink: 0;
     }
 
-    .bc-color-value {
+    .bc-color-value-wrapper sp-theme {
         flex: 1;
-        border: none;
-        outline: none;
-        background: transparent;
-        padding: 0;
-        font-family: var(--body-font-family);
-        font-size: var(--body-font-size-m);
-        color: var(--color-gray-800-variant);
+        display: flex;
     }
 
-    .bc-lock-button {
+    .bc-hex-field {
+        flex: 1;
+        --mod-textfield-border-width: 0;
+        --mod-textfield-background-color: transparent;
+        --mod-textfield-focus-indicator-width: 0;
+        --spectrum-textfield-border-width: 0;
+        --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height, 32px)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid, 18px))) / 2);
+    }
+
+    .bc-lock-icon {
         display: flex;
         align-items: center;
         justify-content: center;
-        background: none;
-        border: none;
-        padding: 0;
-        cursor: pointer;
         flex-shrink: 0;
         opacity: 0.6;
-        transition: opacity 0.2s ease;
     }
 
-    .bc-lock-button:hover {
-        opacity: 1;
-    }
-
-    .bc-lock-button:focus-visible {
-        outline: var(--spacing-50) solid var(--color-blue-800);
-        outline-offset: var(--spacing-50);
-        border-radius: var(--spacing-50);
-    }
-
-    .bc-lock-button img {
+    .bc-lock-icon img {
         display: block;
     }
 
@@ -279,22 +276,7 @@ export const style = css`
         border: 0;
     }
 
-    /* Locked state */
-
-    :host([locked]) .bc-color-area-wrapper sp-color-area,
-    :host([locked]) .bc-color-area-wrapper sp-color-slider,
-    :host([locked]) .bc-slider-wrapper,
-    :host([locked]) .bc-slider-wrapper color-channel-slider,
-    :host([locked]) .bc-channel-input,
-    :host([locked]) .bc-channel-row sp-textfield {
-        opacity: 0.5;
-        cursor: not-allowed;
-        pointer-events: none;
-    }
-
     @media (prefers-reduced-motion: reduce) {
-        .bc-lock-button {
-            transition: none;
-        }
+        /* placeholder for future animated elements */
     }
 `;

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -238,6 +238,8 @@ export const style = css`
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 1;
+        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
+        top: clamp(calc(var(--spacing-80) / 2), var(--dot-y, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     .bc-color-slider-container {
@@ -261,6 +263,7 @@ export const style = css`
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 10;
+        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     /* ---- Channel sliders ---- */

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -140,10 +140,12 @@ export const style = css`
     .bc-color-value-wrapper sp-theme {
         flex: 1;
         display: flex;
+        min-width: 0;
     }
 
     .bc-hex-field {
         flex: 1;
+        min-width: 0;
         --mod-textfield-border-width: 0;
         --mod-textfield-background-color: transparent;
         --mod-textfield-focus-indicator-width: 0;

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -237,6 +237,8 @@ export const style = css`
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 1;
+        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
+        top: clamp(calc(var(--spacing-80) / 2), var(--dot-y, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     .bc-color-slider-container {
@@ -260,6 +262,7 @@ export const style = css`
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 10;
+        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     /* ---- Channel sliders ---- */

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -86,14 +86,11 @@ export const style = css`
         object-fit: contain;
     }
 
-    .bc-mode-wrap sp-theme {
+    .bc-mode-wrap sp-menu {
         position: absolute;
         top: calc(100% - var(--spacing-50));
         right: var(--spacing-50);
         z-index: 10;
-    }
-
-    .bc-mode-wrap sp-menu {
         width: 114px;
         background-color: var(--color-white);
         box-shadow: var(--Alias-drop-shadow-ambient), var(--Alias-drop-shadow-transition), var(--Alias-drop-shadow-elevated-key);
@@ -113,20 +110,41 @@ export const style = css`
         padding: 0 var(--spacing-200);
         background-color: var(--color-white);
     }
+    
+    .bc-color-value-wrapper:hover {
+        border-color: var(--color-gray-400-variant);
+    }
 
     .bc-color-value-wrapper:focus-within {
-        outline: 2px solid var(--color-blue-800);
-        outline-offset: -1px;
-        border-color: transparent;
+        outline: var(--border-width-2) solid var(--color-blue-800);
+        outline-offset: var(--border-width-2);
+        border-color: var(--color-gray-800-variant);
     }
 
     .bc-color-value-wrapper.has-error {
-        border-color: var(--color-error-red);
+        border-color: var(--spectrum-negative-border-color-default);
+    }
+
+    .bc-color-value-wrapper.has-error:hover {
+        border-color: var(--spectrum-negative-border-color-hover);
+    }
+
+    .bc-color-value-wrapper.has-error:active {
+        border-color: var(--spectrum-negative-border-color-down);
     }
 
     .bc-color-value-wrapper.has-error:focus-within {
-        outline-color: var(--color-error-red);
-        border-color: transparent;
+        outline: var(--border-width-2) solid var(--color-blue-800);
+        outline-offset: var(--border-width-2);
+        border-color: var(--spectrum-negative-border-color-focus);
+    }
+
+    .bc-color-value-wrapper.has-error:focus-within:hover {
+        border-color: var(--spectrum-negative-border-color-focus-hover);
+    }
+
+    .bc-color-value-wrapper.has-error:focus-visible {
+        border-color: var(--spectrum-negative-border-color-key-focus);
     }
 
     .bc-color-swatch {
@@ -137,12 +155,6 @@ export const style = css`
         flex-shrink: 0;
     }
 
-    .bc-color-value-wrapper sp-theme {
-        flex: 1;
-        display: flex;
-        min-width: 0;
-    }
-
     .bc-hex-field {
         flex: 1;
         min-width: 0;
@@ -150,7 +162,8 @@ export const style = css`
         --mod-textfield-background-color: transparent;
         --mod-textfield-focus-indicator-width: 0;
         --spectrum-textfield-border-width: 0;
-        --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height, 32px)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid, 18px))) / 2);
+        --mod-textfield-height: 40px;
+        --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid))) / 2);
     }
 
     .bc-lock-icon {
@@ -184,11 +197,8 @@ export const style = css`
         padding-bottom: var(--spacing-200);
     }
 
-    .bc-color-area-wrapper sp-theme {
-        display: flex;
-        flex-direction: column;
+    .bc-color-area-wrapper {
         gap: var(--spacing-200);
-        width: 100%;
     }
 
     .bc-color-area-wrapper sp-color-area {
@@ -249,12 +259,9 @@ export const style = css`
         width: 100%;
     }
 
-    .bc-channel-row sp-theme {
+    .bc-channel-input {
         flex-shrink: 0;
         line-height: var(--ax-detail-l-lh);
-    }
-
-    .bc-channel-input {
         width: var(--spacing-600);
         --mod-textfield-corner-radius: 7px;
         --mod-textfield-border-width: var(--spacing-50);
@@ -262,6 +269,17 @@ export const style = css`
         --mod-textfield-border-color: var(--color-gray-300-variant);
         --mod-textfield-background-color: var(--color-white);
         border-radius: 7px;
+    }
+    
+    .bc-channel-input:hover {
+        --mod-textfield-border-color: var(--color-gray-400-variant);
+        --mod-textfield-border-color-hover: var(--color-gray-400-variant);
+    }
+    
+    .bc-channel-input:focus-within {
+        outline: var(--border-width-2) solid var(--color-blue-800);
+        outline-offset: var(--border-width-2);
+        --mod-textfield-border-color: var(--color-gray-800-variant);
     }
 
     /* Visually hidden – accessible to screen readers only */

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -218,6 +218,8 @@ export const style = css`
 
     .bc-color-area-container {
         position: relative;
+        overflow: hidden;
+        border-radius: var(--Corner-radius-corner-radius-100);
     }
 
     .bc-color-area-wrapper sp-color-area {
@@ -228,20 +230,37 @@ export const style = css`
 
     .bc-original-dot {
         position: absolute;
-        width: 4px;
-        height: 4px;
+        width: var(--spacing-80);
+        height: var(--spacing-80);
         border-radius: 50%;
-        background-color: #fff;
+        background-color: var(--color-white);
         border: 1px solid rgba(31, 31, 31, 0.3);
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 1;
     }
 
-    .bc-color-area-wrapper sp-color-slider {
+    .bc-color-slider-container {
+        position: relative;
+    }
+
+    .bc-color-slider-container sp-color-slider {
         width: 100%;
         height: var(--spacing-80);
         cursor: pointer;
+    }
+
+    .bc-original-slider-dot {
+        position: absolute;
+        width: var(--spacing-80);
+        height: var(--spacing-80);
+        border-radius: 50%;
+        background-color: var(--color-white);
+        border: 1px solid rgba(31, 31, 31, 0.3);
+        top: 50%;
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+        z-index: 10;
     }
 
     /* ---- Channel sliders ---- */

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -179,6 +179,7 @@ export const style = css`
         --spectrum-textfield-border-width: 0;
         --mod-textfield-height: 40px;
         --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid))) / 2);
+        --mod-textfield-icon-spacing-inline-end-invalid: 0;
     }
 
     .bc-lock-icon {
@@ -187,6 +188,10 @@ export const style = css`
         justify-content: center;
         flex-shrink: 0;
         opacity: 0.6;
+    }
+
+    .bc-color-value-wrapper.has-error .bc-lock-icon {
+        display: none;
     }
 
     .bc-lock-icon img {

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -221,22 +221,13 @@ export const style = css`
         gap: var(--spacing-200);
     }
 
-    .bc-color-area-container {
-        position: relative;
-        border-radius: var(--spectrum-corner-radius-100);
-    }
-
     .bc-color-area-wrapper sp-color-area {
         width: 100%;
         height: 156px;
         cursor: pointer;
     }
 
-    .bc-color-slider-container {
-        position: relative;
-    }
-
-    .bc-color-slider-container sp-color-slider {
+    .bc-color-area-wrapper sp-color-slider {
         width: 100%;
         height: var(--spacing-80);
         cursor: pointer;

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -232,20 +232,6 @@ export const style = css`
         cursor: pointer;
     }
 
-    .bc-original-dot {
-        position: absolute;
-        width: var(--spacing-80);
-        height: var(--spacing-80);
-        border-radius: 50%;
-        background-color: var(--color-white);
-        border: 1px solid rgba(31, 31, 31, 0.3);
-        transform: translate(-50%, -50%);
-        pointer-events: none;
-        z-index: 1;
-        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
-        top: clamp(calc(var(--spacing-80) / 2), var(--dot-y, 50%), calc(100% - var(--spacing-80) / 2));
-    }
-
     .bc-color-slider-container {
         position: relative;
     }
@@ -254,20 +240,6 @@ export const style = css`
         width: 100%;
         height: var(--spacing-80);
         cursor: pointer;
-    }
-
-    .bc-original-slider-dot {
-        position: absolute;
-        width: var(--spacing-80);
-        height: var(--spacing-80);
-        border-radius: 50%;
-        background-color: var(--color-white);
-        border: 1px solid rgba(31, 31, 31, 0.3);
-        top: 50%;
-        transform: translate(-50%, -50%);
-        pointer-events: none;
-        z-index: 10;
-        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     /* ---- Channel sliders ---- */

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -94,7 +94,7 @@ export const style = css`
         width: 114px;
         background-color: var(--color-white);
         box-shadow: var(--Alias-drop-shadow-ambient), var(--Alias-drop-shadow-transition), var(--Alias-drop-shadow-elevated-key);
-        border-radius: var(--Corner-radius-corner-radius-100);
+        border-radius: var(--spectrum-corner-radius-100);
     }
 
     /* ---- Color value input ---- */
@@ -218,8 +218,7 @@ export const style = css`
 
     .bc-color-area-container {
         position: relative;
-        overflow: hidden;
-        border-radius: var(--Corner-radius-corner-radius-100);
+        border-radius: var(--spectrum-corner-radius-100);
     }
 
     .bc-color-area-wrapper sp-color-area {
@@ -238,8 +237,6 @@ export const style = css`
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 1;
-        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
-        top: clamp(calc(var(--spacing-80) / 2), var(--dot-y, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     .bc-color-slider-container {
@@ -263,7 +260,6 @@ export const style = css`
         transform: translate(-50%, -50%);
         pointer-events: none;
         z-index: 10;
-        left: clamp(calc(var(--spacing-80) / 2), var(--dot-x, 50%), calc(100% - var(--spacing-80) / 2));
     }
 
     /* ---- Channel sliders ---- */

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -216,10 +216,26 @@ export const style = css`
         gap: var(--spacing-200);
     }
 
+    .bc-color-area-container {
+        position: relative;
+    }
+
     .bc-color-area-wrapper sp-color-area {
         width: 100%;
         height: 156px;
         cursor: pointer;
+    }
+
+    .bc-original-dot {
+        position: absolute;
+        width: 4px;
+        height: 4px;
+        border-radius: 50%;
+        background-color: #fff;
+        border: 1px solid rgba(31, 31, 31, 0.3);
+        transform: translate(-50%, -50%);
+        pointer-events: none;
+        z-index: 1;
     }
 
     .bc-color-area-wrapper sp-color-slider {

--- a/express/code/scripts/color-shared/components/base-color/styles.css.js
+++ b/express/code/scripts/color-shared/components/base-color/styles.css.js
@@ -99,6 +99,13 @@ export const style = css`
 
     /* ---- Color value input ---- */
 
+    .bc-color-value-group {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        gap: 0;
+    }
+
     .bc-color-value-wrapper {
         display: flex;
         align-items: center;
@@ -145,6 +152,14 @@ export const style = css`
 
     .bc-color-value-wrapper.has-error:focus-visible {
         border-color: var(--spectrum-negative-border-color-key-focus);
+    }
+
+    .bc-hex-error-text {
+        display: block;
+        padding-block: 7px;
+        font-size: var(--ax-heading-xxs-size);
+        line-height: var(--ax-heading-xxs-lh);
+        color: var(--spectrum-negative-text-color, var(--spectrum-semantic-negative-color-default));
     }
 
     .bc-color-swatch {

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -10,7 +10,7 @@ import { loadSwatch, loadMenu, loadTextfield } from '../../spectrum/load-spectru
 import { trapFocus, disableBackgroundScroll, restoreBackgroundScroll } from '../../spectrum/utils/a11y.js';
 import '../base-color/index.js';
 
-const COLOR_MODES = ['RGB', 'HEX'];
+const COLOR_MODES = ['HEX', 'RGB'];
 
 class ColorEdit extends LitElement {
   static get styles() {
@@ -37,7 +37,7 @@ class ColorEdit extends LitElement {
     super();
     this.palette = [];
     this.selectedIndex = 0;
-    this.colorMode = 'RGB';
+    this.colorMode = 'HEX';
     this.showPalette = true;
     this.mobile = false;
     this.open = false;

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -390,6 +390,21 @@ class ColorEdit extends LitElement {
     }
   }
 
+  _onHexPaste(e) {
+    const pasted = (e.clipboardData && e.clipboardData.getData('text')) || '';
+    const stripped = pasted.replace(/#/g, '');
+    if (stripped === pasted) return;
+    e.preventDefault();
+    const input = e.composedPath().find((el) => el instanceof HTMLInputElement) || document.activeElement;
+    if (!input || !(input instanceof HTMLInputElement)) return;
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? input.value.length;
+    const value = input.value.slice(0, start) + stripped + input.value.slice(end);
+    input.value = value;
+    input.setSelectionRange(start + stripped.length, start + stripped.length);
+    input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+  }
+
   _onHexCommit(e) {
     const hex = e.target.value.replace(/#/g, '').trim();
     if (!hex.match(/^[0-9A-Fa-f]{6}$/)) {
@@ -410,6 +425,7 @@ class ColorEdit extends LitElement {
           label="HEX color value"
           label-visibility="none"
           @input=${this._onHexInput}
+          @paste=${this._onHexPaste}
           @change=${this._onHexCommit}
         ></sp-textfield>
       </div>

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -29,6 +29,7 @@ class ColorEdit extends LitElement {
       _saturation: { type: Number, state: true },
       _brightness: { type: Number, state: true },
       _modeMenuOpen: { type: Boolean, state: true },
+      _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
     };
   }
@@ -45,6 +46,7 @@ class ColorEdit extends LitElement {
     this._saturation = 100;
     this._brightness = 100;
     this._modeMenuOpen = false;
+    this._hexError = false;
     this._liveRegionText = '';
   }
 
@@ -360,21 +362,47 @@ class ColorEdit extends LitElement {
     this._hue = hue;
     this._saturation = saturation;
     this._brightness = brightness;
+    this._hexError = false;
+    if (this.palette?.length) {
+      const newPalette = [...this.palette];
+      newPalette[this.selectedIndex] = this._hex;
+      this.palette = newPalette;
+    }
     this._emitColorChange();
   }
 
   _onHexInput(e) {
-    const value = e.target.value.trim();
-    if (value.match(/^#?[0-9A-Fa-f]{6}$/)) {
-      const hex = value.startsWith('#') ? value : `#${value}`;
-      const rgb = hexToRGB(hex);
+    const field = e.target;
+    const value = field.value;
+
+    const hex = value.replace(/#/g, '');
+    const normalized = `#${hex}`;
+    if (value !== normalized) {
+      field.value = normalized;
+    }
+
+    if (hex.match(/^[0-9A-Fa-f]{6}$/)) {
+      this._hexError = false;
+      const rgb = hexToRGB(`#${hex}`);
       if (!rgb) return;
       const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
       this._hue = hsb.hue;
       this._saturation = hsb.saturation;
       this._brightness = hsb.brightness;
+      if (this.palette?.length) {
+        const newPalette = [...this.palette];
+        newPalette[this.selectedIndex] = this._hex;
+        this.palette = newPalette;
+      }
       this._emitColorChange();
       this._announceColorChange();
+    }
+  }
+
+  _onHexCommit(e) {
+    const hex = e.target.value.replace(/#/g, '').trim();
+    if (!hex.match(/^[0-9A-Fa-f]{6}$/)) {
+      this._hexError = true;
     }
   }
 
@@ -382,15 +410,19 @@ class ColorEdit extends LitElement {
     return html`
       <div class="ce-hex-section">
         <span class="ce-hex-label">HEX</span>
-        <div class="ce-hex-field">
-          <input
-            type="text"
-            class="ce-hex-input"
+        <sp-theme system="spectrum-two" color="light" scale="medium">
+          <sp-textfield
+            class="ce-hex-field"
+            size="m"
+            maxlength="7"
             .value=${this._hex}
-            @change=${this._onHexInput}
-            aria-label="HEX color value"
-          />
-        </div>
+            ?invalid=${this._hexError}
+            label="HEX color value"
+            label-visibility="none"
+            @input=${this._onHexInput}
+            @change=${this._onHexCommit}
+          ></sp-textfield>
+        </sp-theme>
       </div>
     `;
   }

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -139,6 +139,7 @@ class ColorEdit extends LitElement {
     if (index === this.selectedIndex) return;
     this.selectedIndex = index;
     this._syncFromPalette();
+    this.shadowRoot.querySelector('base-color')?.resetOriginalColor();
     this.dispatchEvent(new CustomEvent('swatch-select', {
       bubbles: true,
       composed: true,

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -415,7 +415,9 @@ class ColorEdit extends LitElement {
           label-visibility="none"
           @input=${this._onHexInput}
           @change=${this._onHexCommit}
-        ></sp-textfield>
+        >
+          <span slot="negative-help-text" class="ce-hex-error-text">Please enter a valid 6-character HEX code</span>
+        </sp-textfield>
       </div>
     `;
   }

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -302,25 +302,22 @@ class ColorEdit extends LitElement {
             <span class="ce-mode-chevron"><img src="/express/code/icons/S2_Icon_ChevronDown_20_N.svg" alt="" width="14" height="14" aria-hidden="true" /></span>
           </button>
           ${this._modeMenuOpen ? html`
-            <sp-theme system="spectrum-two" color="light" scale="medium">
-              <sp-menu
-                id="ce-mode-menu"
-                role="listbox"
-                selects="single"
-                size="s"
-                label="Color mode"
-                @change=${this._onModeMenuChange}
-                @keydown=${this._onModeMenuKeyDown}
-              >
-                ${COLOR_MODES.map((m) => html`
-                  <sp-menu-item
-
-                    value=${m}
-                    ?selected=${m === this.colorMode}
-                  >${m}</sp-menu-item>
-                `)}
-              </sp-menu>
-            </sp-theme>
+            <sp-menu
+              id="ce-mode-menu"
+              role="listbox"
+              selects="single"
+              size="s"
+              label="Color mode"
+              @change=${this._onModeMenuChange}
+              @keydown=${this._onModeMenuKeyDown}
+            >
+              ${COLOR_MODES.map((m) => html`
+                <sp-menu-item
+                  value=${m}
+                  ?selected=${m === this.colorMode}
+                >${m}</sp-menu-item>
+              `)}
+            </sp-menu>
           ` : nothing}
         </div>
       </div>
@@ -332,27 +329,25 @@ class ColorEdit extends LitElement {
     return html`
       <div class="ce-palette-section">
         <span class="ce-palette-label">Palette colors</span>
-        <sp-theme system="spectrum-two" color="light" scale="medium">
-          <sp-swatch-group
-            size="s"
-            cornerRadius="partial"
-          >
-            ${this.palette.map((hex, i) => {
-    const validHex = hex.startsWith('#') ? hex : `#${hex}`;
-    return html`
-                <sp-swatch
-                  border="light"
-                  cornerRounding="partial"
-                  color=${validHex}
-                  value=${String(i)}
-                  ?selected=${i === this.selectedIndex}
-                  @click=${() => this._onSwatchClick(i)}
-                  aria-label="Color ${validHex}"
-                ></sp-swatch>
-              `;
-  })}
-          </sp-swatch-group>
-        </sp-theme>
+        <sp-swatch-group
+          size="s"
+          cornerRadius="partial"
+        >
+          ${this.palette.map((hex, i) => {
+            const validHex = hex.startsWith('#') ? hex : `#${hex}`;
+            return html`
+              <sp-swatch
+                border="light"
+                cornerRounding="partial"
+                color=${validHex}
+                value=${String(i)}
+                ?selected=${i === this.selectedIndex}
+                @click=${() => this._onSwatchClick(i)}
+                aria-label="Color ${validHex}"
+              ></sp-swatch>
+            `;
+          })}
+        </sp-swatch-group>
       </div>
     `;
   }
@@ -410,19 +405,17 @@ class ColorEdit extends LitElement {
     return html`
       <div class="ce-hex-section">
         <span class="ce-hex-label">HEX</span>
-        <sp-theme system="spectrum-two" color="light" scale="medium">
-          <sp-textfield
-            class="ce-hex-field"
-            size="m"
-            maxlength="7"
-            .value=${this._hex}
-            ?invalid=${this._hexError}
-            label="HEX color value"
-            label-visibility="none"
-            @input=${this._onHexInput}
-            @change=${this._onHexCommit}
-          ></sp-textfield>
-        </sp-theme>
+        <sp-textfield
+          class="ce-hex-field"
+          size="m"
+          maxlength="7"
+          .value=${this._hex}
+          ?invalid=${this._hexError}
+          label="HEX color value"
+          label-visibility="none"
+          @input=${this._onHexInput}
+          @change=${this._onHexCommit}
+        ></sp-textfield>
       </div>
     `;
   }
@@ -453,20 +446,26 @@ class ColorEdit extends LitElement {
   render() {
     if (this.mobile) {
       return html`
-        <div class="ce-overlay ${this.open ? 'open' : ''}" @click=${this._onOverlayClick}>
-          <div
-            class="ce-sheet ${this.open ? 'open' : ''}"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Edit color"
-            @keydown=${this._onSheetKeyDown}
-          >
-            ${this._renderPanel()}
+        <sp-theme system="spectrum-two" color="light" scale="medium">
+          <div class="ce-overlay ${this.open ? 'open' : ''}" @click=${this._onOverlayClick}>
+            <div
+              class="ce-sheet ${this.open ? 'open' : ''}"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Edit color"
+              @keydown=${this._onSheetKeyDown}
+            >
+              ${this._renderPanel()}
+            </div>
           </div>
-        </div>
+        </sp-theme>
       `;
     }
-    return this._renderPanel();
+    return html`
+      <sp-theme system="spectrum-two" color="light" scale="medium">
+        ${this._renderPanel()}
+      </sp-theme>
+    `;
   }
 }
 

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -29,7 +29,6 @@ class ColorEdit extends LitElement {
       _saturation: { type: Number, state: true },
       _brightness: { type: Number, state: true },
       _modeMenuOpen: { type: Boolean, state: true },
-      _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
     };
   }
@@ -46,7 +45,6 @@ class ColorEdit extends LitElement {
     this._saturation = 100;
     this._brightness = 100;
     this._modeMenuOpen = false;
-    this._hexError = false;
     this._liveRegionText = '';
   }
 
@@ -357,7 +355,6 @@ class ColorEdit extends LitElement {
     this._hue = hue;
     this._saturation = saturation;
     this._brightness = brightness;
-    this._hexError = false;
     if (this.palette?.length) {
       const newPalette = [...this.palette];
       newPalette[this.selectedIndex] = this._hex;
@@ -377,7 +374,6 @@ class ColorEdit extends LitElement {
     }
 
     if (hex.match(/^[0-9A-Fa-f]{6}$/)) {
-      this._hexError = false;
       const rgb = hexToRGB(`#${hex}`);
       if (!rgb) return;
       const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
@@ -397,7 +393,8 @@ class ColorEdit extends LitElement {
   _onHexCommit(e) {
     const hex = e.target.value.replace(/#/g, '').trim();
     if (!hex.match(/^[0-9A-Fa-f]{6}$/)) {
-      this._hexError = true;
+      e.target.value = this._hex;
+      this.requestUpdate();
     }
   }
 
@@ -410,14 +407,11 @@ class ColorEdit extends LitElement {
           size="m"
           maxlength="7"
           .value=${this._hex}
-          ?invalid=${this._hexError}
           label="HEX color value"
           label-visibility="none"
           @input=${this._onHexInput}
           @change=${this._onHexCommit}
-        >
-          <span slot="negative-help-text" class="ce-hex-error-text">Please enter a valid 6-character HEX code</span>
-        </sp-textfield>
+        ></sp-textfield>
       </div>
     `;
   }

--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -220,31 +220,18 @@ export const style = css`
         color: var(--color-dark-gray);
     }
 
-    .ce-hex-field {
-        display: flex;
-        align-items: center;
+    .ce-hex-section sp-theme {
+        display: block;
         width: 100%;
-        height: var(--spacing-500);
-        border: var(--spacing-50) solid var(--color-gray-300-variant);
-        border-radius: var(--Corner-radius-corner-radius-100);
-        padding: 0 var(--spacing-200);
-        background: var(--color-white);
     }
 
-    .ce-hex-field:focus-within {
-        border-color: var(--color-blue-800);
-    }
-
-    .ce-hex-input {
-        flex: 1;
-        border: none;
-        outline: none;
-        background: transparent;
-        padding: 0;
-        font-family: var(--body-font-family);
-        font-size: var(--body-font-size-m);
-        line-height: var(--ax-detail-l-lh);
-        color: var(--color-gray-800-variant);
+    .ce-hex-field {
+        width: 100%;
+        --mod-textfield-corner-radius: 9px;
+        --mod-textfield-border-width: var(--border-width-2);
+        --mod-textfield-border-color: var(--color-gray-300-variant);
+        --mod-textfield-background-color: var(--color-white);
+        --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height, 32px)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid, 18px))) / 2);
     }
 
     .ce-sr-only {

--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -164,14 +164,11 @@ export const style = css`
         object-fit: contain;
     }
 
-    .ce-mode-wrap sp-theme {
+    .ce-mode-wrap sp-menu {
         position: absolute;
         top: calc(100% - var(--spacing-50));
         right: var(--spacing-50);
         z-index: 10;
-    }
-
-    .ce-mode-wrap sp-menu {
         width: 114px;
         background-color: var(--color-white);
         box-shadow: var(--Alias-drop-shadow-ambient), var(--Alias-drop-shadow-transition), var(--Alias-drop-shadow-elevated-key);
@@ -187,8 +184,10 @@ export const style = css`
         gap: var(--spacing-75);
     }
 
-    .ce-palette-section sp-theme {
-        display: block;
+    .ce-palette-section sp-swatch-group {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
         height: var(--spacing-400);
         min-height: 0;
     }
@@ -220,11 +219,6 @@ export const style = css`
         color: var(--color-dark-gray);
     }
 
-    .ce-hex-section sp-theme {
-        display: block;
-        width: 100%;
-    }
-
     .ce-hex-field {
         width: 100%;
         --mod-textfield-corner-radius: 9px;
@@ -232,6 +226,11 @@ export const style = css`
         --mod-textfield-border-color: var(--color-gray-300-variant);
         --mod-textfield-background-color: var(--color-white);
         --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height, 32px)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid, 18px))) / 2);
+    }
+
+    .ce-hex-field:hover {
+        --mod-textfield-border-color: var(--color-gray-400-variant);
+        --mod-textfield-border-color-hover: var(--color-gray-400-variant);
     }
 
     .ce-sr-only {

--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -225,18 +225,7 @@ export const style = css`
         --mod-textfield-border-width: var(--border-width-2);
         --mod-textfield-border-color: var(--color-gray-300-variant);
         --mod-textfield-background-color: var(--color-white);
-        --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height, 32px)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid, 18px))) / 2);
         --mod-textfield-border-color-hover: var(--color-gray-400-variant);
-        --mod-textfield-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
-        --mod-textfield-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
-    }
-
-    .ce-hex-error-text {
-        display: block;
-        padding-block: 7px;
-        font-size: var(--ax-heading-xxs-size);
-        line-height: var(--ax-heading-xxs-lh);
-        color: var(--spectrum-negative-text-color, var(--spectrum-semantic-negative-color-default));
     }
 
     .ce-sr-only {

--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -226,11 +226,17 @@ export const style = css`
         --mod-textfield-border-color: var(--color-gray-300-variant);
         --mod-textfield-background-color: var(--color-white);
         --mod-textfield-icon-spacing-block-invalid: calc((var(--mod-textfield-height, var(--spectrum-textfield-height, 32px)) - var(--mod-textfield-icon-size-invalid, var(--spectrum-textfield-icon-size-invalid, 18px))) / 2);
+        --mod-textfield-border-color-hover: var(--color-gray-400-variant);
+        --mod-textfield-border-color-invalid-hover: var(--spectrum-negative-border-color-hover);
+        --mod-textfield-border-color-invalid-focus-hover: var(--spectrum-negative-border-color-focus-hover);
     }
 
-    .ce-hex-field:hover {
-        --mod-textfield-border-color: var(--color-gray-400-variant);
-        --mod-textfield-border-color-hover: var(--color-gray-400-variant);
+    .ce-hex-error-text {
+        display: block;
+        padding-block: 7px;
+        font-size: var(--ax-heading-xxs-size);
+        line-height: var(--ax-heading-xxs-lh);
+        color: var(--spectrum-negative-text-color, var(--spectrum-semantic-negative-color-default));
     }
 
     .ce-sr-only {


### PR DESCRIPTION
## Summary

Incorporates the design feedback and new recommendations:
```
All instances

    Ensure that the base color field and all other color mode fields have the proper active state, aligned with the S2 text field states. See documentation [here](https://www.figma.com/design/mcJuQTxJdWsL0dMmqaecpn/Final-Color-Expansion-CCEX-221263?node-id=6107-305773&t=98aajvFDjiQnkfyh-4)
    All fields inside color modes should have error states and character input limitations depending on the context (i.e. Base color is 6 characters, RGB fields at 3 characters, etc)
    Ensure color handles used throughout follow the specs of Express Color handle size S. See documentation here
    Noticing an issue on mobile where the color handle doesn't go back to its original size after I've moved it across the color area to change colors.

Base Color QA

    Missing an error state if a user enters something other than a proper HEX code. See error state [here](https://www.figma.com/design/mcJuQTxJdWsL0dMmqaecpn/Final-Color-Expansion-CCEX-221263?node-id=13140-741254&t=98aajvFDjiQnkfyh-4)
    The dot inside the base color field has a stroke of #1F1F1F at 30% opacity
    On desktop, the component width becomes smaller when I change to other color modes. Component should maintain the same width throughout.
    The lock icon inside the base color field should not be clickable and should not make the field below disabled when active. See this [base color logic flow](https://www.figma.com/design/mcJuQTxJdWsL0dMmqaecpn/Final-Color-Expansion-CCEX-221263?node-id=7668-305934&t=98aajvFDjiQnkfyh-4) for more details about functionality.

Edit color QA

    HEX field is missing error state, needs alignment with S2 field states. See documentation [here](https://www.figma.com/design/mcJuQTxJdWsL0dMmqaecpn/Final-Color-Expansion-CCEX-221263?node-id=6107-305773&t=98aajvFDjiQnkfyh-4)

Edit color with palette

    If I change the color inside the color area, the corresponding selected palette color should change too.
```
Files to review:
`express/code/scripts/color-shared/components/base-color/index.js`
`express/code/scripts/color-shared/components/base-color/styles.css.js`
`express/code/scripts/color-shared/components/color-edit/index.js`
`express/code/scripts/color-shared/components/color-edit/styles.css.js`

Figma for error state: https://www.figma.com/design/mcJuQTxJdWsL0dMmqaecpn/Final-Color-Expansion-CCEX-221263?node-id=13140-741254&m=dev

---

## Jira Ticket

Resolves: [MWPW-189830](https://jira.corp.adobe.com/browse/MWPW-189830)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://MWPW-189830-color-edit-design-qa--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-color-edit-test?martech=off |

---

## Verification Steps
-  The test url showcases two color components.
- **Base Color**: This will be used in `color-wheel` page. It supports color-area, different color-modes.
- **Edit Color**: This is a popup which will appear with or without palletes. It supports bottomsheet view on mobile.
- Edit Color can be triggered by clicking on "Edit Color" and "Edit Color with Pallete" buttons.
---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
