### PR TITLE
Removed Adobe Clean Serif 

### DIFF
--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.css
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.css
@@ -66,7 +66,7 @@ main .section:has(.blog-posts-wrapper) div.blog-posts-decoration {
 
 main .section:has(.blog-posts-v2) div.blog-posts-decoration p {
   margin: 0;
-  font-family: var(--body-serif-font-family);
+  font-family: var(--body-font-family);
 }
 
 main .section:has(.blog-posts-v2) div.blog-posts-decoration p a {
@@ -295,7 +295,7 @@ main .blog-posts-v2 p.blog-card-date {
 }
 
 main .blog-posts-v2 .blog-hero-card p.blog-card-teaser {
-  font-family: var(--body-serif-font-family);
+  font-family: var(--body-font-family);
   font-size: var(--body-font-size-l);
   text-align: left;
   grid-area: teaser;

--- a/express/code/blocks/blog-posts/blog-posts.css
+++ b/express/code/blocks/blog-posts/blog-posts.css
@@ -33,7 +33,7 @@ main .section:has(.blog-posts-wrapper) div.blog-posts-decoration {
 
 main .section:has(.blog-posts) div.blog-posts-decoration p {
     margin: 0;
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
 }
 
 main .section:has(.blog-posts) div.blog-posts-decoration p a {
@@ -135,7 +135,7 @@ main .blog-posts .blog-card p.blog-card-teaser {
     font-size: var(--body-font-size-m);
     line-height: var(--body-line-height);
     font-weight: normal;
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
@@ -145,7 +145,7 @@ main .blog-posts .blog-card p.blog-card-teaser {
 
 
 main .blog-posts .blog-hero-card p.blog-card-teaser {
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
     font-size: var(--body-font-size-l);
     text-align: left;
     grid-area: teaser;
@@ -156,7 +156,7 @@ main .blog-posts .blog-hero-card p.blog-card-teaser {
 main .blog-posts p.blog-card-date {
     font-size: var(--body-font-size-s);
     line-height: var(--body-line-height);
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
     font-weight: var(--heading-font-weight);
     grid-area: date;
 }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -91,7 +91,6 @@
   --body-background-color: var(--color-white);
   --body-alt-background-color: var(--color-gray-200);
   --body-font-family: 'adobe-clean', 'Adobe Clean', 'adobe-clean-fallback', 'Trebuchet MS', sans-serif;
-  --body-serif-font-family: 'adobe-clean-serif', 'Adobe Clean Serif', serif;
   --body-font-weight: normal;
   --body-color: var(--color-gray-800);
   --body-line-height: 1.5;

--- a/express/code/templates/blog/blog.css
+++ b/express/code/templates/blog/blog.css
@@ -43,7 +43,7 @@
 }
 
   .blog main .section > div > p {
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
   }
 
   .blog main .section > div > p .button, .blog .section > div > p .con-button {
@@ -102,7 +102,7 @@
   }
 
   .blog main #hero .blog-header {
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
   }
 
   .blog main #hero .blog-header h1 {
@@ -170,7 +170,7 @@
   }
 
   .blog main .hero-animation p {
-    font-family: var(--body-serif-font-family);
+    font-family: var(--body-font-family);
   }
 
   .blog main .banner {


### PR DESCRIPTION


## Summary

Removed Adobe Clean Serif from blog.css, blog-posts-v2.css, blog-posts.css to align with [milo-core TypeKit updates](https://cclight.slack.com/archives/C03HAU5SU2E/p1772465368449919).
Removed mentions of serif and token --body-serif-font-family from styles.css.

---

## Jira Ticket

[https://jira.corp.adobe.com/browse/MWPW-190370](https://jira.corp.adobe.com/browse/MWPW-190370)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/learn/blog |
| **After**   | https://font-serif--da-express-milo--adobecom.aem.page/express/learn/blog?martech=off |

---

## Verification Steps

- visit the blog links
- ensure that Adobe Serif isn't rendering or referenced in styles. 

---

## Potential Regressions

- https://font-serif--da-express-milo--adobecom.aem.live/express/learn/blog/design-trends-2026?martech=off
- https://font-serif--da-express-milo--adobecom.aem.live/drafts/echen/discover-redesign-copy?martech=off

---

## Additional Notes


