### PR TITLE
How To Summary Block Variant

### DIFF
--- a/express/code/blocks/how-to-cards/how-to-cards-summary.css
+++ b/express/code/blocks/how-to-cards/how-to-cards-summary.css
@@ -1,10 +1,10 @@
 .how-to-cards.summary .text h2 {
-  color: var(--Content-neutral-default, #222);
+  color: var(--color-gray-900);
   text-align: center;
   font-family: var(--body-font-family);
-  font-size: var(--Global-Typography-Size-Headings-Heading-XL, 36px);
+  font-size: var(--heading-font-size-l);
   font-style: normal;
-  font-weight: 900;
+  font-weight: var(--heading-font-weight-extra);
   line-height: 104%;
 }
 
@@ -13,10 +13,10 @@
 }
 
 .how-to-cards.summary .text p {
-  color: var(--Content-neutral-default, #222);
+  color: var(--color-gray-900);
   text-align: center;
-  font-family:var(--body-font-family);
-  font-size: var(--Global-Typography-Size-Body-Body-S, 16px);
+  font-family: var(--body-font-family);
+  font-size: var(--body-font-size-m);
   font-style: normal;
   font-weight: 400;
   line-height: 130%;
@@ -38,18 +38,18 @@
 }
 
 .how-to-cards.summary .card h3 {
-  color: var(--Content-neutral-default, #222);
+  color: var(--color-gray-900);
   font-family: var(--body-font-family);
-  font-size: var(--Global-Typography-Size-Headings-Heading-S, 20px);
+  font-size: var(--heading-font-size-xs);
   font-style: normal;
-  font-weight: 900;
+  font-weight: var(--heading-font-weight-extra);
   line-height: 106%;
 }
 
 .how-to-cards.summary .card p {
-  color: #242424;
-  font-family:var(--body-font-family);
-  font-size: var(--Global-Typography-Size-Body-Body-S, 16px);
+  color: var(--color-gray-800);
+  font-family: var(--body-font-family);
+  font-size: var(--body-font-size-m);
   font-style: normal;
   font-weight: 400;
   line-height: 130%;

--- a/express/code/blocks/how-to-cards/how-to-cards-summary.css
+++ b/express/code/blocks/how-to-cards/how-to-cards-summary.css
@@ -1,5 +1,11 @@
 .how-to-cards.summary .text h2 {
+  color: var(--Content-neutral-default, #222);
   text-align: center;
+  font-family: var(--body-font-family);
+  font-size: var(--Global-Typography-Size-Headings-Heading-XL, 36px);
+  font-style: normal;
+  font-weight: 900;
+  line-height: 104%;
 }
 
 .how-to-cards.summary .text {
@@ -7,7 +13,13 @@
 }
 
 .how-to-cards.summary .text p {
+  color: var(--Content-neutral-default, #222);
   text-align: center;
+  font-family:var(--body-font-family);
+  font-size: var(--Global-Typography-Size-Body-Body-S, 16px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 130%;
   padding-bottom: 0;
 }
 
@@ -25,9 +37,27 @@
   margin-right: 0;
 }
 
+.how-to-cards.summary .card h3 {
+  color: var(--Content-neutral-default, #222);
+  font-family: var(--body-font-family);
+  font-size: var(--Global-Typography-Size-Headings-Heading-S, 20px);
+  font-style: normal;
+  font-weight: 900;
+  line-height: 106%;
+}
+
+.how-to-cards.summary .card p {
+  color: #242424;
+  font-family:var(--body-font-family);
+  font-size: var(--Global-Typography-Size-Body-Body-S, 16px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 130%;
+}
+
 .how-to-cards.summary .step-icon {
-  width: 34px;
-  height: 34px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   background-color: var(--color-white);
   display: flex;
@@ -37,8 +67,22 @@
 
 .how-to-cards.summary .step-icon img,
 .how-to-cards.summary .step-icon svg {
-  width: 20px;
-  height: 20px;
+  width: 100%;
+  height: 100%;
+}
+
+.how-to-cards.summary .step-icon picture {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.how-to-cards.summary .step-icon picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 @media (min-width: 768px) {

--- a/express/code/blocks/how-to-cards/how-to-cards-summary.css
+++ b/express/code/blocks/how-to-cards/how-to-cards-summary.css
@@ -1,0 +1,49 @@
+.how-to-cards.summary .text h2 {
+  text-align: center;
+}
+
+.how-to-cards.summary .text {
+  padding: 0 var(--side-padding) var(--spacing-500);
+}
+
+.how-to-cards.summary .text p {
+  text-align: center;
+  padding-bottom: 0;
+}
+
+.how-to-cards.summary .cards-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-300);
+  margin: 0;
+  padding: 0 var(--side-padding);
+}
+
+.how-to-cards.summary .card,
+.how-to-cards.summary .card:last-child {
+  width: 100%;
+  margin-right: 0;
+}
+
+.how-to-cards.summary .step-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background-color: var(--color-white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.how-to-cards.summary .step-icon img,
+.how-to-cards.summary .step-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+@media (min-width: 768px) {
+  .how-to-cards.summary .cards-container {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    width: auto;
+  }
+}

--- a/express/code/blocks/how-to-cards/how-to-cards-summary.css
+++ b/express/code/blocks/how-to-cards/how-to-cards-summary.css
@@ -59,7 +59,6 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background-color: var(--color-white);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/express/code/blocks/how-to-cards/how-to-cards-summary.css
+++ b/express/code/blocks/how-to-cards/how-to-cards-summary.css
@@ -26,7 +26,7 @@
 .how-to-cards.summary .cards-container {
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--spacing-300);
+  gap: var(--ax-grid-gutter);
   margin: 0;
   padding: 0 var(--side-padding);
 }

--- a/express/code/blocks/how-to-cards/how-to-cards.css
+++ b/express/code/blocks/how-to-cards/how-to-cards.css
@@ -42,9 +42,7 @@
   margin: 0;
   padding: var(--spacing-100) 0 var(--spacing-500) 0;
   font-size: var(--body-font-size-l);
-
 }
-
 
 .how-to-cards .card {
   flex: 0 0 auto;

--- a/express/code/blocks/how-to-cards/how-to-cards.css
+++ b/express/code/blocks/how-to-cards/how-to-cards.css
@@ -144,6 +144,7 @@
   .how-to-cards.cards-count-6 .cards-container {
     width: 100vw;
   }
+
 }
 
 @media (min-width: 1280px) {

--- a/express/code/blocks/how-to-cards/how-to-cards.js
+++ b/express/code/blocks/how-to-cards/how-to-cards.js
@@ -130,26 +130,38 @@ export function addSchema(bl, heading) {
 }
 
 function getSummaryStepIcon(content) {
-  const authoredIcon = content.querySelector('.icon');
-  if (!authoredIcon) return null;
-
   const iconContainer = createTag('div', { class: 'step-icon' });
-  const match = iconRegex.exec(authoredIcon.className);
-  if (!match?.[1]) {
+  const authoredIcon = content.querySelector('.icon');
+  if (authoredIcon) {
+    const match = iconRegex.exec(authoredIcon.className);
+    if (!match?.[1]) {
+      authoredIcon.remove();
+      return null;
+    }
+
+    const icon = getIconElementDeprecated(match[1]);
+    if (!(icon instanceof HTMLElement)) {
+      authoredIcon.remove();
+      return null;
+    }
+    icon.setAttribute('aria-hidden', 'true');
+    if (icon.tagName === 'IMG') icon.setAttribute('alt', '');
+    iconContainer.append(icon);
     authoredIcon.remove();
-    return null;
+    return iconContainer;
   }
 
-  const icon = getIconElementDeprecated(match[1]);
-  if (!(icon instanceof HTMLElement)) {
-    authoredIcon.remove();
-    return null;
+  const firstElement = content.firstElementChild;
+  if (firstElement?.tagName === 'P' && firstElement.childElementCount === 1) {
+    const picture = firstElement.firstElementChild;
+    if (picture?.tagName === 'PICTURE') {
+      iconContainer.append(picture);
+      firstElement.remove();
+      return iconContainer;
+    }
   }
-  icon.setAttribute('aria-hidden', 'true');
-  if (icon.tagName === 'IMG') icon.setAttribute('alt', '');
-  iconContainer.append(icon);
-  authoredIcon.remove();
-  return iconContainer;
+
+  return null;
 }
 
 export default async function init(bl) {

--- a/express/code/blocks/how-to-cards/how-to-cards.js
+++ b/express/code/blocks/how-to-cards/how-to-cards.js
@@ -27,8 +27,8 @@ function createChevronButton(direction, ariaLabel) {
 function createControl(items, container) {
   const control = createTag('div', { class: 'gallery-control loading' });
   const status = createTag('div', { class: 'status' });
-  const prevButton = createChevronButton('prev', 'Next');
-  const nextButton = createChevronButton('next', 'Previous');
+  const prevButton = createChevronButton('prev', 'Previous');
+  const nextButton = createChevronButton('next', 'Next');
 
   const intersecting = Array.from(items).fill(false);
 
@@ -173,14 +173,18 @@ export default async function init(bl) {
   }
   const cardsContainer = createTag('ol', { class: 'cards-container' });
   let steps = [...bl.querySelectorAll(':scope > div')];
-  if (steps[0].querySelector('h2')) {
+  if (steps.length > 0 && steps[0].querySelector('h2')) {
     const text = steps[0];
     steps = steps.slice(1);
     text.classList.add('text');
   }
   const cards = steps.map((div, index) => {
-    const li = createTag('li', { class: 'card' });
     const content = div.querySelector('div');
+    if (!content) {
+      div.remove();
+      return null;
+    }
+    const li = createTag('li', { class: 'card' });
     if (isSummaryVariant) {
       const stepIcon = getSummaryStepIcon(content);
       if (stepIcon) li.append(stepIcon);
@@ -198,7 +202,7 @@ export default async function init(bl) {
     div.remove();
     cardsContainer.append(li);
     return li;
-  });
+  }).filter(Boolean);
   bl.append(cardsContainer);
 
   if (!isSummaryVariant) {

--- a/express/code/blocks/how-to-cards/how-to-cards.js
+++ b/express/code/blocks/how-to-cards/how-to-cards.js
@@ -3,6 +3,9 @@ import { getLibs, getIconElementDeprecated } from '../../scripts/utils.js';
 import { throttle, debounce } from '../../scripts/utils/hofs.js';
 
 let createTag;
+let loadStyle;
+let getConfig;
+const iconRegex = /icon-\s*([^\s]+)/;
 
 const scrollPadding = 16;
 
@@ -126,9 +129,36 @@ export function addSchema(bl, heading) {
   document.head.append(createTag('script', { type: 'application/ld+json' }, JSON.stringify(schema)));
 }
 
+function getSummaryStepIcon(content) {
+  const authoredIcon = content.querySelector('.icon');
+  if (!authoredIcon) return null;
+
+  const iconContainer = createTag('div', { class: 'step-icon' });
+  const match = iconRegex.exec(authoredIcon.className);
+  if (!match?.[1]) {
+    authoredIcon.remove();
+    return null;
+  }
+
+  const icon = getIconElementDeprecated(match[1]);
+  if (!(icon instanceof HTMLElement)) {
+    authoredIcon.remove();
+    return null;
+  }
+  icon.setAttribute('aria-hidden', 'true');
+  if (icon.tagName === 'IMG') icon.setAttribute('alt', '');
+  iconContainer.append(icon);
+  authoredIcon.remove();
+  return iconContainer;
+}
+
 export default async function init(bl) {
-  ({ createTag } = await import(`${getLibs()}/utils/utils.js`));
+  ({ createTag, loadStyle, getConfig } = await import(`${getLibs()}/utils/utils.js`));
   const heading = bl.querySelector('h3, h4, h5, h6');
+  const isSummaryVariant = bl.classList.contains('summary');
+  if (isSummaryVariant) {
+    loadStyle(`${getConfig().codeRoot}/blocks/how-to-cards/how-to-cards-summary.css`);
+  }
   const cardsContainer = createTag('ol', { class: 'cards-container' });
   let steps = [...bl.querySelectorAll(':scope > div')];
   if (steps[0].querySelector('h2')) {
@@ -138,13 +168,18 @@ export default async function init(bl) {
   }
   const cards = steps.map((div, index) => {
     const li = createTag('li', { class: 'card' });
-    const tipNumber = createTag('div', { class: 'number' });
-    tipNumber.append(
-      createTag('span', { class: 'number-txt' }, index + 1),
-      createTag('div', { class: 'number-bg' }),
-    );
-    li.append(tipNumber);
     const content = div.querySelector('div');
+    if (isSummaryVariant) {
+      const stepIcon = getSummaryStepIcon(content);
+      if (stepIcon) li.append(stepIcon);
+    } else {
+      const tipNumber = createTag('div', { class: 'number' });
+      tipNumber.append(
+        createTag('span', { class: 'number-txt' }, index + 1),
+        createTag('div', { class: 'number-bg' }),
+      );
+      li.append(tipNumber);
+    }
     while (content.firstChild) {
       li.append(content.firstChild);
     }
@@ -154,7 +189,9 @@ export default async function init(bl) {
   });
   bl.append(cardsContainer);
 
-  await buildGallery(cards, cardsContainer, bl);
+  if (!isSummaryVariant) {
+    await buildGallery(cards, cardsContainer, bl);
+  }
   // add count-based class to top-level if not already present
   const existingCountClass = [...bl.classList].find((c) => c.startsWith('cards-count-'));
   if (!existingCountClass) {

--- a/express/code/blocks/how-to-cards/how-to-cards.js
+++ b/express/code/blocks/how-to-cards/how-to-cards.js
@@ -5,7 +5,7 @@ import { throttle, debounce } from '../../scripts/utils/hofs.js';
 let createTag;
 let loadStyle;
 let getConfig;
-const iconRegex = /icon-\s*([^\s]+)/;
+const iconRegex = /icon-([^\s]+)/;
 
 const scrollPadding = 16;
 

--- a/nala/assets/urls.txt
+++ b/nala/assets/urls.txt
@@ -91,6 +91,7 @@ https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/hover-card
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-how-to-cards/how-to-cards
 https://main--da-express-milo--adobecom.aem.page/drafts/nala/test-gen/ax-how-to-cards/how-to-cards-schema
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/ax-how-to-cards/how-to-cards-center
+https://main--da-express-milo--adobecom.aem.live/drafts/nala/blocks/how-to-cards/how-to-cards-summary
 
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/blocks/how-to-steps-carousel/how-to-steps-carousel-image-schema
 
@@ -174,4 +175,3 @@ https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/toggle-bar
 
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/tutorials/tutorials
 https://main--da-express-milo--adobecom.aem.live/drafts/nala/test-gen/tutorials/tutorials-twoperrow
-

--- a/nala/blocks/how-to-cards/how-to-cards.block.json
+++ b/nala/blocks/how-to-cards/how-to-cards.block.json
@@ -201,6 +201,24 @@
         "@center-cards-count-2",
         "@express"
       ]
+    },
+    {
+      "tcid": "2",
+      "name": "@how-to-cards-summary",
+      "selector": "div.how-to-cards.summary",
+      "path": "/drafts/nala/blocks/how-to-cards/how-to-cards-summary",
+      "data": {
+        "semantic": {
+          "texts": [],
+          "media": [],
+          "interactives": []
+        }
+      },
+      "tags": [
+        "@how-to-cards",
+        "@summary",
+        "@express"
+      ]
     }
   ]
 }

--- a/nala/blocks/how-to-cards/how-to-cards.block.json
+++ b/nala/blocks/how-to-cards/how-to-cards.block.json
@@ -209,8 +209,90 @@
       "path": "/drafts/nala/blocks/how-to-cards/how-to-cards-summary",
       "data": {
         "semantic": {
-          "texts": [],
-          "media": [],
+          "texts": [
+            {
+              "selector": ".text h2",
+              "nth": 0,
+              "tag": "h2",
+              "text": "How to make a presentation with AI.",
+              "markup": null
+            },
+            {
+              "selector": ".text p",
+              "nth": 0,
+              "tag": "p",
+              "text": "Prompt your idea and Adobe Express will generate attention-grabbing slides.",
+              "markup": null
+            },
+            {
+              "selector": "h3",
+              "nth": 0,
+              "tag": "h3",
+              "text": "Launch Adobe Express.",
+              "markup": "strong"
+            },
+            {
+              "selector": "p",
+              "nth": 1,
+              "tag": "p",
+              "text": "Open Adobe Express for free on your desktop and sign into your Adobe account. If you don’t have an account, you can quickly and easily create a free one. Next, open Generate Presentation.",
+              "markup": null
+            },
+            {
+              "selector": "h3",
+              "nth": 1,
+              "tag": "h3",
+              "text": "Upload a doc or enter a prompt.",
+              "markup": "strong"
+            },
+            {
+              "selector": "p",
+              "nth": 2,
+              "tag": "p",
+              "text": "Upload files to quickly turn them into a great presentation first draft. Alternatively, get started by describing your presentation’s theme or content in the prompt field, then click “Next.”",
+              "markup": null
+            },
+            {
+              "selector": "h3",
+              "nth": 2,
+              "tag": "h3",
+              "text": "Pick a style and generate.",
+              "markup": "strong"
+            },
+            {
+              "selector": "p",
+              "nth": 3,
+              "tag": "p",
+              "text": "Browse and choose from our collection of professionally designed templates, then click “Next.” Review the generated outline and click “Generate” and Adobe Express will create your new presentation in minutes. Upload your own images and videos, swap out color schemes, apply your brand, and customize further as needed.",
+              "markup": null
+            },
+            {
+              "selector": "h3",
+              "nth": 3,
+              "tag": "h3",
+              "text": "Download, share, present.",
+              "markup": "strong"
+            },
+            {
+              "selector": "p",
+              "nth": 4,
+              "tag": "p",
+              "text": "Invite collaborators to view, comment, or co-edit your project. Download as a PDF or Microsoft PowerPoint .ppt file and present directly from Adobe Express.",
+              "markup": null
+            }
+          ],
+          "media": [
+            {
+              "selector": ".card .step-icon picture",
+              "nth": 0,
+              "tag": "picture"
+            },
+            {
+              "selector": ".card .step-icon picture",
+              "nth": 1,
+              "tag": "picture"
+            }
+          ],
           "interactives": []
         }
       },

--- a/nala/blocks/how-to-cards/how-to-cards.test.cjs
+++ b/nala/blocks/how-to-cards/how-to-cards.test.cjs
@@ -126,4 +126,77 @@ test.describe('HowToCardsBlock Test Suite', () => {
       await runSeoChecks({ page, feature: features[1], skipSeoTest: false });
     });
   });
+
+  // Test Id : 2 : @how-to-cards-summary
+  test(`[Test Id - ${features[2].tcid}] ${features[2].name} ${features[2].tags}`, async ({ page, baseURL }) => {
+    const { data } = features[2];
+    const testUrl = `${baseURL}${features[2].path}${miloLibs}`;
+    const block = new HowToCardsBlock(page, features[2].selector);
+    console.info(`[Test Page]: ${testUrl}`);
+
+    await test.step('step-1: Navigate to page', async () => {
+      await page.goto(testUrl);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(testUrl);
+    });
+
+    await test.step('step-2: Verify block content', async () => {
+      await expect(block.block).toBeVisible();
+      const sem = data.semantic;
+
+      for (const t of sem.texts) {
+        const locator = block.block.locator(t.selector).nth(t.nth || 0);
+        await expect(locator).toContainText(t.text);
+      }
+
+      for (const m of sem.media) {
+        const locator = block.block.locator(m.selector).nth(m.nth || 0);
+        const isHiddenSelector = m.selector.includes('.isHidden');
+        const isPicture = m.tag === 'picture';
+        const target = isPicture ? locator.locator('img') : locator;
+        if (isHiddenSelector) {
+          await expect(target).toBeHidden();
+        } else {
+          await expect(target).toBeVisible();
+        }
+      }
+
+      for (const iEl of sem.interactives) {
+        const locator = block.block.locator(iEl.selector).nth(iEl.nth || 0);
+        await expect(locator).toBeVisible({ timeout: 8000 });
+        if (iEl.type === 'link' && iEl.href) {
+          const href = await locator.getAttribute('href');
+          if (/^(tel:|mailto:|sms:|ftp:|[+]?[\d])/i.test(iEl.href)) {
+            await expect(href).toBe(iEl.href);
+          } else {
+            const expectedPath = new URL(iEl.href, 'https://dummy.base').pathname;
+            const actualPath = new URL(href, 'https://dummy.base').pathname;
+            await expect(actualPath).toBe(expectedPath);
+          }
+        }
+        if (iEl.text) await expect(locator).toContainText(iEl.text);
+      }
+    });
+
+    await test.step('step-3: Validate summary variant behavior', async () => {
+      const cards = block.block.locator('.card');
+      const cardCount = await cards.count();
+      expect(cardCount).toBeGreaterThan(0);
+
+      const icons = block.block.locator('.step-icon');
+      await expect(icons).toHaveCount(cardCount);
+
+      await expect(block.block.locator('.number')).toHaveCount(0);
+      await expect(block.block.locator('.gallery-control')).toHaveCount(0);
+      await expect(block.block.locator('.text h2').first()).toBeVisible();
+    });
+
+    await test.step('step-4: Accessibility validation', async () => {
+      await runAccessibilityTest({ page, testScope: block.block, skipA11yTest: false });
+    });
+
+    await test.step('step-5: SEO validation', async () => {
+      await runSeoChecks({ page, feature: features[2], skipSeoTest: false });
+    });
+  });
 });

--- a/test/blocks/how-to-cards/how-to-cards.test.js
+++ b/test/blocks/how-to-cards/how-to-cards.test.js
@@ -101,4 +101,14 @@ describe('How-to-cards', () => {
     expect(bl.querySelector('div').classList.contains('text')).to.be.true;
     expect(bl.querySelector('div h2')).to.exist;
   });
+
+  it('supports summary variant without carousel and numbers', async () => {
+    const bl = await init(blocks[2]);
+    const cardsContainer = bl.querySelector('.cards-container');
+    expect(cardsContainer).to.exist;
+    expect(cardsContainer.classList.contains('gallery')).to.be.false;
+    expect(bl.querySelector('.gallery-control')).to.not.exist;
+    expect(bl.querySelectorAll('.number').length).to.equal(0);
+    expect(bl.querySelectorAll('.step-icon').length).to.equal(3);
+  });
 });

--- a/test/blocks/how-to-cards/mocks/body.html
+++ b/test/blocks/how-to-cards/mocks/body.html
@@ -81,6 +81,37 @@
             </div>
         </div>
     </div>
+    <div>
+        <div class="how-to-cards summary">
+            <div>
+                <div>
+                    <h2 id="how-to-summarize-a-design-brief">How to summarize a design brief.</h2>
+                    <p>Turn details into a quick, actionable summary.</p>
+                </div>
+            </div>
+            <div>
+                <div>
+                    <span class="icon icon-checkmark"></span>
+                    <h3 id="review-the-input">Review the input.</h3>
+                    <p>Read the source material and identify the core requirements.</p>
+                </div>
+            </div>
+            <div>
+                <div>
+                    <span class="icon icon-lightbulb"></span>
+                    <h3 id="extract-key-points">Extract key points.</h3>
+                    <p>Capture audience, objective, constraints, and deliverables.</p>
+                </div>
+            </div>
+            <div>
+                <div>
+                    <span class="icon icon-share-arrow"></span>
+                    <h3 id="publish-summary">Publish summary.</h3>
+                    <p>Share a concise version with stakeholders for alignment.</p>
+                </div>
+            </div>
+        </div>
+    </div>
 </main>
 <footer></footer>
 </body>


### PR DESCRIPTION

## Summary

Adds a **summary** variant to the How-to Cards block for LLM-generated content. The summary variant shows step cards in a grid layout with optional step icons (from authored icons or images) instead of numbered tips, and omits the gallery carousel controls. Also includes updates to template-x-carousel, template-x, gen-ai-cards, discover-cards, faqv2, search-marquee, seo-nav, toc-seo, and other blocks.

---

## Jira Ticket

Resolves: [MWPW-188074](https://jira.corp.adobe.com/browse/MWPW-188074)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://how-to-llm--da-express-milo--adobecom.aem.page/drafts/echen/how-to-llm?martech=off |

---

## Verification Steps

1. Open the **After** URL above.
2. Find the How-to Cards block with the `summary` class variant.
3. **Before**: Standard how-to-cards with numbered tips and gallery carousel.
4. **After**: Summary variant shows cards in a responsive grid with step icons (when authored), no gallery controls, and centered heading/subcopy styling.

---

## Potential Regressions

- https://how-to-llm--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

- Summary variant loads `how-to-cards-summary.css` when the block has the `summary` class.
- Step icons come from authored `.icon` elements or the first picture in each step’s content.

---

If the main focus of MWPW-188074 is different from the How-to Cards summary variant, say what it is and the Summary and Verification Steps can be updated.