### PR TITLE
[Color][MWPW-187557] Add accessibility and focus order for Color Blindness Page

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -4,6 +4,7 @@ import { createColorConflictsAdapter } from '../../scripts/color-shared/adapters
 import ColorThemeExpressController from '../../scripts/color-shared/controllers/ColorThemeExpressController.js';
 import { createStripContainerRenderer } from '../../scripts/color-shared/renderers/createStripContainerRenderer.js';
 import { getConflictPairs, TYPE_ORDER } from '../../scripts/color-shared/services/createColorBlindnessService.js';
+import { announceToScreenReader } from '../../scripts/color-shared/spectrum/utils/a11y.js';
 import '../../scripts/color-shared/components/color-wheel-express/index.js';
 
 const PALETTE_PRESETS = [
@@ -90,6 +91,9 @@ export default async function decorate(block) {
     const { layout } = parseContent(block);
     block.innerHTML = '';
 
+    const section = createTag('section', { 'aria-label': 'Color blindness simulator' });
+    block.appendChild(section);
+
     const initialPalette = pickRandomPalette();
 
     const navLinks = [
@@ -104,7 +108,7 @@ export default async function decorate(block) {
 
     const isSingleStack = window.matchMedia('(max-width: 887px)').matches;
     const isDesktop = window.matchMedia('(min-width: 1200px)').matches;
-    layoutInstance = await createColorToolLayout(block, {
+    layoutInstance = await createColorToolLayout(section, {
       palette: initialPalette,
       toolbar: {
         variant: isSingleStack ? 'sticky' : 'standalone',
@@ -131,11 +135,19 @@ export default async function decorate(block) {
       },
     });
 
-    const { sidebar, canvas } = layoutInstance.slots;
+    const { sidebar, canvas, topbar } = layoutInstance.slots;
+    const layoutRoot = sidebar.parentElement;
+    if (layoutRoot && topbar) {
+      layoutRoot.insertBefore(sidebar, topbar);
+    }
     const actionMenuApi = layoutInstance.actionMenu;
     const conflicts = createColorConflictsAdapter({
       conflictsFound: true,
       label: 'Potential color blind conflicts',
+    });
+    conflicts.element.setAttribute('tabindex', '0');
+    conflicts.element.addEventListener('focus', () => {
+      announceToScreenReader('The conflicts between colors are shown with a caution symbol.');
     });
     sidebar.appendChild(conflicts.element);
 
@@ -162,6 +174,10 @@ export default async function decorate(block) {
     const wheelEl = createTag('color-wheel-express', {
       'aria-label': 'Color wheel',
       color: initialPalette.colors[0],
+      tabindex: '0',
+    });
+    wheelEl.addEventListener('focus', () => {
+      announceToScreenReader('Color wheel');
     });
     wheelEl.showLines = true;
 

--- a/express/code/scripts/color-shared/components/color-conflicts/index.js
+++ b/express/code/scripts/color-shared/components/color-conflicts/index.js
@@ -5,6 +5,8 @@ import { loadBadge, loadTooltip } from '../../spectrum/load-spectrum.js';
 const TOOLTIP_CSS_PATH = '/express/code/scripts/color-shared/spectrum/styles/tooltip.css';
 
 class ColorConflicts extends LitElement {
+  static shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
   static get styles() {
     return [style];
   }

--- a/express/code/scripts/color-shared/components/createActionMenuComponent.js
+++ b/express/code/scripts/color-shared/components/createActionMenuComponent.js
@@ -2,6 +2,7 @@
 import { createTag, getLibs } from '../../utils.js';
 import { createExpressButton, createExpressTooltip } from '../spectrum/index.js';
 import { createActionMenuState } from './createActionMenuState.js';
+import { attachRovingTabIndex } from '../spectrum/utils/a11y.js';
 import {
   COLOR_ICON,
   ACCESSIBILITY_ICON,
@@ -26,7 +27,6 @@ const ICON_MAP = {
     minimize: MINIMIZE_ICON,
   },
 };
-const ROVING_INDEX_ATTR = 'data-roving-index';
 const LANA_TAGS = 'color,color-action-menu';
 
 function isValidActionMenuItem(item, requiredField) {
@@ -38,40 +38,6 @@ function isValidActionMenuItem(item, requiredField) {
     severity: 'error',
   });
   return false;
-}
-
-function attachRovingTabIndex(container, elements, initialFocusIndex = 0) {
-  if (!elements.length) return;
-  const focusIndex = Math.max(0, Math.min(initialFocusIndex, elements.length - 1));
-  elements.forEach((el, index) => {
-    el.setAttribute('tabindex', index === focusIndex ? '0' : '-1');
-    el.setAttribute(ROVING_INDEX_ATTR, index.toString());
-  });
-  container.addEventListener('keydown', (e) => {
-    const target = e.target.closest(`[${ROVING_INDEX_ATTR}]`);
-    if (!target || !elements.includes(target)) return;
-    const currentIndex = parseInt(target.getAttribute(ROVING_INDEX_ATTR), 10);
-    if (Number.isNaN(currentIndex) || currentIndex < 0 || currentIndex >= elements.length) return;
-    let targetIndex = -1;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-      e.preventDefault();
-      targetIndex = (currentIndex + 1) % elements.length;
-    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-      e.preventDefault();
-      targetIndex = (currentIndex - 1 + elements.length) % elements.length;
-    } else if (e.key === 'Home') {
-      e.preventDefault();
-      targetIndex = 0;
-    } else if (e.key === 'End') {
-      e.preventDefault();
-      targetIndex = elements.length - 1;
-    }
-    if (targetIndex !== -1 && targetIndex !== currentIndex) {
-      elements[currentIndex].setAttribute('tabindex', '-1');
-      elements[targetIndex].setAttribute('tabindex', '0');
-      elements[targetIndex].focus();
-    }
-  });
 }
 
 export async function loadStyles() {

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -12,6 +12,7 @@ import {
   simulateHex,
 } from '../services/createColorBlindnessService.js';
 import { createExpressTooltip } from '../spectrum/components/express-tooltip.js';
+import { announceToScreenReader } from '../spectrum/utils/a11y.js';
 
 const COLORS_PER_ROW_TWO_ROWS = 5;
 
@@ -117,10 +118,13 @@ function createColorBlindnessRowsInMatrix(controller, orientation, containerEl, 
       const titleCell = createTag('div', {
         class: `strip-color-blindness-row__title-cell strip-color-blindness-row--${type} ${pairs.length > 0 ? 'fail' : 'pass'}`,
       });
-      const label = createTag('span', { class: 'strip-color-blindness-row__label' });
+      const label = createTag('span', { class: 'strip-color-blindness-row__label', tabindex: '0' });
       label.textContent = TYPE_LABELS[type];
       label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-      label.setAttribute('aria-label', DEFECT_DEFINITIONS[type]);
+      label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      label.addEventListener('focus', () => {
+        announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      });
       titleCell.appendChild(label);
       titleCell.style.gridColumn = '1';
       titleCell.style.gridRow = String(gridRow);
@@ -136,6 +140,8 @@ function createColorBlindnessRowsInMatrix(controller, orientation, containerEl, 
         const swatch = createTag('div', {
           class: `strip-color-blindness-swatch${conflicting.has(i) ? ' conflict' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
+          role: 'img',
+          'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,
         });
         if (conflicting.has(i)) swatch.appendChild(createConflictIcon());
         swatchesWrap.appendChild(swatch);
@@ -170,10 +176,13 @@ function createFourRowsColorBlindnessTitlesOnly(controller, containerEl, railWra
     const titleCell = createTag('div', {
       class: `strip-four-rows-cb-title strip-four-rows-cb-title--${type}`,
     });
-    const label = createTag('span', { class: 'strip-four-rows-cb-title__label' });
+    const label = createTag('span', { class: 'strip-four-rows-cb-title__label', tabindex: '0' });
     label.textContent = TYPE_LABELS[type];
     label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-    label.setAttribute('aria-label', DEFECT_DEFINITIONS[type]);
+    label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+    label.addEventListener('focus', () => {
+      announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+    });
     titleCell.style.gridColumn = '1';
     titleCell.style.gridRow = String(gridRow);
     titleCell.appendChild(label);
@@ -208,10 +217,13 @@ function createMobileCBLayout(controller, maxColumns = FOUR_ROWS_CB_COLS) {
 
   TYPE_ORDER.forEach((type) => {
     const wrap = createTag('div', { class: 'strip-cb-mobile-header__label-wrap' });
-    const label = createTag('span', { class: 'strip-cb-mobile-header__label' });
+    const label = createTag('span', { class: 'strip-cb-mobile-header__label', tabindex: '0' });
     label.textContent = TYPE_LABELS[type];
     label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-    label.setAttribute('aria-label', DEFECT_DEFINITIONS[type]);
+    label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+    label.addEventListener('focus', () => {
+      announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+    });
     wrap.appendChild(label);
     header.appendChild(wrap);
   });
@@ -271,6 +283,8 @@ function createMobileCBLayout(controller, maxColumns = FOUR_ROWS_CB_COLS) {
         const simCell = createTag('div', {
           class: `strip-cb-mobile-row__sim${conflicting.has(colorIndex) ? ' conflict' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
+          role: 'img',
+          'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,
         });
         if (conflicting.has(colorIndex)) simCell.appendChild(createConflictIcon());
         row.appendChild(simCell);
@@ -340,10 +354,13 @@ function createColorBlindnessRows(controller, orientation) {
         class: `strip-color-blindness-row strip-color-blindness-row--${type} ${rowFails ? 'fail' : 'pass'} strip-color-blindness-row--two-rows`,
       });
       const header = createTag('div', { class: 'strip-color-blindness-row__header' });
-      const label = createTag('span', { class: 'strip-color-blindness-row__label' });
+      const label = createTag('span', { class: 'strip-color-blindness-row__label', tabindex: '0' });
       label.textContent = TYPE_LABELS[type];
       label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-      label.setAttribute('aria-label', DEFECT_DEFINITIONS[type]);
+      label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      label.addEventListener('focus', () => {
+        announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      });
       header.appendChild(label);
       const swatchesContainer = createTag('div', { class: 'strip-color-blindness-row__grid' });
       const rowColors = colors.slice(0, COLORS_PER_ROW_TWO_ROWS);
@@ -357,6 +374,8 @@ function createColorBlindnessRows(controller, orientation) {
         const swatch = createTag('div', {
           class: `strip-color-blindness-swatch${conflicting.has(colIndex) ? ' conflict' : ''}${isPlaceholder ? ' strip-color-blindness-swatch--placeholder' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
+          role: 'img',
+          'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,
         });
         if (conflicting.has(colIndex)) swatch.appendChild(createConflictIcon());
         swatchesContainer.appendChild(swatch);

--- a/express/code/scripts/color-shared/spectrum/utils/a11y.js
+++ b/express/code/scripts/color-shared/spectrum/utils/a11y.js
@@ -277,3 +277,50 @@ export function announceToScreenReader(message, priority = 'polite', options = {
     region.textContent = text ? text + suffix : '';
   }, delay);
 }
+
+// ── Roving Tabindex ──────────────────────────────────────────────────
+
+const ROVING_INDEX_ATTR = 'data-roving-index';
+
+/**
+ * Attach roving tabindex keyboard navigation to a container.
+ * Arrow keys (Left/Right/Up/Down) cycle through elements; Home/End jump
+ * to the first/last element. Only the active element has tabindex="0".
+ *
+ * @param {HTMLElement} container — the parent element to listen on
+ * @param {HTMLElement[]} elements — the focusable children
+ * @param {number} [initialFocusIndex=0] — which element starts with tabindex="0"
+ */
+export function attachRovingTabIndex(container, elements, initialFocusIndex = 0) {
+  if (!elements.length) return;
+  const focusIndex = Math.max(0, Math.min(initialFocusIndex, elements.length - 1));
+  elements.forEach((el, index) => {
+    el.setAttribute('tabindex', index === focusIndex ? '0' : '-1');
+    el.setAttribute(ROVING_INDEX_ATTR, index.toString());
+  });
+  container.addEventListener('keydown', (e) => {
+    const target = e.target.closest(`[${ROVING_INDEX_ATTR}]`);
+    if (!target || !elements.includes(target)) return;
+    const currentIndex = parseInt(target.getAttribute(ROVING_INDEX_ATTR), 10);
+    if (Number.isNaN(currentIndex) || currentIndex < 0 || currentIndex >= elements.length) return;
+    let targetIndex = -1;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      targetIndex = (currentIndex + 1) % elements.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      targetIndex = (currentIndex - 1 + elements.length) % elements.length;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      targetIndex = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      targetIndex = elements.length - 1;
+    }
+    if (targetIndex !== -1 && targetIndex !== currentIndex) {
+      elements[currentIndex].setAttribute('tabindex', '-1');
+      elements[targetIndex].setAttribute('tabindex', '0');
+      elements[targetIndex].focus();
+    }
+  });
+}

--- a/express/code/scripts/color-shared/spectrum/utils/a11y.js
+++ b/express/code/scripts/color-shared/spectrum/utils/a11y.js
@@ -278,19 +278,8 @@ export function announceToScreenReader(message, priority = 'polite', options = {
   }, delay);
 }
 
-// ── Roving Tabindex ──────────────────────────────────────────────────
-
 const ROVING_INDEX_ATTR = 'data-roving-index';
 
-/**
- * Attach roving tabindex keyboard navigation to a container.
- * Arrow keys (Left/Right/Up/Down) cycle through elements; Home/End jump
- * to the first/last element. Only the active element has tabindex="0".
- *
- * @param {HTMLElement} container — the parent element to listen on
- * @param {HTMLElement[]} elements — the focusable children
- * @param {number} [initialFocusIndex=0] — which element starts with tabindex="0"
- */
 export function attachRovingTabIndex(container, elements, initialFocusIndex = 0) {
   if (!elements.length) return;
   const focusIndex = Math.max(0, Math.min(initialFocusIndex, elements.length - 1));


### PR DESCRIPTION
## Summary

Added focus order and accessibility voiceover as per bluelines
<img width="1030" height="601" alt="Screenshot 2026-03-23 at 7 01 25 PM" src="https://github.com/user-attachments/assets/ebe313b7-e67c-44cd-ae60-e0d62197e9e5" />


---

## Jira Ticket

Resolves: [MWPW-187557](https://jira.corp.adobe.com/browse/MWPW-187557)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://mwpw-187409-color-blindness-sidebar--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-sidebar?martech=off|
| **After**   | https://mwpw-187557-cb-bluelines--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-sidebar?martech=off |

---

## Verification Steps

- Press tab on page, the focus and voiceover order will be as shown in attached image.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
