### PR TITLE
updated all instances of lana.log to include all required fields

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -726,8 +726,8 @@ export default async function decorate(block) {
   if (phoneNumberTags.length > 0) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
-    } catch (e) {
-      window.lana?.log('ax-columns.js - error fetching sales phones numbers:', e.message);
+    } catch (error) {
+      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { clientId: 'express', tags: 'ax-columns', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -727,7 +727,7 @@ export default async function decorate(block) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
     } catch (error) {
-      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { clientId: 'express', tags: 'ax-columns', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { tags: 'ax-columns', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -727,7 +727,7 @@ export default async function decorate(block) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
     } catch (error) {
-      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { tags: 'ax-columns', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { tags: 'ax-columns', severity: 'error' });
     }
   }
 

--- a/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.js
+++ b/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.js
@@ -62,7 +62,7 @@ async function setupVideoControls(block) {
 
     await createAccessibilityVideoControls(videoElement);
   } catch (error) {
-    window.lana?.log(`Error creating video controls: ${error}`, { clientId: 'express', tags: 'ax-marquee-dynamic-hero', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error creating video controls: ${error}`, { tags: 'ax-marquee-dynamic-hero', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.js
+++ b/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.js
@@ -62,7 +62,7 @@ async function setupVideoControls(block) {
 
     await createAccessibilityVideoControls(videoElement);
   } catch (error) {
-    window.lana?.log(`Error creating video controls: ${error}`, { tags: 'ax-marquee-dynamic-hero', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error creating video controls: ${error}`, { tags: 'ax-marquee-dynamic-hero', severity: 'error' });
   }
 }
 

--- a/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.js
+++ b/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.js
@@ -62,7 +62,7 @@ async function setupVideoControls(block) {
 
     await createAccessibilityVideoControls(videoElement);
   } catch (error) {
-    window.lana?.log('Error creating video controls:', error);
+    window.lana?.log(`Error creating video controls: ${error}`, { clientId: 'express', tags: 'ax-marquee-dynamic-hero', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/ax-marquee/ax-marquee.js
+++ b/express/code/blocks/ax-marquee/ax-marquee.js
@@ -47,7 +47,7 @@ async function handlePrice(block, tokenType = '((pricing))', responseFieldName =
     const response = await fetchPlanOnePlans(priceEl?.href);
     newContainer.innerHTML = response[responseFieldName];
   } catch (error) {
-    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'ax-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'ax-marquee', severity: 'error' });
   }
   return newContainer;
 }

--- a/express/code/blocks/ax-marquee/ax-marquee.js
+++ b/express/code/blocks/ax-marquee/ax-marquee.js
@@ -47,7 +47,7 @@ async function handlePrice(block, tokenType = '((pricing))', responseFieldName =
     const response = await fetchPlanOnePlans(priceEl?.href);
     newContainer.innerHTML = response[responseFieldName];
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'ax-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'ax-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   return newContainer;
 }

--- a/express/code/blocks/ax-marquee/ax-marquee.js
+++ b/express/code/blocks/ax-marquee/ax-marquee.js
@@ -47,8 +47,7 @@ async function handlePrice(block, tokenType = '((pricing))', responseFieldName =
     const response = await fetchPlanOnePlans(priceEl?.href);
     newContainer.innerHTML = response[responseFieldName];
   } catch (error) {
-    window.lana.log('Failed to fetch prices for page plan');
-    window.lana.log(error);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'ax-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   return newContainer;
 }

--- a/express/code/blocks/banner-bg/banner-bg.js
+++ b/express/code/blocks/banner-bg/banner-bg.js
@@ -121,7 +121,7 @@ async function formatPhoneNumbers(block) {
   try {
     await formatSalesPhoneNumber(phoneTags);
   } catch (error) {
-    window.lana?.log(`Error formatting phone numbers: ${error.message}`, { clientId: 'express', tags: 'banner-bg', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error formatting phone numbers: ${error.message}`, { tags: 'banner-bg', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/banner-bg/banner-bg.js
+++ b/express/code/blocks/banner-bg/banner-bg.js
@@ -121,7 +121,7 @@ async function formatPhoneNumbers(block) {
   try {
     await formatSalesPhoneNumber(phoneTags);
   } catch (error) {
-    window.lana?.log('banner-bg.js - error formatting phone numbers:', error.message);
+    window.lana?.log(`Error formatting phone numbers: ${error.message}`, { clientId: 'express', tags: 'banner-bg', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/banner-bg/banner-bg.js
+++ b/express/code/blocks/banner-bg/banner-bg.js
@@ -121,7 +121,7 @@ async function formatPhoneNumbers(block) {
   try {
     await formatSalesPhoneNumber(phoneTags);
   } catch (error) {
-    window.lana?.log(`Error formatting phone numbers: ${error.message}`, { tags: 'banner-bg', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error formatting phone numbers: ${error.message}`, { tags: 'banner-bg', severity: 'error' });
   }
 }
 

--- a/express/code/blocks/banner/banner.js
+++ b/express/code/blocks/banner/banner.js
@@ -62,7 +62,7 @@ export default async function decorate(block) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
     } catch (error) {
-      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { tags: 'banner', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { tags: 'banner', severity: 'error' });
     }
   }
   fixIcons(block);

--- a/express/code/blocks/banner/banner.js
+++ b/express/code/blocks/banner/banner.js
@@ -62,7 +62,7 @@ export default async function decorate(block) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
     } catch (error) {
-      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { clientId: 'express', tags: 'banner', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { tags: 'banner', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   fixIcons(block);

--- a/express/code/blocks/banner/banner.js
+++ b/express/code/blocks/banner/banner.js
@@ -61,8 +61,8 @@ export default async function decorate(block) {
   if (phoneNumberTags.length > 0) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
-    } catch (e) {
-      window.lana?.log('banner.js - error fetching sales phones numbers:', e.message);
+    } catch (error) {
+      window.lana?.log(`Error fetching sales phones numbers: ${error.message}`, { clientId: 'express', tags: 'banner', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   fixIcons(block);

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.css
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.css
@@ -232,7 +232,7 @@ main .blog-posts-v2 .blog-hero-card .blog-card-image {
 
 main .blog-posts-v2 .blog-card .blog-card-image img {
   object-fit: cover;
-  height: 100%;
+  height: auto;
   width: 100%;
   border-radius: var(--spacing-300) var(--spacing-300) 0 0;
   aspect-ratio: 16 / 9;

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.css
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.css
@@ -231,6 +231,7 @@ main .blog-posts-v2 .blog-hero-card .blog-card-image {
 }
 
 main .blog-posts-v2 .blog-card .blog-card-image img {
+  display: block;
   object-fit: cover;
   height: auto;
   width: 100%;

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -149,7 +149,7 @@ function getSafeHrefFromText(text) {
       return url.href;
     }
   } catch (error) {
-    window.lana.log(`Failed to get href from text: ${error}`, { clientId: 'express', tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to get href from text: ${error}`, { tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
   return null;
@@ -285,7 +285,7 @@ async function filterAllBlogPostsOnPage() {
             locales.push(blogLocale);
           }
         } catch (error) {
-          window.lana?.log(`Invalid blog post URL: ${l.href}: ${error}`, { clientId: 'express', tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+          window.lana?.log(`Invalid blog post URL: ${l.href}: ${error}`, { tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
         }
       });
 

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -149,7 +149,7 @@ function getSafeHrefFromText(text) {
       return url.href;
     }
   } catch (error) {
-    window.lana?.log(`Failed to get href from text: ${error}`, { tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to get href from text: ${error}`, { tags: 'blog-posts-v2', severity: 'error' });
     return null;
   }
   return null;
@@ -285,7 +285,7 @@ async function filterAllBlogPostsOnPage() {
             locales.push(blogLocale);
           }
         } catch (error) {
-          window.lana?.log(`Invalid blog post URL: ${l.href}: ${error}`, { tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+          window.lana?.log(`Invalid blog post URL: ${l.href}: ${error}`, { tags: 'blog-posts-v2', severity: 'error' });
         }
       });
 

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -148,8 +148,8 @@ function getSafeHrefFromText(text) {
     if (url.protocol === 'http:' || url.protocol === 'https:') {
       return url.href;
     }
-  } catch (e) {
-    window.lana.log('Invalid URL', e);
+  } catch (error) {
+    window.lana.log(`Failed to get href from text: ${error}`, { clientId: 'express', tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
   return null;

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -284,8 +284,8 @@ async function filterAllBlogPostsOnPage() {
           if (!locales.includes(blogLocale)) {
             locales.push(blogLocale);
           }
-        } catch (e) {
-          window.lana?.log(`Invalid blog post URL: ${l.href}`, { tags: 'blog-posts-v2', errorType: 'e' });
+        } catch (error) {
+          window.lana?.log(`Invalid blog post URL: ${l.href}: ${error}`, { clientId: 'express', tags: 'blog-posts-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
         }
       });
 

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -799,7 +799,7 @@ export default async function decorate(comparisonBlock) {
       }
     });
   } catch (error) {
-    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', severity: 'error' });
+    window.lana?.log(`Failed to initialize comparison table: ${error}`, { clientId: 'express', tags: 'comparison-table-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -799,7 +799,7 @@ export default async function decorate(comparisonBlock) {
       }
     });
   } catch (error) {
-    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', severity: 'error' });
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }
 }

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -799,7 +799,7 @@ export default async function decorate(comparisonBlock) {
       }
     });
   } catch (error) {
-    window.lana?.log(`Failed to initialize comparison table: ${error}`, { clientId: 'express', tags: 'comparison-table-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to initialize comparison table: ${error}`, { tags: 'comparison-table-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
     comparisonBlock.innerHTML = '<p>Unable to load comparison table. Please refresh the page.</p>';
   }
 }

--- a/express/code/blocks/drawer-cards/drawer-cards.js
+++ b/express/code/blocks/drawer-cards/drawer-cards.js
@@ -179,7 +179,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to format dynamic cart link: ${error}`, { clientId: 'express', tags: 'drawer-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to format dynamic cart link: ${error}`, { tags: 'drawer-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/blocks/drawer-cards/drawer-cards.js
+++ b/express/code/blocks/drawer-cards/drawer-cards.js
@@ -179,7 +179,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana?.log(`Failed to format dynamic cart link: ${error}`, { tags: 'drawer-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to format dynamic cart link: ${error}`, { tags: 'drawer-cards', severity: 'error' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/blocks/drawer-cards/drawer-cards.js
+++ b/express/code/blocks/drawer-cards/drawer-cards.js
@@ -179,7 +179,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to format dynamic cart link: ${error}`, { clientId: 'express', tags: 'drawer-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/blocks/faq/faq.js
+++ b/express/code/blocks/faq/faq.js
@@ -74,7 +74,7 @@ export default async function decorate(block) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
     } catch (error) {
-      window.lana?.log(`Error fetching sales phones numbers: ${error}`, { tags: 'faq', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error fetching sales phones numbers: ${error}`, { tags: 'faq', severity: 'error' });
     }
   }
 }

--- a/express/code/blocks/faq/faq.js
+++ b/express/code/blocks/faq/faq.js
@@ -74,7 +74,7 @@ export default async function decorate(block) {
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
     } catch (error) {
-      window.lana?.log(`Error fetching sales phones numbers: ${error}`, { clientId: 'express', tags: 'faq', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error fetching sales phones numbers: ${error}`, { tags: 'faq', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 }

--- a/express/code/blocks/faq/faq.js
+++ b/express/code/blocks/faq/faq.js
@@ -73,8 +73,8 @@ export default async function decorate(block) {
     );
     try {
       await formatSalesPhoneNumber(phoneNumberTags);
-    } catch (e) {
-      window.lana?.log('faq.js - error fetching sales phones numbers:', e.message);
+    } catch (error) {
+      window.lana?.log(`Error fetching sales phones numbers: ${error}`, { clientId: 'express', tags: 'faq', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 }

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -435,7 +435,7 @@ export default async function decorate(block) {
               });
             }
           } catch (error) {
-            window.lana?.log(`faqv2 schema merge error: ${error?.message || error}`, { tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
+            window.lana?.log(`faqv2 schema merge error: ${error?.message || error}`, { tags: 'faqv2', severity: 'error' });
           }
         } else {
           const script = document.createElement('script');
@@ -450,7 +450,7 @@ export default async function decorate(block) {
         }
       }
     } catch (error) {
-      window.lana?.log(`faqv2 schema error: ${error?.message || error}`, { tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`faqv2 schema error: ${error?.message || error}`, { tags: 'faqv2', severity: 'error' });
     }
   }
 }

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -435,7 +435,7 @@ export default async function decorate(block) {
               });
             }
           } catch (error) {
-            window.lana?.log(`faqv2 schema merge error: ${error?.message || error}`, { clientId: 'express', tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
+            window.lana?.log(`faqv2 schema merge error: ${error?.message || error}`, { tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
           }
         } else {
           const script = document.createElement('script');
@@ -450,7 +450,7 @@ export default async function decorate(block) {
         }
       }
     } catch (error) {
-      window.lana?.log(`faqv2 schema error: ${error?.message || error}`, { clientId: 'express', tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`faqv2 schema error: ${error?.message || error}`, { tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 }

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -434,9 +434,8 @@ export default async function decorate(block) {
                 mainEntity: [...current, ...entities],
               });
             }
-          } catch (e2) {
-            // eslint-disable-next-line no-unused-expressions
-            window.lana?.log(`faqv2 schema merge error: ${e2?.message || e2}`);
+          } catch (error) {
+            window.lana?.log(`faqv2 schema merge error: ${error?.message || error}`, { clientId: 'express', tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
           }
         } else {
           const script = document.createElement('script');
@@ -450,9 +449,8 @@ export default async function decorate(block) {
           document.head.appendChild(script);
         }
       }
-    } catch (e) {
-      // eslint-disable-next-line no-unused-expressions
-      window.lana?.log(`faqv2 schema error: ${e?.message || e}`);
+    } catch (error) {
+      window.lana?.log(`faqv2 schema error: ${error?.message || error}`, { clientId: 'express', tags: 'faqv2', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 }

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -287,7 +287,11 @@ async function uploadAssetToStorage(file, quickAction, uploadStartTime) {
         + `uploadDuration:${uploadDuration}`,
       {
         clientId: 'express',
-        tags: 'frictionless-video-upload-success',
+        tags: 'frictionless-quick-action, frictionless-video-upload-success',
+        errorType: 'i',
+        severity: 'info',
+        sampleRate: '1',
+
       },
     );
   }
@@ -326,14 +330,14 @@ async function performStorageUpload(files, block, quickAction) {
           + `errorMessage:${error.message}`,
         {
           clientId: 'express',
-          tags: 'frictionless-video-upload-failed',
+          tags: 'frictionless-video-upload-failed, frictionless-quick-action',
+          errorType: 'e',
+          severity: 'error',
+          sampleRate: '1',
         },
       );
     }
-
-    // Clear upload state on failure
     uploadInProgress = null;
-
     return null;
   }
 }
@@ -346,7 +350,7 @@ async function startAssetDecoding(file, controller) {
   }).catch((error) => {
     window.lana?.log(
       `Asset decode failed error:${error.message || error}`,
-      { clientId: 'express', tags: 'frictionless-asset-decode-failed' },
+      { clientId: 'express', tags: 'frictionless-asset-decode-failed, frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' },
     );
     return null;
   }), 5000);
@@ -670,8 +674,8 @@ export default async function decorate(block) {
 
   // Load IMS if not already loaded
   if (!window.adobeIMS) {
-    try { await utils.loadIms(); } catch (e) {
-      window.lana?.log(`Unable to load IMS in frictionless-quick-action: ${e}`);
+    try { await utils.loadIms(); } catch (error) {
+      window.lana?.log(`Unable to load IMS in frictionless-quick-action: ${error?.message || error}`, { clientId: 'express', tags: 'frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   setupFrictionlessTargetBaseUrl(quickAction);
@@ -807,7 +811,10 @@ export default async function decorate(block) {
           + `uploadDuration:${uploadDuration}`,
         {
           clientId: 'express',
-          tags: 'frictionless-video-upload-cancelled',
+          tags: 'frictionless-quick-action, frictionless-video-upload-cancelled',
+          errorType: 'i',
+          severity: 'info',
+          sampleRate: '1',
         },
       );
       uploadInProgress = null;

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -350,7 +350,7 @@ async function startAssetDecoding(file, controller) {
   }).catch((error) => {
     window.lana?.log(
       `Asset decode failed error:${error.message || error}`,
-      { clientId: 'express', tags: 'frictionless-asset-decode-failed, frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' },
+      { tags: 'frictionless-asset-decode-failed, frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' },
     );
     return null;
   }), 5000);
@@ -675,7 +675,7 @@ export default async function decorate(block) {
   // Load IMS if not already loaded
   if (!window.adobeIMS) {
     try { await utils.loadIms(); } catch (error) {
-      window.lana?.log(`Unable to load IMS in frictionless-quick-action: ${error?.message || error}`, { clientId: 'express', tags: 'frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Unable to load IMS in frictionless-quick-action: ${error?.message || error}`, { tags: 'frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   setupFrictionlessTargetBaseUrl(quickAction);

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -290,7 +290,6 @@ async function uploadAssetToStorage(file, quickAction, uploadStartTime) {
         tags: 'frictionless-quick-action, frictionless-video-upload-success',
         errorType: 'i',
         severity: 'info',
-        sampleRate: '1',
 
       },
     );
@@ -331,9 +330,8 @@ async function performStorageUpload(files, block, quickAction) {
         {
           clientId: 'express',
           tags: 'frictionless-video-upload-failed, frictionless-quick-action',
-          errorType: 'e',
           severity: 'error',
-          sampleRate: '1',
+
         },
       );
     }
@@ -350,7 +348,7 @@ async function startAssetDecoding(file, controller) {
   }).catch((error) => {
     window.lana?.log(
       `Asset decode failed error:${error.message || error}`,
-      { tags: 'frictionless-asset-decode-failed, frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' },
+      { tags: 'frictionless-asset-decode-failed, frictionless-quick-action', severity: 'error' },
     );
     return null;
   }), 5000);
@@ -675,7 +673,7 @@ export default async function decorate(block) {
   // Load IMS if not already loaded
   if (!window.adobeIMS) {
     try { await utils.loadIms(); } catch (error) {
-      window.lana?.log(`Unable to load IMS in frictionless-quick-action: ${error?.message || error}`, { tags: 'frictionless-quick-action', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Unable to load IMS in frictionless-quick-action: ${error?.message || error}`, { tags: 'frictionless-quick-action', severity: 'error' });
     }
   }
   setupFrictionlessTargetBaseUrl(quickAction);
@@ -814,7 +812,7 @@ export default async function decorate(block) {
           tags: 'frictionless-quick-action, frictionless-video-upload-cancelled',
           errorType: 'i',
           severity: 'info',
-          sampleRate: '1',
+
         },
       );
       uploadInProgress = null;

--- a/express/code/blocks/headline/headline.js
+++ b/express/code/blocks/headline/headline.js
@@ -15,7 +15,7 @@ export default async function init(el) {
     });
     cfg?.remove();
   } catch (error) {
-    window.lana?.log(`${error?.message || error}`, { clientId: 'express', tags: 'headline', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`${error?.message || error}`, { tags: 'headline', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   if (document.querySelector('.headline:first-of-type') === el && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
     const logo = getIconElementDeprecated('adobe-express-logo');

--- a/express/code/blocks/headline/headline.js
+++ b/express/code/blocks/headline/headline.js
@@ -15,7 +15,7 @@ export default async function init(el) {
     });
     cfg?.remove();
   } catch (error) {
-    window.lana?.log(`${error?.message || error}`, { tags: 'headline', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`${error?.message || error}`, { tags: 'headline', severity: 'error' });
   }
   if (document.querySelector('.headline:first-of-type') === el && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
     const logo = getIconElementDeprecated('adobe-express-logo');

--- a/express/code/blocks/headline/headline.js
+++ b/express/code/blocks/headline/headline.js
@@ -14,8 +14,8 @@ export default async function init(el) {
       heading.style[key] = value;
     });
     cfg?.remove();
-  } catch (e) {
-    window.lana?.log(e);
+  } catch (error) {
+    window.lana?.log(`${error?.message || error}`, { clientId: 'express', tags: 'headline', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   if (document.querySelector('.headline:first-of-type') === el && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
     const logo = getIconElementDeprecated('adobe-express-logo');

--- a/express/code/blocks/how-to-v3/how-to-v3.js
+++ b/express/code/blocks/how-to-v3/how-to-v3.js
@@ -156,7 +156,7 @@ export default function decorate(block) {
         }
       }
     } catch (error) {
-      window.lana?.log(`how-to-v3 schema error: ${error?.message || error}`, { tags: 'how-to-v3', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`how-to-v3 schema error: ${error?.message || error}`, { tags: 'how-to-v3', severity: 'error' });
     }
   }
 }

--- a/express/code/blocks/how-to-v3/how-to-v3.js
+++ b/express/code/blocks/how-to-v3/how-to-v3.js
@@ -156,7 +156,7 @@ export default function decorate(block) {
         }
       }
     } catch (error) {
-      window.lana?.log(`how-to-v3 schema error: ${error?.message || error}`, { clientId: 'express', tags: 'how-to-v3', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`how-to-v3 schema error: ${error?.message || error}`, { tags: 'how-to-v3', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 }

--- a/express/code/blocks/how-to-v3/how-to-v3.js
+++ b/express/code/blocks/how-to-v3/how-to-v3.js
@@ -155,9 +155,8 @@ export default function decorate(block) {
           document.head.appendChild(script);
         }
       }
-    } catch (e) {
-      // eslint-disable-next-line no-unused-expressions
-      window.lana?.log(`how-to-v3 schema error: ${e?.message || e}`);
+    } catch (error) {
+      window.lana?.log(`how-to-v3 schema error: ${error?.message || error}`, { clientId: 'express', tags: 'how-to-v3', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
 }

--- a/express/code/blocks/interactive-marquee/interactive-marquee.js
+++ b/express/code/blocks/interactive-marquee/interactive-marquee.js
@@ -180,7 +180,7 @@ function interactiveInit(el) {
 
 export default async function init(el) {
   if (!el.classList.contains('horizontal-masonry')) {
-    window.lana?.log('Using interactive-marquee on Express requires using the horizontal-masonry class.', { tags: 'interactive-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log('Using interactive-marquee on Express requires using the horizontal-masonry class.', { tags: 'interactive-marquee', severity: 'error' });
     return;
   }
   await Promise.all([import(`${getLibs()}/utils/utils.js`), import(`${getLibs()}/features/placeholders.js`), import(`${getLibs()}/utils/decorate.js`)]).then(([utils, placeholders, decorate]) => {

--- a/express/code/blocks/interactive-marquee/interactive-marquee.js
+++ b/express/code/blocks/interactive-marquee/interactive-marquee.js
@@ -180,7 +180,7 @@ function interactiveInit(el) {
 
 export default async function init(el) {
   if (!el.classList.contains('horizontal-masonry')) {
-    window.lana?.log('Using interactive-marquee on Express requires using the horizontal-masonry class.', { clientId: 'express', tags: 'interactive-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log('Using interactive-marquee on Express requires using the horizontal-masonry class.', { tags: 'interactive-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
     return;
   }
   await Promise.all([import(`${getLibs()}/utils/utils.js`), import(`${getLibs()}/features/placeholders.js`), import(`${getLibs()}/utils/decorate.js`)]).then(([utils, placeholders, decorate]) => {

--- a/express/code/blocks/interactive-marquee/interactive-marquee.js
+++ b/express/code/blocks/interactive-marquee/interactive-marquee.js
@@ -180,7 +180,7 @@ function interactiveInit(el) {
 
 export default async function init(el) {
   if (!el.classList.contains('horizontal-masonry')) {
-    window.lana?.log('Using interactive-marquee on Express requires using the horizontal-masonry class.');
+    window.lana?.log('Using interactive-marquee on Express requires using the horizontal-masonry class.', { clientId: 'express', tags: 'interactive-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
     return;
   }
   await Promise.all([import(`${getLibs()}/utils/utils.js`), import(`${getLibs()}/features/placeholders.js`), import(`${getLibs()}/utils/decorate.js`)]).then(([utils, placeholders, decorate]) => {

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -94,7 +94,7 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
       }
     });
   } catch (error) {
-    window.lana.log(`Failed to handle-pricing-token: ${error}`, { clientId: 'express', tags: 'pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle-pricing-token: ${error}`, { tags: 'pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -93,8 +93,8 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
         p.innerHTML = p.innerHTML.replaceAll(priceToken, '');
       }
     });
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle-pricing-token: ${error}`, { clientId: 'express', tags: 'pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -94,7 +94,7 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
       }
     });
   } catch (error) {
-    window.lana?.log(`Failed to handle-pricing-token: ${error}`, { tags: 'pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle-pricing-token: ${error}`, { tags: 'pricing-cards-v2', severity: 'error' });
   }
 }
 

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -217,7 +217,7 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
       year2PricingToken.textContent = '';
     }
   } catch (error) {
-    window.lana.log(`Failed to handle pricing token: ${error}`, { clientId: 'express', tags: 'pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle pricing token: ${error}`, { tags: 'pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -217,7 +217,7 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
       year2PricingToken.textContent = '';
     }
   } catch (error) {
-    window.lana?.log(`Failed to handle pricing token: ${error}`, { tags: 'pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle pricing token: ${error}`, { tags: 'pricing-cards', severity: 'error' });
   }
 }
 

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -216,8 +216,8 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
     } else {
       year2PricingToken.textContent = '';
     }
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle pricing token: ${error}`, { clientId: 'express', tags: 'pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
+++ b/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
@@ -24,7 +24,7 @@ export default async function fetchAPIData(productId, parameters, endpoint, idTy
   try {
     apiDataFetch = await fetch(formatUrlForEnvironment(url));
   } catch (error) {
-    window.lana.log('Error fetching product details: ', { error }, { tags: 'print-product-detail', severity: 'error' });
+    window.lana.log(`Failed to fetch product details: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   const apiDataJSON = await apiDataFetch.json();
   const apiData = apiDataJSON.data;

--- a/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
+++ b/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
@@ -24,7 +24,7 @@ export default async function fetchAPIData(productId, parameters, endpoint, idTy
   try {
     apiDataFetch = await fetch(formatUrlForEnvironment(url));
   } catch (error) {
-    window.lana.log(`Failed to fetch product details: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch product details: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   const apiDataJSON = await apiDataFetch.json();
   const apiData = apiDataJSON.data;

--- a/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
+++ b/express/code/blocks/print-product-detail/fetchData/fetchProductDetails.js
@@ -24,7 +24,7 @@ export default async function fetchAPIData(productId, parameters, endpoint, idTy
   try {
     apiDataFetch = await fetch(formatUrlForEnvironment(url));
   } catch (error) {
-    window.lana?.log(`Failed to fetch product details: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch product details: ${error}`, { tags: 'print-product-detail', severity: 'error' });
   }
   const apiDataJSON = await apiDataFetch.json();
   const apiData = apiDataJSON.data;

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -204,12 +204,12 @@ export default async function decorate(block) {
       link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
       head.appendChild(link);
     } catch (error) {
-      window.lana?.log(`Failed to preload hero image on PDP Page: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+      window.lana?.log(`Failed to preload hero image on PDP Page: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
     }
     try {
       document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
     } catch (error) {
-      window.lana?.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+      window.lana?.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
     }
     updatePageWithProductDetails(dataObject, globalContainer);
     // SEO: title/description (respect authored), initial Product JSON-LD
@@ -273,7 +273,7 @@ export default async function decorate(block) {
         true,
       );
     } catch (error) {
-      window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+      window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
     }
   });
 }

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -204,18 +204,12 @@ export default async function decorate(block) {
       link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
       head.appendChild(link);
     } catch (error) {
-      window.lana.log(`Failed to preload hero image on PDP Page: ${error}`, {
-        severity: 'warning',
-        tags: 'print-product-detail',
-      });
+      window.lana.log(`Failed to preload hero image on PDP Page: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
     try {
       document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
     } catch (error) {
-      window.lana.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, {
-        severity: 'warning',
-        tags: 'print-product-detail',
-      });
+      window.lana.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
     updatePageWithProductDetails(dataObject, globalContainer);
     // SEO: title/description (respect authored), initial Product JSON-LD
@@ -279,10 +273,7 @@ export default async function decorate(block) {
         true,
       );
     } catch (error) {
-      window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, {
-        severity: 'warning',
-        tags: 'print-product-detail, analytics',
-      });
+      window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
   });
 }

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -204,12 +204,12 @@ export default async function decorate(block) {
       link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
       head.appendChild(link);
     } catch (error) {
-      window.lana.log(`Failed to preload hero image on PDP Page: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+      window.lana?.log(`Failed to preload hero image on PDP Page: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
     try {
       document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
     } catch (error) {
-      window.lana.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+      window.lana?.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
     updatePageWithProductDetails(dataObject, globalContainer);
     // SEO: title/description (respect authored), initial Product JSON-LD
@@ -273,7 +273,7 @@ export default async function decorate(block) {
         true,
       );
     } catch (error) {
-      window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+      window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
     }
   });
 }

--- a/express/code/blocks/print-product-detail/print-product-detail.js
+++ b/express/code/blocks/print-product-detail/print-product-detail.js
@@ -204,12 +204,12 @@ export default async function decorate(block) {
       link.setAttribute('imagesizes', '(max-width: 600px) 100vw, 50vw');
       head.appendChild(link);
     } catch (error) {
-      window.lana?.log(`Failed to preload hero image on PDP Page: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
+      window.lana?.log(`Failed to preload hero image on PDP Page: ${error}`, { tags: 'print-product-detail', severity: 'warning' });
     }
     try {
       document.querySelector('meta[property="og:image"]').content = dataObject.heroImage;
     } catch (error) {
-      window.lana?.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
+      window.lana?.log(`Failed to update meta[property="og:image"] value on PDP Page: ${error}`, { tags: 'print-product-detail', severity: 'warning' });
     }
     updatePageWithProductDetails(dataObject, globalContainer);
     // SEO: title/description (respect authored), initial Product JSON-LD
@@ -273,7 +273,7 @@ export default async function decorate(block) {
         true,
       );
     } catch (error) {
-      window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
+      window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', severity: 'warning' });
     }
   });
 }

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -23,7 +23,7 @@ try {
   utils = await import(`${getLibs()}/utils/utils.js`);
   ({ createTag, getConfig, loadStyle } = utils);
 } catch (error) {
-  window.lana?.log('Failed to load utils:', error, { tags: 'quotes', errorType: 'e', severity: 'error', sampleRate: '1' });
+  window.lana?.log('Failed to load utils:', error, { tags: 'quotes', severity: 'error' });
   throw error;
 }
 

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -23,7 +23,7 @@ try {
   utils = await import(`${getLibs()}/utils/utils.js`);
   ({ createTag, getConfig, loadStyle } = utils);
 } catch (error) {
-  window.lana?.log('Failed to load utils:', error, { clientId: 'express', tags: 'quotes', errorType: 'e', severity: 'error', sampleRate: '1' });
+  window.lana?.log('Failed to load utils:', error, { tags: 'quotes', errorType: 'e', severity: 'error', sampleRate: '1' });
   throw error;
 }
 

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -23,7 +23,7 @@ try {
   utils = await import(`${getLibs()}/utils/utils.js`);
   ({ createTag, getConfig, loadStyle } = utils);
 } catch (error) {
-  window.lana?.log('Failed to load utils:', error, { tags: 'ax quotes' });
+  window.lana?.log('Failed to load utils:', error, { clientId: 'express', tags: 'quotes', errorType: 'e', severity: 'error', sampleRate: '1' });
   throw error;
 }
 

--- a/express/code/blocks/ratings/ratings.js
+++ b/express/code/blocks/ratings/ratings.js
@@ -356,10 +356,10 @@ export default async function decorate(block) {
       if (stars && stars instanceof Node) {
         headingWrapper.appendChild(stars);
       } else {
-        window.lana?.log('Invalid stars element returned from getCurrentRatingStars', { tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
+        window.lana?.log('Invalid stars element returned from getCurrentRatingStars', { tags: 'ratings', severity: 'error' });
       }
     } catch (error) {
-      window.lana?.log(`Error creating rating stars: ${error?.message || error}`, { tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error creating rating stars: ${error?.message || error}`, { tags: 'ratings', severity: 'error' });
     }
     block.appendChild(headingWrapper);
     const textAndCTA = createTag('div', { class: 'no-slider' });

--- a/express/code/blocks/ratings/ratings.js
+++ b/express/code/blocks/ratings/ratings.js
@@ -356,10 +356,10 @@ export default async function decorate(block) {
       if (stars && stars instanceof Node) {
         headingWrapper.appendChild(stars);
       } else {
-        window.lana?.log('Invalid stars element returned from getCurrentRatingStars', { clientId: 'express', tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
+        window.lana?.log('Invalid stars element returned from getCurrentRatingStars', { tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
       }
     } catch (error) {
-      window.lana?.log(`Error creating rating stars: ${error?.message || error}`, { clientId: 'express', tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error creating rating stars: ${error?.message || error}`, { tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
     block.appendChild(headingWrapper);
     const textAndCTA = createTag('div', { class: 'no-slider' });

--- a/express/code/blocks/ratings/ratings.js
+++ b/express/code/blocks/ratings/ratings.js
@@ -356,10 +356,10 @@ export default async function decorate(block) {
       if (stars && stars instanceof Node) {
         headingWrapper.appendChild(stars);
       } else {
-        window.lana?.log('Invalid stars element returned from getCurrentRatingStars', { tags: 'ratings' });
+        window.lana?.log('Invalid stars element returned from getCurrentRatingStars', { clientId: 'express', tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
       }
     } catch (error) {
-      window.lana?.log('Error creating rating stars:', error, { tags: 'ratings' });
+      window.lana?.log(`Error creating rating stars: ${error?.message || error}`, { clientId: 'express', tags: 'ratings', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
     block.appendChild(headingWrapper);
     const textAndCTA = createTag('div', { class: 'no-slider' });

--- a/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
+++ b/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
@@ -96,7 +96,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
       year2PricingToken.remove();
     }
   } catch (error) {
-    window.lana?.log(`Failed to handle year 2 pricing token: ${error}`, { tags: 'simplified-pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle year 2 pricing token: ${error}`, { tags: 'simplified-pricing-cards-v2', severity: 'error' });
   }
 }
 

--- a/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
+++ b/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
@@ -96,7 +96,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
       year2PricingToken.remove();
     }
   } catch (error) {
-    window.lana.log(`Failed to handle year 2 pricing token: ${error}`, { clientId: 'express', tags: 'simplified-pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle year 2 pricing token: ${error}`, { tags: 'simplified-pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
+++ b/express/code/blocks/simplified-pricing-cards-v2/simplified-pricing-cards-v2.js
@@ -95,8 +95,8 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
     } else {
       year2PricingToken.remove();
     }
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle year 2 pricing token: ${error}`, { clientId: 'express', tags: 'simplified-pricing-cards-v2', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -69,8 +69,8 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
     } else {
       year2PricingToken.textContent = '';
     }
-  } catch (e) {
-    window.lana.log(e);
+  } catch (error) {
+    window.lana.log(`Failed to handle year 2 pricing token: ${error}`, { clientId: 'express', tags: 'simplified-pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -70,7 +70,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
       year2PricingToken.textContent = '';
     }
   } catch (error) {
-    window.lana?.log(`Failed to handle year 2 pricing token: ${error}`, { tags: 'simplified-pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle year 2 pricing token: ${error}`, { tags: 'simplified-pricing-cards', severity: 'error' });
   }
 }
 

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -70,7 +70,7 @@ function handleYear2PricingToken(pricingArea, y2p, priceSuffix) {
       year2PricingToken.textContent = '';
     }
   } catch (error) {
-    window.lana.log(`Failed to handle year 2 pricing token: ${error}`, { clientId: 'express', tags: 'simplified-pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to handle year 2 pricing token: ${error}`, { tags: 'simplified-pricing-cards', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -28,12 +28,12 @@ const onRedirect = (e) => {
     window.location.assign(e.detail);
   }, 100);
 };
-const onError = (e) => {
-  window.lana?.log('on error:', e);
+const onError = (error) => {
+  window.lana?.log(`on error: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light', errorType: 'e', severity: 'error', sampleRate: '1' });
 };
 
-const onAuthFailed = (e) => {
-  window.lana?.log(`on auth failed: ${e.detail}`);
+const onAuthFailed = (error) => {
+  window.lana?.log(`on auth failed: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light, susi-auth-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
 };
 // easier to mock in unit test
 export const SUSIUtils = {
@@ -51,8 +51,8 @@ async function getDestURL(url) {
   try {
     const appended = await getTrackingAppendedURL(url);
     destURL = new URL(appended);
-  } catch (err) {
-    window.lana?.log(`invalid redirect uri for susi-light: ${url}`);
+  } catch (error) {
+    window.lana?.log(`invalid redirect uri for susi-light: ${url}: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light, susi-invalid-redirect-uri', errorType: 'e', severity: 'error', sampleRate: '1' });
     destURL = new URL('https://new.express.adobe.com');
   }
   if (isStage) {
@@ -148,7 +148,9 @@ function redirectIfLoggedIn(destURL) {
         /* c8 ignore next */
         window.adobeIMS?.isSignedInUser() && goDest();
       })
-      .catch((e) => { window.lana?.log(`Unable to load IMS in susi-light: ${e}`); });
+      .catch((error) => {
+        window.lana?.log(`Unable to load IMS in susi-light: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light, susi-load-ims-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
+      });
   }
 }
 

--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -29,11 +29,11 @@ const onRedirect = (e) => {
   }, 100);
 };
 const onError = (error) => {
-  window.lana?.log(`on error: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light', errorType: 'e', severity: 'error', sampleRate: '1' });
+  window.lana?.log(`on error: ${error?.message || error?.detail || error}`, { tags: 'susi-light', errorType: 'e', severity: 'error', sampleRate: '1' });
 };
 
 const onAuthFailed = (error) => {
-  window.lana?.log(`on auth failed: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light, susi-auth-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
+  window.lana?.log(`on auth failed: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-auth-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
 };
 // easier to mock in unit test
 export const SUSIUtils = {
@@ -52,7 +52,7 @@ async function getDestURL(url) {
     const appended = await getTrackingAppendedURL(url);
     destURL = new URL(appended);
   } catch (error) {
-    window.lana?.log(`invalid redirect uri for susi-light: ${url}: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light, susi-invalid-redirect-uri', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`invalid redirect uri for susi-light: ${url}: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-invalid-redirect-uri', errorType: 'e', severity: 'error', sampleRate: '1' });
     destURL = new URL('https://new.express.adobe.com');
   }
   if (isStage) {
@@ -149,7 +149,7 @@ function redirectIfLoggedIn(destURL) {
         window.adobeIMS?.isSignedInUser() && goDest();
       })
       .catch((error) => {
-        window.lana?.log(`Unable to load IMS in susi-light: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'susi-light, susi-load-ims-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
+        window.lana?.log(`Unable to load IMS in susi-light: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-load-ims-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
       });
   }
 }

--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -29,11 +29,11 @@ const onRedirect = (e) => {
   }, 100);
 };
 const onError = (error) => {
-  window.lana?.log(`on error: ${error?.message || error?.detail || error}`, { tags: 'susi-light', errorType: 'e', severity: 'error', sampleRate: '1' });
+  window.lana?.log(`on error: ${error?.message || error?.detail || error}`, { tags: 'susi-light', severity: 'error' });
 };
 
 const onAuthFailed = (error) => {
-  window.lana?.log(`on auth failed: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-auth-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
+  window.lana?.log(`on auth failed: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-auth-failed', severity: 'error' });
 };
 // easier to mock in unit test
 export const SUSIUtils = {
@@ -52,7 +52,7 @@ async function getDestURL(url) {
     const appended = await getTrackingAppendedURL(url);
     destURL = new URL(appended);
   } catch (error) {
-    window.lana?.log(`invalid redirect uri for susi-light: ${url}: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-invalid-redirect-uri', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`invalid redirect uri for susi-light: ${url}: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-invalid-redirect-uri', severity: 'error' });
     destURL = new URL('https://new.express.adobe.com');
   }
   if (isStage) {
@@ -149,7 +149,7 @@ function redirectIfLoggedIn(destURL) {
         window.adobeIMS?.isSignedInUser() && goDest();
       })
       .catch((error) => {
-        window.lana?.log(`Unable to load IMS in susi-light: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-load-ims-failed', errorType: 'e', severity: 'error', sampleRate: '1' });
+        window.lana?.log(`Unable to load IMS in susi-light: ${error?.message || error?.detail || error}`, { tags: 'susi-light, susi-load-ims-failed', severity: 'error' });
       });
   }
 }

--- a/express/code/blocks/template-promo-carousel/template-promo-carousel.js
+++ b/express/code/blocks/template-promo-carousel/template-promo-carousel.js
@@ -101,7 +101,7 @@ export default async function init(el, { premiumTagsElements, imageElements, tem
     el.append(templatesContainer);
     el.append(galleryControl);
   } catch (error) {
-    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-promo-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { tags: 'template-promo-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-promo-carousel/template-promo-carousel.js
+++ b/express/code/blocks/template-promo-carousel/template-promo-carousel.js
@@ -100,8 +100,8 @@ export default async function init(el, { premiumTagsElements, imageElements, tem
 
     el.append(templatesContainer);
     el.append(galleryControl);
-  } catch (err) {
-    window.lana?.log(`Error in template-x-carousel-toolbar: ${err}`);
+  } catch (error) {
+    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-promo-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-promo-carousel/template-promo-carousel.js
+++ b/express/code/blocks/template-promo-carousel/template-promo-carousel.js
@@ -101,7 +101,7 @@ export default async function init(el, { premiumTagsElements, imageElements, tem
     el.append(templatesContainer);
     el.append(galleryControl);
   } catch (error) {
-    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { tags: 'template-promo-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { tags: 'template-promo-carousel', severity: 'error' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
@@ -267,7 +267,7 @@ export default async function init(el) {
 
     el.append(templatesContainer);
   } catch (error) {
-    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { tags: 'template-x-carousel-toolbar', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { tags: 'template-x-carousel-toolbar', severity: 'error' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
@@ -267,7 +267,7 @@ export default async function init(el) {
 
     el.append(templatesContainer);
   } catch (error) {
-    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-x-carousel-toolbar', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { tags: 'template-x-carousel-toolbar', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
@@ -266,8 +266,8 @@ export default async function init(el) {
     toolbar.append(controlsContainer);
 
     el.append(templatesContainer);
-  } catch (err) {
-    window.lana?.log(`Error in template-x-carousel-toolbar: ${err}`);
+  } catch (error) {
+    window.lana?.log(`Error in template-x-carousel-toolbar: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-x-carousel-toolbar', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -103,7 +103,7 @@ async function renderTemplates(el, recipe, toolbar, isPanel = false, queryParams
 
     el.append(templatesContainer);
   } catch (error) {
-    window.lana?.log(`Error in template-x-carousel: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-x-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error in template-x-carousel: ${error?.message || error?.detail || error}`, { tags: 'template-x-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -103,7 +103,7 @@ async function renderTemplates(el, recipe, toolbar, isPanel = false, queryParams
 
     el.append(templatesContainer);
   } catch (error) {
-    window.lana?.log(`Error in template-x-carousel: ${error?.message || error?.detail || error}`, { tags: 'template-x-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error in template-x-carousel: ${error?.message || error?.detail || error}`, { tags: 'template-x-carousel', severity: 'error' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x-carousel/template-x-carousel.js
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.js
@@ -102,8 +102,8 @@ async function renderTemplates(el, recipe, toolbar, isPanel = false, queryParams
     toolbar.append(controlsContainer);
 
     el.append(templatesContainer);
-  } catch (err) {
-    window.lana?.log(`Error in template-x-carousel: ${err}`);
+  } catch (error) {
+    window.lana?.log(`Error in template-x-carousel: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-x-carousel', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       el.remove();
     } else {

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1359,7 +1359,7 @@ async function decorateToolbar(block, props) {
     const gnavHeight = getGnavHeight();
     tBarWrapper.style.top = `${gnavHeight}px`;
   } catch (error) {
-    window.lana?.log(`Error getting gnav height: ${error?.message || error?.detail || error}`, { tags: 'template-x', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error getting gnav height: ${error?.message || error?.detail || error}`, { tags: 'template-x', severity: 'error' });
   }
 
   tBarWrapper.append(tBar);
@@ -1872,7 +1872,7 @@ async function buildTemplateList(block, props, type = []) {
 
     await decorateTemplates(block, props);
   } else {
-    window.lana?.log(`failed to load templates with props: ${JSON.stringify(props)}`, { tags: 'template-x, templates-api', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`failed to load templates with props: ${JSON.stringify(props)}`, { tags: 'template-x, templates-api', severity: 'error' });
     if (getConfig().env.name === 'prod') {
       block.remove();
     } else {

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1359,7 +1359,7 @@ async function decorateToolbar(block, props) {
     const gnavHeight = getGnavHeight();
     tBarWrapper.style.top = `${gnavHeight}px`;
   } catch (error) {
-    window.lana?.log(`Error getting gnav height: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-x', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error getting gnav height: ${error?.message || error?.detail || error}`, { tags: 'template-x', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 
   tBarWrapper.append(tBar);
@@ -1872,7 +1872,7 @@ async function buildTemplateList(block, props, type = []) {
 
     await decorateTemplates(block, props);
   } else {
-    window.lana.log(`failed to load templates with props: ${JSON.stringify(props)}`, { clientId: 'express', tags: 'template-x, templates-api', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`failed to load templates with props: ${JSON.stringify(props)}`, { tags: 'template-x, templates-api', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       block.remove();
     } else {

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1872,8 +1872,7 @@ async function buildTemplateList(block, props, type = []) {
 
     await decorateTemplates(block, props);
   } else {
-    window.lana.log(`failed to load templates with props: ${JSON.stringify(props)}`, { tags: 'templates-api' });
-
+    window.lana.log(`failed to load templates with props: ${JSON.stringify(props)}`, { clientId: 'express', tags: 'template-x, templates-api', errorType: 'e', severity: 'error', sampleRate: '1' });
     if (getConfig().env.name === 'prod') {
       block.remove();
     } else {

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1358,8 +1358,8 @@ async function decorateToolbar(block, props) {
     const { getGnavHeight } = await import(`${getLibs()}/blocks/global-navigation/utilities/utilities.js`);
     const gnavHeight = getGnavHeight();
     tBarWrapper.style.top = `${gnavHeight}px`;
-  } catch (e) {
-    window.lana?.log(`Error getting gnav height ${e}`);
+  } catch (error) {
+    window.lana?.log(`Error getting gnav height: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'template-x', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 
   tBarWrapper.append(tBar);

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -744,7 +744,7 @@ async function initializeDependencies() {
       getMetadata: utils.getMetadata,
     };
   } catch (error) {
-    window.lana?.log(`TOC: Failed to initialize dependencies: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`TOC: Failed to initialize dependencies: ${error?.message || error?.detail || error}`, { tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
     throw new Error('Failed to load required utilities');
   }
 }
@@ -804,7 +804,7 @@ export default async function decorate(block) {
     if (startElement) {
       startElement.insertAdjacentElement('afterend', container);
     } else {
-      window.lana?.log('TOC: No start element found', { clientId: 'express', tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log('TOC: No start element found', { tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
 
     // Phase 7: Insert floating button and setup behavior (mobile/tablet only)
@@ -847,7 +847,7 @@ export default async function decorate(block) {
     // Hide original block
     block.style.display = 'none';
   } catch (error) {
-    window.lana?.log(`TOC: Error during decoration: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`TOC: Error during decoration: ${error?.message || error?.detail || error}`, { tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
     block.style.display = 'none';
   }
 }

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -744,7 +744,7 @@ async function initializeDependencies() {
       getMetadata: utils.getMetadata,
     };
   } catch (error) {
-    window.lana?.log(`TOC: Failed to initialize dependencies: ${error?.message || error?.detail || error}`, { tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`TOC: Failed to initialize dependencies: ${error?.message || error?.detail || error}`, { tags: 'toc-seo', severity: 'error' });
     throw new Error('Failed to load required utilities');
   }
 }
@@ -804,7 +804,7 @@ export default async function decorate(block) {
     if (startElement) {
       startElement.insertAdjacentElement('afterend', container);
     } else {
-      window.lana?.log('TOC: No start element found', { tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log('TOC: No start element found', { tags: 'toc-seo', severity: 'error' });
     }
 
     // Phase 7: Insert floating button and setup behavior (mobile/tablet only)
@@ -847,7 +847,7 @@ export default async function decorate(block) {
     // Hide original block
     block.style.display = 'none';
   } catch (error) {
-    window.lana?.log(`TOC: Error during decoration: ${error?.message || error?.detail || error}`, { tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`TOC: Error during decoration: ${error?.message || error?.detail || error}`, { tags: 'toc-seo', severity: 'error' });
     block.style.display = 'none';
   }
 }

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -744,7 +744,7 @@ async function initializeDependencies() {
       getMetadata: utils.getMetadata,
     };
   } catch (error) {
-    window.lana?.log(`TOC: Failed to initialize dependencies: ${error}`, { tags: 'toc-seo', severity: 'error' });
+    window.lana?.log(`TOC: Failed to initialize dependencies: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
     throw new Error('Failed to load required utilities');
   }
 }
@@ -804,7 +804,7 @@ export default async function decorate(block) {
     if (startElement) {
       startElement.insertAdjacentElement('afterend', container);
     } else {
-      window.lana?.log('TOC: No start element found', { tags: 'toc-seo', severity: 'error' });
+      window.lana?.log('TOC: No start element found', { clientId: 'express', tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
 
     // Phase 7: Insert floating button and setup behavior (mobile/tablet only)
@@ -847,7 +847,7 @@ export default async function decorate(block) {
     // Hide original block
     block.style.display = 'none';
   } catch (error) {
-    window.lana?.log(`TOC: Error during decoration: ${error}`, { tags: 'toc-seo', severity: 'error' });
+    window.lana?.log(`TOC: Error during decoration: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'toc-seo', errorType: 'e', severity: 'error', sampleRate: '1' });
     block.style.display = 'none';
   }
 }

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -75,8 +75,8 @@ export default async function loadDelayed() {
     turnContentLinksIntoButtons();
     preloadSUSILight();
     return null;
-  } catch (err) {
-    window.lana?.log(`Express-Delayed Error: ${err}`);
+  } catch (error) {
+    window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'express-delayed', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -76,7 +76,7 @@ export default async function loadDelayed() {
     preloadSUSILight();
     return null;
   } catch (error) {
-    window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'express-delayed', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { tags: 'express-delayed', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -76,7 +76,7 @@ export default async function loadDelayed() {
     preloadSUSILight();
     return null;
   } catch (error) {
-    window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { tags: 'express-delayed', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { tags: 'express-delayed', severity: 'error' });
     return null;
   }
 }

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -248,7 +248,7 @@ export async function trackViewTemplatePage(
   try {
     safelyFireAnalyticsEvent(fireEvent);
   } catch (error) {
-    window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+    window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
   }
 }
 

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -248,7 +248,7 @@ export async function trackViewTemplatePage(
   try {
     safelyFireAnalyticsEvent(fireEvent);
   } catch (error) {
-    window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', severity: 'warning', });
+    window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', severity: 'warning' });
   }
 }
 

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -248,7 +248,7 @@ export async function trackViewTemplatePage(
   try {
     safelyFireAnalyticsEvent(fireEvent);
   } catch (error) {
-    window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
+    window.lana?.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -248,10 +248,7 @@ export async function trackViewTemplatePage(
   try {
     safelyFireAnalyticsEvent(fireEvent);
   } catch (error) {
-    window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, {
-      severity: 'warning',
-      tags: 'print-product-detail, analytics',
-    });
+    window.lana.log(`Failed to track PDP pageload using _satellite.track: ${error}`, { clientId: 'express', tags: 'print-product-detail', errorType: 'e', severity: 'warning', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -167,7 +167,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'grid-marquee, ace1057', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'grid-marquee, ace1057', severity: 'error' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -167,7 +167,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'grid-marquee, ace1057', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'grid-marquee, ace1057', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -167,7 +167,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'grid-marquee, ace1057', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
@@ -187,7 +187,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'grid-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'grid-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
@@ -187,7 +187,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'grid-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/aexg5198/grid-marquee/grid-marquee.js
@@ -187,7 +187,7 @@ async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'grid-marquee', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'grid-marquee', severity: 'error' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/upload-service/src/upload-service/UploadService.ts
+++ b/express/code/scripts/upload-service/src/upload-service/UploadService.ts
@@ -533,7 +533,6 @@ export class UploadService {
     }), {
       clientId: 'express',
       sampleRate: 100,
-      errorType: 'e',
       severity: 'error',
       tags: 'upload-service',
     });

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -359,8 +359,8 @@ export async function decorateButtonsDeprecated(el, size) {
           }
         }
       }
-    } catch (e) {
-      window.lana?.log(`Ignoring button due to error: ${e}`);
+    } catch (error) {
+      window.lana?.log(`Ignoring button due to error: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   });
 }
@@ -471,8 +471,8 @@ export function preDecorateSections(area) {
       let linkToTargetURL = null;
       try {
         linkToTargetURL = new URL(linkToTarget);
-      } catch (err) {
-        window.lana?.log(err);
+      } catch (error) {
+        window.lana?.log(`${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
       }
       const sameUrlCTAs = Array.from(area.querySelectorAll('a:any-link'))
         .filter((a) => {
@@ -486,8 +486,8 @@ export function preDecorateSections(area) {
 
             return (sameText || (samePathname && sameHash))
               && isNotInFloatingCta && notFloatingCtaIgnore;
-          } catch (err) {
-            window.lana?.log(err);
+          } catch (error) {
+            window.lana?.log(`${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
             return false;
           }
         });
@@ -832,7 +832,7 @@ export async function convertToInlineSVG(img) {
     const svgElement = svgDoc.querySelector('svg');
 
     if (!svgElement) {
-      window.lana?.log(`No SVG element found in file ${img.src}`);
+      window.lana?.log(`No SVG element found in file ${img.src}`, { clientId: 'express', tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
       return img;
     }
 
@@ -859,7 +859,7 @@ export async function convertToInlineSVG(img) {
 
     return svgElement;
   } catch (error) {
-    window.lana?.log(`Error converting SVG: ${error}`);
+    window.lana?.log(`Error converting SVG: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
     return img;
   }
 }

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -764,7 +764,7 @@ export async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -360,7 +360,7 @@ export async function decorateButtonsDeprecated(el, size) {
         }
       }
     } catch (error) {
-      window.lana?.log(`Ignoring button due to error: ${error?.message || error?.detail || error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Ignoring button due to error: ${error?.message || error?.detail || error}`, { tags: 'utils', severity: 'error' });
     }
   });
 }
@@ -472,7 +472,7 @@ export function preDecorateSections(area) {
       try {
         linkToTargetURL = new URL(linkToTarget);
       } catch (error) {
-        window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+        window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', severity: 'error' });
       }
       const sameUrlCTAs = Array.from(area.querySelectorAll('a:any-link'))
         .filter((a) => {
@@ -487,7 +487,7 @@ export function preDecorateSections(area) {
             return (sameText || (samePathname && sameHash))
               && isNotInFloatingCta && notFloatingCtaIgnore;
           } catch (error) {
-            window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+            window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', severity: 'error' });
             return false;
           }
         });
@@ -764,7 +764,7 @@ export async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'utils', severity: 'error' });
   }
   a.style.visibility = 'visible';
   return a;
@@ -832,7 +832,7 @@ export async function convertToInlineSVG(img) {
     const svgElement = svgDoc.querySelector('svg');
 
     if (!svgElement) {
-      window.lana?.log(`No SVG element found in file ${img.src}`, { tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`No SVG element found in file ${img.src}`, { tags: 'utils, convertToInlineSVG', severity: 'error' });
       return img;
     }
 
@@ -859,7 +859,7 @@ export async function convertToInlineSVG(img) {
 
     return svgElement;
   } catch (error) {
-    window.lana?.log(`Error converting SVG: ${error?.message || error?.detail || error}`, { tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error converting SVG: ${error?.message || error?.detail || error}`, { tags: 'utils, convertToInlineSVG', severity: 'error' });
     return img;
   }
 }

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -360,7 +360,7 @@ export async function decorateButtonsDeprecated(el, size) {
         }
       }
     } catch (error) {
-      window.lana?.log(`Ignoring button due to error: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Ignoring button due to error: ${error?.message || error?.detail || error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   });
 }
@@ -472,7 +472,7 @@ export function preDecorateSections(area) {
       try {
         linkToTargetURL = new URL(linkToTarget);
       } catch (error) {
-        window.lana?.log(`${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+        window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
       }
       const sameUrlCTAs = Array.from(area.querySelectorAll('a:any-link'))
         .filter((a) => {
@@ -487,7 +487,7 @@ export function preDecorateSections(area) {
             return (sameText || (samePathname && sameHash))
               && isNotInFloatingCta && notFloatingCtaIgnore;
           } catch (error) {
-            window.lana?.log(`${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+            window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
             return false;
           }
         });
@@ -764,7 +764,7 @@ export async function formatDynamicCartLink(a) {
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'utils', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   a.style.visibility = 'visible';
   return a;
@@ -832,7 +832,7 @@ export async function convertToInlineSVG(img) {
     const svgElement = svgDoc.querySelector('svg');
 
     if (!svgElement) {
-      window.lana?.log(`No SVG element found in file ${img.src}`, { clientId: 'express', tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`No SVG element found in file ${img.src}`, { tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
       return img;
     }
 
@@ -859,7 +859,7 @@ export async function convertToInlineSVG(img) {
 
     return svgElement;
   } catch (error) {
-    window.lana?.log(`Error converting SVG: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Error converting SVG: ${error?.message || error?.detail || error}`, { tags: 'utils, convertToInlineSVG', errorType: 'e', severity: 'error', sampleRate: '1' });
     return img;
   }
 }

--- a/express/code/scripts/utils/browse-api-controller.js
+++ b/express/code/scripts/utils/browse-api-controller.js
@@ -78,8 +78,8 @@ export default async function getData() {
     const filtered = buckets?.filter((pill) => pill?.metadata?.status === 'enabled');
 
     return filtered || null;
-  } catch (err) {
-    window.lana?.log('error fetching sdc browse api:', err.message);
+  } catch (error) {
+    window.lana?.log(`error fetching sdc browse api: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils, browse-api-controller, getData', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }

--- a/express/code/scripts/utils/browse-api-controller.js
+++ b/express/code/scripts/utils/browse-api-controller.js
@@ -79,7 +79,7 @@ export default async function getData() {
 
     return filtered || null;
   } catch (error) {
-    window.lana?.log(`error fetching sdc browse api: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils, browse-api-controller, getData', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`error fetching sdc browse api: ${error?.message || error?.detail || error}`, { tags: 'utils, browse-api-controller, getData', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }

--- a/express/code/scripts/utils/browse-api-controller.js
+++ b/express/code/scripts/utils/browse-api-controller.js
@@ -79,7 +79,7 @@ export default async function getData() {
 
     return filtered || null;
   } catch (error) {
-    window.lana?.log(`error fetching sdc browse api: ${error?.message || error?.detail || error}`, { tags: 'utils, browse-api-controller, getData', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`error fetching sdc browse api: ${error?.message || error?.detail || error}`, { tags: 'utils, browse-api-controller, getData', severity: 'error' });
     return null;
   }
 }

--- a/express/code/scripts/utils/content-replace.js
+++ b/express/code/scripts/utils/content-replace.js
@@ -315,7 +315,7 @@ async function autoUpdatePage(main) {
         url = new URL(a.href);
       }
     } catch (error) {
-      window.lana?.log(`Error while attempting to replace link ${a.href}: ${error?.message || error?.detail || error}`, { tags: 'utils, content-replace, autoUpdatePage', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error while attempting to replace link ${a.href}: ${error?.message || error?.detail || error}`, { tags: 'utils, content-replace, autoUpdatePage', severity: 'error' });
     }
   });
 }

--- a/express/code/scripts/utils/content-replace.js
+++ b/express/code/scripts/utils/content-replace.js
@@ -315,7 +315,7 @@ async function autoUpdatePage(main) {
         url = new URL(a.href);
       }
     } catch (error) {
-      window.lana?.log(`Error while attempting to replace link ${a.href}: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils, content-replace, autoUpdatePage', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Error while attempting to replace link ${a.href}: ${error?.message || error?.detail || error}`, { tags: 'utils, content-replace, autoUpdatePage', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   });
 }

--- a/express/code/scripts/utils/content-replace.js
+++ b/express/code/scripts/utils/content-replace.js
@@ -314,8 +314,8 @@ async function autoUpdatePage(main) {
         a.href = getMetadata(url.hash.replace('#', ''));
         url = new URL(a.href);
       }
-    } catch (e) {
-      window.lana?.log(`Error while attempting to replace link ${a.href}: ${e}`);
+    } catch (error) {
+      window.lana?.log(`Error while attempting to replace link ${a.href}: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'utils, content-replace, autoUpdatePage', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   });
 }

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -506,8 +506,8 @@ export async function loadAndInitializeCCEverywhere(getConfig) {
   if (urlOverride) {
     try {
       if (new URL(urlOverride).host === 'dev.cc-embed.adobe.com') valid = true;
-    } catch (e) {
-      window.lana.log('Invalid SDK URL');
+    } catch (error) {
+      window.lana.log(`Invalid SDK URL: ${error}`, { clientId: 'express', tags: 'frictionless-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   const CDN_URL = valid

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -507,7 +507,7 @@ export async function loadAndInitializeCCEverywhere(getConfig) {
     try {
       if (new URL(urlOverride).host === 'dev.cc-embed.adobe.com') valid = true;
     } catch (error) {
-      window.lana?.log(`Invalid SDK URL: ${error}`, { tags: 'frictionless-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Invalid SDK URL: ${error}`, { tags: 'frictionless-utils', severity: 'error' });
     }
   }
   const CDN_URL = valid

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -507,7 +507,7 @@ export async function loadAndInitializeCCEverywhere(getConfig) {
     try {
       if (new URL(urlOverride).host === 'dev.cc-embed.adobe.com') valid = true;
     } catch (error) {
-      window.lana.log(`Invalid SDK URL: ${error}`, { clientId: 'express', tags: 'frictionless-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log(`Invalid SDK URL: ${error}`, { tags: 'frictionless-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
     }
   }
   const CDN_URL = valid

--- a/express/code/scripts/utils/location-utils.js
+++ b/express/code/scripts/utils/location-utils.js
@@ -40,7 +40,7 @@ export async function getCountry(ignoreCookie = false) {
       return normalized;
     }
   } catch (error) {
-    window.lana?.log(`Could not fetch geo2 data from geo2 service: ${error}`, { tags: 'location-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Could not fetch geo2 data from geo2 service: ${error}`, { tags: 'location-utils', severity: 'error' });
   }
 
   const configCountry = getConfig().locale.region;

--- a/express/code/scripts/utils/location-utils.js
+++ b/express/code/scripts/utils/location-utils.js
@@ -39,8 +39,8 @@ export async function getCountry(ignoreCookie = false) {
       sessionStorage.setItem('visitorCountry', normalized);
       return normalized;
     }
-  } catch (e) {
-    window.lana.log('could not fet geo2 data from geo2 service', e);
+  } catch (error) {
+    window.lana.log(`Could not fetch geo2 data from geo2 service: ${error}`, { clientId: 'express', tags: 'location-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 
   const configCountry = getConfig().locale.region;

--- a/express/code/scripts/utils/location-utils.js
+++ b/express/code/scripts/utils/location-utils.js
@@ -40,7 +40,7 @@ export async function getCountry(ignoreCookie = false) {
       return normalized;
     }
   } catch (error) {
-    window.lana.log(`Could not fetch geo2 data from geo2 service: ${error}`, { clientId: 'express', tags: 'location-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Could not fetch geo2 data from geo2 service: ${error}`, { tags: 'location-utils', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 
   const configCountry = getConfig().locale.region;

--- a/express/code/scripts/utils/media.js
+++ b/express/code/scripts/utils/media.js
@@ -144,8 +144,8 @@ export function transformLinkToAnimation($a, $videoLooping = true, hasControls =
     try {
       params = new URL($a.href).searchParams;
       videoUrl = new URL($a.href);
-    } catch (urlError) {
-      window.lana?.log('Invalid video URL in transformLinkToAnimation:', urlError);
+    } catch (error) {
+      window.lana?.log('Invalid video URL in transformLinkToAnimation:', error?.message || error?.detail || error, { clientId: 'express', tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
       return null;
     }
 
@@ -197,13 +197,11 @@ export function transformLinkToAnimation($a, $videoLooping = true, hasControls =
         });
       }
     });
-
     // TODO: make this authorable or edit all blocks that use this func
     if (hasControls) createAccessibilityVideoControls($video);
-
     return $video;
   } catch (error) {
-    window.lana?.log('Error in transformLinkToAnimation:', error);
+    window.lana?.log('Error in transformLinkToAnimation:', error?.message || error?.detail || error, { clientId: 'express', tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }

--- a/express/code/scripts/utils/media.js
+++ b/express/code/scripts/utils/media.js
@@ -145,7 +145,7 @@ export function transformLinkToAnimation($a, $videoLooping = true, hasControls =
       params = new URL($a.href).searchParams;
       videoUrl = new URL($a.href);
     } catch (error) {
-      window.lana?.log('Invalid video URL in transformLinkToAnimation:', error?.message || error?.detail || error, { tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log('Invalid video URL in transformLinkToAnimation:', error?.message || error?.detail || error, { tags: 'utils, media, transformLinkToAnimation', severity: 'error' });
       return null;
     }
 
@@ -201,7 +201,7 @@ export function transformLinkToAnimation($a, $videoLooping = true, hasControls =
     if (hasControls) createAccessibilityVideoControls($video);
     return $video;
   } catch (error) {
-    window.lana?.log('Error in transformLinkToAnimation:', error?.message || error?.detail || error, { tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log('Error in transformLinkToAnimation:', error?.message || error?.detail || error, { tags: 'utils, media, transformLinkToAnimation', severity: 'error' });
     return null;
   }
 }

--- a/express/code/scripts/utils/media.js
+++ b/express/code/scripts/utils/media.js
@@ -145,7 +145,7 @@ export function transformLinkToAnimation($a, $videoLooping = true, hasControls =
       params = new URL($a.href).searchParams;
       videoUrl = new URL($a.href);
     } catch (error) {
-      window.lana?.log('Invalid video URL in transformLinkToAnimation:', error?.message || error?.detail || error, { clientId: 'express', tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
+      window.lana?.log('Invalid video URL in transformLinkToAnimation:', error?.message || error?.detail || error, { tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
       return null;
     }
 
@@ -201,7 +201,7 @@ export function transformLinkToAnimation($a, $videoLooping = true, hasControls =
     if (hasControls) createAccessibilityVideoControls($video);
     return $video;
   } catch (error) {
-    window.lana?.log('Error in transformLinkToAnimation:', error?.message || error?.detail || error, { clientId: 'express', tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log('Error in transformLinkToAnimation:', error?.message || error?.detail || error, { tags: 'utils, media, transformLinkToAnimation', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -388,7 +388,7 @@ export async function formatDynamicCartLink(a, plan) {
       a.href = newTrialHref;
     }
   } catch (error) {
-    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'pricing-js', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'pricing-js', severity: 'error' });
   }
   return a;
 }

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -388,8 +388,7 @@ export async function formatDynamicCartLink(a, plan) {
       a.href = newTrialHref;
     }
   } catch (error) {
-    window.lana.log('Failed to fetch prices for page plan');
-    window.lana.log(error);
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'pricing-js', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   return a;
 }

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -388,7 +388,7 @@ export async function formatDynamicCartLink(a, plan) {
       a.href = newTrialHref;
     }
   } catch (error) {
-    window.lana.log(`Failed to fetch prices for page plan: ${error}`, { clientId: 'express', tags: 'pricing-js', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`Failed to fetch prices for page plan: ${error}`, { tags: 'pricing-js', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
   return a;
 }

--- a/express/code/scripts/utils/ratings-utils.js
+++ b/express/code/scripts/utils/ratings-utils.js
@@ -172,7 +172,7 @@ export async function fetchRatingsData(sheet) {
       segments: null, // RNR API doesn't provide segments in the same way
     };
   } catch (error) {
-    window.lana?.log(`RnR: Could not load review data for sheet '${sheet}': ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'ratings-utils, Express_Milo, RnR Block, fetchRatingsData', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`RnR: Could not load review data for sheet '${sheet}': ${error?.message || error?.detail || error}`, { tags: 'ratings-utils, Express_Milo, RnR Block, fetchRatingsData', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }
@@ -397,7 +397,7 @@ export async function submitRating(sheet, rating, comment) {
     }
     localStorage.setItem('ccxActionRatings', ccxActionRatings);
   } catch (error) {
-    window.lana?.log(`RnR: Could not post review for sheet '${sheet}': ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'ratings-utils, Express_Milo, RnR Block, submitRating', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`RnR: Could not post review for sheet '${sheet}': ${error?.message || error?.detail || error}`, { tags: 'ratings-utils, Express_Milo, RnR Block, submitRating', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/utils/ratings-utils.js
+++ b/express/code/scripts/utils/ratings-utils.js
@@ -172,7 +172,7 @@ export async function fetchRatingsData(sheet) {
       segments: null, // RNR API doesn't provide segments in the same way
     };
   } catch (error) {
-    window.lana?.log(`RnR: Could not load review data for sheet '${sheet}': ${error?.message || error?.detail || error}`, { tags: 'ratings-utils, Express_Milo, RnR Block, fetchRatingsData', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`RnR: Could not load review data for sheet '${sheet}': ${error?.message || error?.detail || error}`, { tags: 'ratings-utils, Express_Milo, RnR Block, fetchRatingsData', severity: 'error' });
     return null;
   }
 }
@@ -397,7 +397,7 @@ export async function submitRating(sheet, rating, comment) {
     }
     localStorage.setItem('ccxActionRatings', ccxActionRatings);
   } catch (error) {
-    window.lana?.log(`RnR: Could not post review for sheet '${sheet}': ${error?.message || error?.detail || error}`, { tags: 'ratings-utils, Express_Milo, RnR Block, submitRating', errorType: 'e', severity: 'error', sampleRate: '1' });
+    window.lana?.log(`RnR: Could not post review for sheet '${sheet}': ${error?.message || error?.detail || error}`, { tags: 'ratings-utils, Express_Milo, RnR Block, submitRating', severity: 'error' });
   }
 }
 

--- a/express/code/scripts/utils/ratings-utils.js
+++ b/express/code/scripts/utils/ratings-utils.js
@@ -33,12 +33,6 @@ function isNalaTestRatings() {
   return isPreviewHost && params.get('nala') === 'ratings';
 }
 
-// Errors & Logging
-const lanaOptions = {
-  sampleRate: 1,
-  tags: 'Express_Milo, RnR Block',
-};
-
 // Initialize required dependencies
 async function initDependencies() {
   if (!createTag || !getConfig || !getMetadata) {
@@ -178,10 +172,7 @@ export async function fetchRatingsData(sheet) {
       segments: null, // RNR API doesn't provide segments in the same way
     };
   } catch (error) {
-    window.lana?.log(
-      `RnR: Could not load review data for sheet '${sheet}': ${error?.message}`,
-      lanaOptions,
-    );
+    window.lana?.log(`RnR: Could not load review data for sheet '${sheet}': ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'ratings-utils, Express_Milo, RnR Block, fetchRatingsData', errorType: 'e', severity: 'error', sampleRate: '1' });
     return null;
   }
 }
@@ -406,10 +397,7 @@ export async function submitRating(sheet, rating, comment) {
     }
     localStorage.setItem('ccxActionRatings', ccxActionRatings);
   } catch (error) {
-    window.lana?.log(
-      `RnR: Could not post review for sheet '${sheet}': ${error?.message}`,
-      lanaOptions,
-    );
+    window.lana?.log(`RnR: Could not post review for sheet '${sheet}': ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'ratings-utils, Express_Milo, RnR Block, submitRating', errorType: 'e', severity: 'error', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/utils/ratings-utils.js
+++ b/express/code/scripts/utils/ratings-utils.js
@@ -28,7 +28,10 @@ const RNR_API_URL = isProd ? 'https://rnr.adobe.io/v1' : 'https://rnr-stage.adob
  */
 function isNalaTestRatings() {
   if (typeof window === 'undefined' || !window.location?.hostname) return false;
-  const isPreviewHost = window.location.hostname.includes('aem.live') || window.location.hostname.includes('aem.page');
+  const { hostname } = window.location;
+  const isPreviewHost = hostname === 'localhost'
+    || hostname.includes('aem.live')
+    || hostname.includes('aem.page');
   const params = new URLSearchParams(window.location.search);
   return isPreviewHost && params.get('nala') === 'ratings';
 }

--- a/express/code/scripts/utils/template-ckg.js
+++ b/express/code/scripts/utils/template-ckg.js
@@ -283,16 +283,16 @@ async function lazyLoadSearchMarqueeLinklist() {
           });
         });
       } else {
-        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { clientId: 'express', tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
+        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
       }
 
       await updateLinkList(linkListContainer, linkListTemplate, linkListData);
       linkListContainer.parentElement.classList.add('appear');
     } else {
-      window.lana?.log('template-ckg: No carousel container found in search-marquee', { clientId: 'express', tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
+      window.lana?.log('template-ckg: No carousel container found in search-marquee', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
     }
   } else {
-    window.lana?.log('template-ckg: No .search-marquee element found on page', { clientId: 'express', tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
+    window.lana?.log('template-ckg: No .search-marquee element found on page', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/utils/template-ckg.js
+++ b/express/code/scripts/utils/template-ckg.js
@@ -283,16 +283,16 @@ async function lazyLoadSearchMarqueeLinklist() {
           });
         });
       } else {
-        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', });
+        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info' });
       }
 
       await updateLinkList(linkListContainer, linkListTemplate, linkListData);
       linkListContainer.parentElement.classList.add('appear');
     } else {
-      window.lana?.log('template-ckg: No carousel container found in search-marquee', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', });
+      window.lana?.log('template-ckg: No carousel container found in search-marquee', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info' });
     }
   } else {
-    window.lana?.log('template-ckg: No .search-marquee element found on page', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', });
+    window.lana?.log('template-ckg: No .search-marquee element found on page', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info' });
   }
 }
 

--- a/express/code/scripts/utils/template-ckg.js
+++ b/express/code/scripts/utils/template-ckg.js
@@ -283,16 +283,16 @@ async function lazyLoadSearchMarqueeLinklist() {
           });
         });
       } else {
-        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated');
+        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { clientId: 'express', tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
       }
 
       await updateLinkList(linkListContainer, linkListTemplate, linkListData);
       linkListContainer.parentElement.classList.add('appear');
     } else {
-      window.lana?.log('template-ckg: No carousel container found in search-marquee');
+      window.lana?.log('template-ckg: No carousel container found in search-marquee', { clientId: 'express', tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
     }
   } else {
-    window.lana?.log('template-ckg: No .search-marquee element found on page');
+    window.lana?.log('template-ckg: No .search-marquee element found on page', { clientId: 'express', tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
   }
 }
 

--- a/express/code/scripts/utils/template-ckg.js
+++ b/express/code/scripts/utils/template-ckg.js
@@ -283,16 +283,16 @@ async function lazyLoadSearchMarqueeLinklist() {
           });
         });
       } else {
-        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
+        window.lana?.log('template-ckg: Missing ckgData or short-title metadata - pills will not be populated', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', });
       }
 
       await updateLinkList(linkListContainer, linkListTemplate, linkListData);
       linkListContainer.parentElement.classList.add('appear');
     } else {
-      window.lana?.log('template-ckg: No carousel container found in search-marquee', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
+      window.lana?.log('template-ckg: No carousel container found in search-marquee', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', });
     }
   } else {
-    window.lana?.log('template-ckg: No .search-marquee element found on page', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', sampleRate: '1' });
+    window.lana?.log('template-ckg: No .search-marquee element found on page', { tags: 'template-ckg, lazyLoadSearchMarqueeLinklist', errorType: 'i', severity: 'info', });
   }
 }
 

--- a/express/code/scripts/widgets/basic-carousel.js
+++ b/express/code/scripts/widgets/basic-carousel.js
@@ -313,7 +313,7 @@ function initializeCarousel(selector, parent) {
             setTimeout(() => tooltip.classList.remove('display-tooltip'), 2000);
           }
         }).catch((error) => {
-          window.lana?.log(`Failed to copy link: ${error?.message || error?.detail || error}`, { tags: 'basic-carousel, copyLink', errorType: 'e', severity: 'error', sampleRate: '1' });
+          window.lana?.log(`Failed to copy link: ${error?.message || error?.detail || error}`, { tags: 'basic-carousel, copyLink', severity: 'error' });
         });
         return;
       }

--- a/express/code/scripts/widgets/basic-carousel.js
+++ b/express/code/scripts/widgets/basic-carousel.js
@@ -313,7 +313,7 @@ function initializeCarousel(selector, parent) {
             setTimeout(() => tooltip.classList.remove('display-tooltip'), 2000);
           }
         }).catch((error) => {
-          window.lana?.log(`Failed to copy link: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'basic-carousel, copyLink', errorType: 'e', severity: 'error', sampleRate: '1' });
+          window.lana?.log(`Failed to copy link: ${error?.message || error?.detail || error}`, { tags: 'basic-carousel, copyLink', errorType: 'e', severity: 'error', sampleRate: '1' });
         });
         return;
       }

--- a/express/code/scripts/widgets/basic-carousel.js
+++ b/express/code/scripts/widgets/basic-carousel.js
@@ -312,8 +312,8 @@ function initializeCarousel(selector, parent) {
             tooltip.classList.add('display-tooltip');
             setTimeout(() => tooltip.classList.remove('display-tooltip'), 2000);
           }
-        }).catch((err) => {
-          window.lana?.log('Failed to copy link:', err);
+        }).catch((error) => {
+          window.lana?.log(`Failed to copy link: ${error?.message || error?.detail || error}`, { clientId: 'express', tags: 'basic-carousel, copyLink', errorType: 'e', severity: 'error', sampleRate: '1' });
         });
         return;
       }

--- a/nala/blocks/blog-feature-marquee/blog-feature-marquee.test.cjs
+++ b/nala/blocks/blog-feature-marquee/blog-feature-marquee.test.cjs
@@ -31,6 +31,8 @@ test.describe('BlogFeatureMarqueeBlock Test Suite', () => {
         return;
       }
 
+      // Wait for async decoration (blog index fetch) to complete
+      await expect(block.block).toHaveClass(/blog-feature-marquee-ready/, { timeout: 15000 });
       await expect(block.block).toBeVisible();
       const sem = data.semantic;
 

--- a/nala/blocks/blog-posts-v2/blog-posts-v2.test.cjs
+++ b/nala/blocks/blog-posts-v2/blog-posts-v2.test.cjs
@@ -163,6 +163,7 @@ test.describe('BlogPostsV2Block Test Suite', () => {
       }
 
       await page.waitForLoadState('domcontentloaded');
+      await page.waitForLoadState('load');
       await expect(page).toHaveURL(testUrl);
     });
 
@@ -178,7 +179,9 @@ test.describe('BlogPostsV2Block Test Suite', () => {
 
       // Verify first card has expected structure
       await expect(block.blogCard.first()).toBeVisible();
-      await expect(block.blogCardImage.first()).toBeVisible();
+      // Scroll into view to trigger lazy-loaded images before asserting visibility
+      await block.blogCardImage.first().scrollIntoViewIfNeeded();
+      await expect(block.blogCardImage.first()).toBeVisible({ timeout: 10000 });
       await expect(block.blogCardTitle.first()).toBeVisible();
       await expect(block.blogCardTeaser.first()).toBeVisible();
       await expect(block.blogCardDate.first()).toBeVisible();
@@ -196,9 +199,10 @@ test.describe('BlogPostsV2Block Test Suite', () => {
       const imageCount = await block.blogCardImage.count();
       expect(imageCount).toBeGreaterThan(0);
 
-      // Verify first card image has an img tag
+      // Verify first card image has an img tag (scroll to trigger lazy loading)
       const img = block.blogCardImage.first().locator('img');
-      await expect(img).toBeVisible();
+      await img.scrollIntoViewIfNeeded();
+      await expect(img).toBeVisible({ timeout: 10000 });
     });
 
     await test.step('step-5: Verify blog tags on cards', async () => {

--- a/nala/blocks/floating-button/floating-button.test.cjs
+++ b/nala/blocks/floating-button/floating-button.test.cjs
@@ -25,14 +25,11 @@ test.describe('Express Floating Button Block test suite', () => {
     });
 
     await test.step('Verify floating-button block content/specs', async () => {
-      // Wait for floating button to be present and visible
       await expect(floatingButton.floatingButton).toBeAttached();
 
-      // Wait for the floating button to be properly positioned and visible
       await page.locator('.discover-cards').scrollIntoViewIfNeeded();
       await expect(floatingButton.floatingButton).toBeVisible({ timeout: 15000 });
 
-      // Wait for the floating button to be in a clickable state
       await page.waitForFunction(() => {
         const button = document.querySelector('.floating-button');
         if (!button) return false;
@@ -41,21 +38,18 @@ test.describe('Express Floating Button Block test suite', () => {
       }, { timeout: 10000 });
 
       await expect(floatingButton.floatingButton).toContainText(data.buttonText);
-
-      // Click the floating button
-      await floatingButton.floatingButton.click({ timeout: 10000 });
-      await expect(page).not.toHaveURL(`${testUrl}`);
     });
 
     await test.step('Verify hidden state is removed from accessibility tree', async () => {
-      // Scroll footer into view so the CTA hides
-      await page.locator('.global-footer').scrollIntoViewIfNeeded();
+      const footer = page.locator('.global-footer');
+      await expect(footer).toBeAttached({ timeout: 20000 });
+      await footer.scrollIntoViewIfNeeded();
+
       const wrapper = floatingButton.section;
       await expect(wrapper).toHaveClass(/floating-button--hidden/);
       await expect(wrapper).toHaveAttribute('aria-hidden', 'true');
       await expect(wrapper).toHaveAttribute('inert', '');
 
-      // Programmatically attempt to focus the CTA link; it should not receive focus
       const focusResult = await page.evaluate(() => {
         const w = document.querySelector('.floating-button-wrapper');
         const link = w?.querySelector('a');
@@ -65,7 +59,6 @@ test.describe('Express Floating Button Block test suite', () => {
       });
       expect(focusResult).not.toBe(true);
 
-      // Scroll back up and confirm attributes are removed
       await page.evaluate(() => window.scrollTo(0, 0));
       await expect(wrapper).not.toHaveAttribute('aria-hidden', 'true');
       await expect(wrapper).not.toHaveAttribute('inert', '');
@@ -78,6 +71,14 @@ test.describe('Express Floating Button Block test suite', () => {
 
     await test.step('Verify accessibility', async () => {
       await runAccessibilityTest({ page, testScope: floatingButton.floatingButton });
+    });
+
+    await test.step('Verify CTA click navigates to target page', async () => {
+      // Scroll past the hero CTA so the fixed floating button enters the viewport
+      await page.locator('.discover-cards').scrollIntoViewIfNeeded();
+      await expect(floatingButton.floatingButton).toBeVisible({ timeout: 15000 });
+      await floatingButton.floatingButton.click({ timeout: 10000 });
+      await expect(page).not.toHaveURL(`${testUrl}`);
     });
   });
 });

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -218,8 +218,8 @@ describe('transformLinkToAnimation', () => {
 
     const result = transformLinkToAnimation(invalidLink);
     expect(result).to.be.null;
-    expect(window.lana.log.calledOnce).to.be.true;
-    expect(window.lana.log.firstCall.args[0]).to.equal('Invalid video URL in transformLinkToAnimation:');
+    expect(window.lana?.log.calledOnce).to.be.true;
+    expect(window.lana?.log.firstCall.args[0]).to.equal('Invalid video URL in transformLinkToAnimation:');
 
     // Restore original lana and URL
     window.lana = originalLana;
@@ -245,8 +245,8 @@ describe('transformLinkToAnimation', () => {
 
     const result = transformLinkToAnimation(problematicLink);
     expect(result).to.be.null;
-    expect(window.lana.log.calledOnce).to.be.true;
-    expect(window.lana.log.firstCall.args[0]).to.equal('Error in transformLinkToAnimation:');
+    expect(window.lana?.log.calledOnce).to.be.true;
+    expect(window.lana?.log.firstCall.args[0]).to.equal('Error in transformLinkToAnimation:');
 
     // Restore original lana
     window.lana = originalLana;


### PR DESCRIPTION
## Summary

Cleaned up all of the window.lana.log calls in the repository to use a clean / consistent format that includes all of the required and optional fields. Included a severity level of 'error' for most logs, with the exception of a few that I left at 'warning'.

---

## Jira Ticket

Resolves: [MWPW-186049](https://jira.corp.adobe.com/browse/MWPW-186049)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.live/express/ |
| **After**   | https://mwpw-186049--da-express-milo--adobecom.aem.live/express/?martech=off&mep=off&target=off |

---

## Verification Steps

Verifying these updates would involve manually triggering an error that would cause a lana log to be produced, and then checking the repository where our lana logs get logged. I am personally not sure of how to access this repository, but I think we can say with fairly high confidence that the logging behavior should be the same and should not be affected by simply including these extra parameters. 

---

## Potential Regressions

See ticket for full list of potential regression links (all blocks containing lana.log calls). Moved to ticket in order to avoid problems with aem-psi check, as per Brad's suggestion

---

## Additional Notes

If any of the severity levels of any of these logs need to be adjusted, that can be addressed in future tickets. This simply accomplishes the base level task of assigning an explicit severity to the logs so that they don't default to the default severity value which is 'info'.