### PR TITLE
re-implemented fix for homepage h1 with more targeted approach

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -404,6 +404,7 @@ main .section .grid-marquee.pricing-page h1 {
   }
   main .section .grid-marquee .headline h1 {
     font-size: var(--heading-font-size-xl);
+    font-weight: var(--heading-font-weight-extra);
   }
   .grid-marquee .headline .ctas {
     padding-top: 24px;


### PR DESCRIPTION
## Summary

Issue described in detail in JIRA.

Basically our current typekit file (https://use.typekit.net/jdq5hay.css) for en-US does not contain a rule for the '800' font-eight of the 'adobe-clean' font. As a result, we are seeing text declared with a weight of '800' fall back to render at the nearest available weight that is included in our typekit file, which is '900'. This works for the US site, however other regions, such as UK do have the '800' font font-weight of the 'adobe-clean' font included in their typescript file (https://use.typekit.net/pps7abe.css) and thus are rendering the text at it's proper weight of 800, which Design has identified is too small.

tldr;
By adjusting the '--heading-font-weight' variable from 800 to 900 we should see no visible effect in US (and other regions that dont include 'font-weight: 800' in their typescript files), and regions like UK should start rendering these font-weights at the value that was intended by Design. 

---

## Jira Ticket

Resolves: [MWPW-189093](https://jira.corp.adobe.com/browse/MWPW-189093)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/uk/express/ |
| **After**   | https://mwpw-189093--da-express-milo--adobecom.aem.page/uk/express/?martech=off |

---

## Verification Steps

- Navigate to the 'Before' link and notice that the H1 title font-weight is too thin. 
- Navigate to the 'After link and notice that the H1 title font-weight is correct and matches the appearance of the title on the US homepage. 

---

## Potential Regressions

This change affects the default heading-font-weight variable and thus could affect any page that uses this variable, i.e.
- https://mwpw-189093--da-express-milo--adobecom.aem.live/uk/express/discover/ideas/social-media-marketing?martech=off

---

## Additional Notes

Opened for Max