### PR TITLE
Mwpw 187662

### DIFF
--- a/express/code/blocks/template-x-promo/template-x-promo.css
+++ b/express/code/blocks/template-x-promo/template-x-promo.css
@@ -516,7 +516,7 @@
   outline: none;
 }
 
-/* All carousel types use the same track padding */
+/* All carousel types use the same track padding  */
 
 .ax-template-x-promo.multiple-up .promo-carousel-track {
   padding: 0 15%;

--- a/express/code/blocks/template-x-promo/template-x-promo.css
+++ b/express/code/blocks/template-x-promo/template-x-promo.css
@@ -521,6 +521,11 @@
 .ax-template-x-promo.multiple-up .promo-carousel-track {
   padding: 0 15%;
 }
+.ax-template-x-promo.two-up .promo-carousel-track {
+  padding: 0;
+  padding-inline-start: var(--ax-grid-margin);
+  justify-content: start;
+}
 
 .ax-template-x-promo .template.prev-template,
 .ax-template-x-promo .template.current-template,


### PR DESCRIPTION
## Summary

Adjusted padding and justification of templates within carousel treatment

---

## Jira Ticket

Resolves: [MWPW-187662](https://jira.corp.adobe.com/browse/MWPW-187662)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/drafts/stella/discover/new-layout/2en/ideas/infographic |
| **After**   | https://mwpw-187662--da-express-milo--adobecom.aem.page/drafts/stella/discover/new-layout/2en/ideas/infographic?martech=off |

---

## Verification Steps

- Navigate to the 'Before' page, open Chrome Devtools and select the 'Toggle device' icon in order to preview the mobile treatment of the device. 
- Scroll down the page to the 'two-up' template carousel and notice the positioning of the templates is such that they are each getting cut off. 
- Navigate to the 'After' page, open Chrome Devtools and select the 'Toggle device' icon in order to preview the mobile treatment of the device. 
- Scroll down the page to the 'two-up' template carousel and notice the positioning of the templates has been adjusted to align with the treatment described in the JIRA ticket. 

---

## Potential Regressions

This update affects the 'template-x-promo' block and so any page using this block could be affected, i.e.

https://main--https://mwpw-187662--da-express-milo--adobecom.aem.page/express/discover/ideas/card
https://main--https://mwpw-187662--da-express-milo--adobecom.aem.page/express/discover/messages/card/sympathy
https://main--https://mwpw-187662--da-express-milo--adobecom.aem.page/fr/express/discover/ideas/birthday/first
https://main--https://mwpw-187662--da-express-milo--adobecom.aem.page/express/discover/messages/condolence
https://main--https://mwpw-187662--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/instagram/go-live

---

## Additional Notes

Opened for Max