### PR TITLE
Template X Carousel Locales

### DIFF
--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -21,10 +21,12 @@ async function createTemplatesContainer(recipe, el, isPanel = false, queryParams
   const templatesContainer = createTag('div', { class: containerClass });
 
   const isIOS = getMobileOperatingSystem() === 'iOS';
+  const { locale: { ietf, region } } = getConfig();
+  const localeParams = `locale=${ietf}&contentRegion=${region === 'uk' ? 'gb' : region}`;
   const customProperties = isIOS ? null : {
     customUrlConfig: {
       baseUrl: 'https://adobesparkpost.app.link/8JaoEy0DrSb',
-      queryParams: ['source=seo-template', queryParams].filter(Boolean).join('&'),
+      queryParams: ['source=seo-template', queryParams, localeParams].filter(Boolean).join('&'),
     },
   };
 


### PR DESCRIPTION

## Summary

Passes locale and content region parameters (`locale` and `contentRegion`) into all template links in the Template X Carousel block. Users visiting localized Express pages (e.g. `/de/`, `/jp/`, `/br/`) will now get the correct language and region in the card maker experience instead of defaulting to English.

<img width="1475" height="685" alt="Screenshot 2026-03-18 at 11 04 10 AM" src="https://github.com/user-attachments/assets/702daa2c-90cb-487e-82f1-8dae401bfaf0" />

---

## Jira Ticket

Resolves: [MWPW-190366](https://jira.corp.adobe.com/browse/MWPW-190366)

---

## Test URLs

| Env | URL |
|-----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://template-x-carousel-locale--da-express-milo--adobecom.aem.page/de/express/create/card |

---

## Verification Steps

1. Open a localized Express create card page (e.g. `/de/express/create/card`, `/jp/express/create/card`, or `/br/express/create/card`).
2. Use a Template X Carousel block with template links.
3. Click a template link to open the card maker.
4. **Before**: Card maker opens in English regardless of page locale.
5. **After**: Card maker opens in the correct locale and content region for the page.

---

## Potential Regressions

- https://template-x-carousel-locale--da-express-milo--adobecom.aem.live/de/express/create/card

---

## Additional Notes

- Uses `getConfig()` to read `locale.ietf` and `locale.region`, with `region === 'uk'` mapped to `contentRegion=gb`.
- Locale params are appended to the `customUrlConfig.queryParams` for the adobesparkpost.app.link deep links.
- iOS uses a different flow and does not receive these params (unchanged behavior).