### PR TITLE
Blog Article Marquee Field Change

### DIFF
--- a/express/code/blocks/blog-article-marquee/blog-article-marquee.js
+++ b/express/code/blocks/blog-article-marquee/blog-article-marquee.js
@@ -13,7 +13,7 @@ const PRODUCT_ICON_SIZE = 48;
 const METADATA_KEYS = {
   eyebrow: 'category',
   headline: 'headline',
-  subcopy: 'sub-heading',
+  subcopy: 'subheading',
   title: 'og:title',
   productName: 'author',
   productIcon: 'blog-marquee-icon',

--- a/test/blocks/blog-article-marquee/blog-article-marquee.test.js
+++ b/test/blocks/blog-article-marquee/blog-article-marquee.test.js
@@ -84,7 +84,7 @@ describe('Blog Article Marquee block', () => {
     const expectedProductName = META_FIXTURES.author;
     const expectedProductDate = META_FIXTURES['publication-date'];
     const expectedEyebrow = META_FIXTURES.category;
-    const expectedSubcopy = META_FIXTURES['sub-heading'];
+    const expectedSubcopy = META_FIXTURES.subheading;
     const expectedHeadline = META_FIXTURES.headline;
 
     const eyebrow = contentColumn.querySelector('.blog-article-marquee-eyebrow');

--- a/test/blocks/blog-article-marquee/blog-article-marquee.test.js
+++ b/test/blocks/blog-article-marquee/blog-article-marquee.test.js
@@ -15,7 +15,7 @@ const META_FIXTURES = {
   category: 'Enterprise',
   headline: 'Test title',
   'og:title': 'Test title fallback',
-  'subheading': 'Lorem ipsum dolor sit amet consectetur. Mauris elementum ullamcorper dignissim sodales tempus. A a nam ut facilisi nunc. Convallis morbi faucibus vulputate proin cras lectus interdum risus diam. Lacus semper sit magnis pellentesque.',
+  subheading: 'Lorem ipsum dolor sit amet consectetur. Mauris elementum ullamcorper dignissim sodales tempus. A a nam ut facilisi nunc. Convallis morbi faucibus vulputate proin cras lectus interdum risus diam. Lacus semper sit magnis pellentesque.',
   author: 'Adobe Express',
   'publication-date': '10/20/2025',
   description: 'Get the lowdown on the hottest graphic design trends predicted for 2025.',

--- a/test/blocks/blog-article-marquee/blog-article-marquee.test.js
+++ b/test/blocks/blog-article-marquee/blog-article-marquee.test.js
@@ -15,7 +15,7 @@ const META_FIXTURES = {
   category: 'Enterprise',
   headline: 'Test title',
   'og:title': 'Test title fallback',
-  'sub-heading': 'Lorem ipsum dolor sit amet consectetur. Mauris elementum ullamcorper dignissim sodales tempus. A a nam ut facilisi nunc. Convallis morbi faucibus vulputate proin cras lectus interdum risus diam. Lacus semper sit magnis pellentesque.',
+  'subheading': 'Lorem ipsum dolor sit amet consectetur. Mauris elementum ullamcorper dignissim sodales tempus. A a nam ut facilisi nunc. Convallis morbi faucibus vulputate proin cras lectus interdum risus diam. Lacus semper sit magnis pellentesque.',
   author: 'Adobe Express',
   'publication-date': '10/20/2025',
   description: 'Get the lowdown on the hottest graphic design trends predicted for 2025.',


### PR DESCRIPTION
## Summary

Restores the correct metadata key for the blog article marquee subcopy from `sub-heading` to `subheading`. A previous change introduced `sub-heading` (with a dash); it should remain `subheading` (without a dash) so the text below the H1 on the blog article page correctly maps to the subheading metadata.

---

## Jira Ticket

Resolves: [MWPW-190454](https://jira.corp.adobe.com/browse/MWPW-190454)

---

## Test URLs

| Env | URL |
|-----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://blog-article-marquee-f--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

1. Open the blog article draft page:  
   https://main--da-express-milo--adobecom.aem.page/express/learn/blog/blog-article  
   (or the "After" URL with the branch).
2. Confirm the page uses metadata with `name="subheading"` for the text below the H1.
3. **Before**: The blog article marquee reads `sub-heading` metadata; the subcopy below the H1 may not show when only `subheading` is set.
4. **After**: The blog article marquee reads `subheading` metadata; the subcopy displays correctly and matches the blog template.

---

## Potential Regressions

- https://blog-article-marquee-f--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

- The blog template already uses `getMetadata('subheading')` for the hero subheading. This change aligns the blog article marquee block with that behavior.
- In `test/blocks/blog-article-marquee/blog-article-marquee.test.js`, `expectedSubcopy` was updated from `META_FIXTURES['sub-heading']` to `META_FIXTURES.subheading` so the test passes with the new metadata key.