### PR TITLE
updated all instances of lana.log to include all required and optiona…

### DIFF
--- a/express/code/blocks/ax-marquee/ax-marquee.js
+++ b/express/code/blocks/ax-marquee/ax-marquee.js
@@ -47,8 +47,7 @@ async function handlePrice(block, tokenType = '((pricing))', responseFieldName =
     const response = await fetchPlanOnePlans(priceEl?.href);
     newContainer.innerHTML = response[responseFieldName];
   } catch (error) {
-    window.lana.log('Failed to fetch prices for page plan');
-    window.lana.log(error);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'ax-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   return newContainer;
 }

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -148,8 +148,8 @@ function getSafeHrefFromText(text) {
     if (url.protocol === 'http:' || url.protocol === 'https:') {
       return url.href;
     }
-  } catch (e) {
-    window.lana.log('Invalid URL', e);
+  } catch (error) {
+    window.lana.log(`Failed to get href from text: ${error}`, { clientId: 'express', tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
   return null;

--- a/express/code/blocks/drawer-cards/drawer-cards.js
+++ b/express/code/blocks/drawer-cards/drawer-cards.js
@@ -179,7 +179,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to format dynamic cart link: ${error}`, { clientId: 'express', tags: 'drawer-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -93,8 +93,8 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
         p.innerHTML = p.innerHTML.replaceAll(priceToken, '');
       }
     });
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle-pricing-token: ${error}`, { clientId: 'express', tags: 'pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -216,8 +216,8 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
     } else {
       year2PricingToken.textContent = '';
     }
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle pricing token: ${error}`, { clientId: 'express', tags: 'pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
+++ b/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
@@ -24,7 +24,7 @@ export default async function fetchAPIData(productId, parameters, endpoint, idTy
   try {
     apiDataFetch = await fetch(formatUrlForEnvironment(url));
   } catch (error) {
-    window.lana.log('Error fetching product details: ', { error }, { tags: 'print-product-detail', severity: 'error' });
+    window.lana.log(`Failed to fetch product details: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   const apiDataJSON = await apiDataFetch.json();
   const apiData = apiDataJSON.data;

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -204,18 +204,12 @@ export default async function decorate(block) {
       link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
       head.appendChild(link);
     } catch (error) {
-      window.lana.log(`Failed to preload hero image on PDP Page: ${error}`, {
-        severity: 'warning',
-        tags: 'print-product-detail',
-      });
+      window.lana.log(`Failed to preload hero image on PDP Page: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
     try {
       document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
     } catch (error) {
-      window.lana.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, {
-        severity: 'warning',
-        tags: 'print-product-detail',
-      });
+      window.lana.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
     updatePageWithProductDetails(dataObject, globalContainer);
     // SEO: title/description (respect authored), initial Product JSON-LD
@@ -279,10 +273,7 @@ export default async function decorate(block) {
         true,
       );
     } catch (error) {
-      window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, {
-        severity: 'warning',
-        tags: 'print-product-detail, analytics',
-      });
+      window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
   });
 }

--- a/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
+++ b/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
@@ -95,8 +95,8 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
     } else {
       year2PricingToken.remove();
     }
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle year 2 pricing token: ${error}`, { clientId: 'express', tags: 'simplified-pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -69,8 +69,8 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
     } else {
       year2PricingToken.textContent = '';
     }
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle year 2 pricing token: ${error}`, { clientId: 'express', tags: 'simplified-pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1872,8 +1872,7 @@ async function buildTemplateList(block, props, type = []) {
 
     await decorateTemplates(block, props);
   } else {
-    window.lana.log(`failed to load templates with props: ${JSON.stringify(props)}`, { tags: 'templates-api' });
-
+    window.lana.log(`failed to load templates with props: ${JSON.stringify(props)}`, { clientId: 'express', tags: 'template-x, templates-api', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       block.remove();
     } else {

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -248,10 +248,7 @@ export async function trackViewTemplatePage(
   try {
     safelyFireAnalyticsEvent(fireEvent);
   } catch (error) {
-    window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, {
-      severity: 'warning',
-      tags: 'print-product-detail, analytics',
-    });
+    window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -167,7 +167,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'grid-marquee, ace1057', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
@@ -187,7 +187,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'grid-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -764,7 +764,7 @@ export async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -506,8 +506,8 @@ export async function loadAndInitializeCCEverywhere(getConfig) {
   if (urlOverride) {
     try {
       if (new URL(urlOverride).host === 'dev.cc-embed.adobe.com') valid = true;
-    } catch (e) {
-      window.lana.log('Invalid SDK URL');
+    } catch (error) {
+      window.lana.log(`Invalid SDK URL: ${error}`, { clientId: 'express', tags: 'frictionless-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   const CDN_URL = valid

--- a/express/code/scripts/utils/location-utils.js
+++ b/express/code/scripts/utils/location-utils.js
@@ -39,8 +39,8 @@ export async function getCountry(ignoreCookie = false) {
       sessionStorage.setItem('visitorCountry', normalized);
       return normalized;
     }
-  } catch (e) {
-    window.lana.log('could not fet geo2 data from geo2 service', e);
+  } catch (error) {
+    window.lana.log(`Could not fetch geo2 data from geo2 service: ${error}`, { clientId: 'express', tags: 'location-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 
   const configCountry = getConfig().locale.region;

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -388,8 +388,7 @@ export async function formatDynamicCartLink(a, plan) {
       a.href = newTrialHref;
     }
   } catch (error) {
-    window.lana.log('Failed to fetch prices for page plan');
-    window.lana.log(error);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'pricing-js', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   return a;
 }


### PR DESCRIPTION
## Summary

Cleaned up all of the window.lana.log calls in the repository to use a clean / consistent format that includes all of the required and optional fields. Included a severity level of 'error' for most logs, with the exception of a few that I left at 'warning'.

---

## Jira Ticket

Resolves: [MWPW-186049](https://jira.corp.adobe.com/browse/MWPW-186049)

---

## Test URLs

N/A

---

## Verification Steps

Verifying these updates would involve manually triggering an error that would cause a lana log to be produced, and then checking the repository where our lana logs get logged. I am personally not sure of how to access this repository, but I think we can say with fairly high confidence that the logging behavior should be the same and should not be affected by simply including these extra parameters. 

---

## Potential Regressions

Should be none. 

---

## Additional Notes

If any of the severity levels of any of these logs need to be adjusted, that can be addressed in future tickets. This simply accomplishes the base level task of assigning an explicit severity to the logs so that they don't default to the default severity value which is 'info'. 

Opened for Max