### PR TITLE
TOC SEO Appearance Fix

### DIFF
--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -68,7 +68,10 @@ function buildBlockConfig(block) {
   // Validate and set defaults
   const title = config['toc-title'] || 'Table of Contents';
   const ariaLabel = config['toc-aria-label'] || 'Table of Contents Navigation';
-  const stopElement = config['stop-element'] || config['toc-stop-element'];
+  const rawStopElement = config.stopElement || config['stop-element'] || config['toc-stop-element'];
+  const stopElement = rawStopElement && !rawStopElement.startsWith('.')
+    ? `.${rawStopElement}`
+    : rawStopElement;
   const contents = [];
 
   // Build content array with validation
@@ -574,18 +577,19 @@ function updateDesktopPosition(tocContainer) {
 
   // Check if there's a stop element we shouldn't scroll past
   const stopSelector = tocContainer.dataset.stopSelector || CONFIG.selectors.stopElement;
-  const stopElement = stopSelector ? document.querySelector(stopSelector) : null;
+  const stopElement = stopSelector
+    ? Array.from(document.querySelectorAll(stopSelector)).find((el) => el.offsetHeight > 0)
+    : null;
   if (stopElement && scrollY > 0) {
     const stopRect = stopElement.getBoundingClientRect();
     const stopTop = stopRect.top; // Position relative to viewport
     const tocHeight = tocContainer.offsetHeight;
-
     // If the TOC would overlap with the stop element, limit its position
     // We want: topPosition + tocHeight <= stopTop
     // So: topPosition <= stopTop - tocHeight
     const maxTopPosition = stopTop - tocHeight - 20; // 20px buffer
 
-    if (topPosition > maxTopPosition) {
+    if (topPosition > maxTopPosition && stopRect.height > 0) {
       topPosition = maxTopPosition;
     }
   }
@@ -765,7 +769,9 @@ export default async function decorate(block) {
 
     // Phase 3: Create DOM structure
     const container = createContainer();
-    const stopSelector = config.stopElement || CONFIG.selectors.stopElement || '';
+    const rawMetaStop = getMetadata('stopElement') || getMetadata('stop-element');
+    const metaStop = rawMetaStop && !rawMetaStop.startsWith('.') ? `.${rawMetaStop}` : rawMetaStop;
+    const stopSelector = config.stopElement || metaStop || CONFIG.selectors.stopElement || '';
     container.dataset.stopSelector = stopSelector;
     const titleBar = createTitleBar(config.title);
     const content = createContentList(config);

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -10,7 +10,7 @@ const CONFIG = {
     section: 'main .section',
     headers: ['main .section.long-form .content h2', 'main .section.long-form .content h3', 'main .section.long-form .content h4'],
     navigation: '.global-navigation, header',
-    stopElement: '.faqv2, .ax-link-list-v2-container, .ax-blog-posts-container, footer',
+    stopElement: '.faqv2, .ax-link-list-v2-container, .ax-blog-posts-container, .banner-bg, footer',
   },
   scrollOffset: {
     mobile: 75,

--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -769,7 +769,7 @@ export default async function decorate(block) {
 
     // Phase 3: Create DOM structure
     const container = createContainer();
-    const rawMetaStop = getMetadata('stopElement') || getMetadata('stop-element');
+    const rawMetaStop = getMetadata('stopelement');
     const metaStop = rawMetaStop && !rawMetaStop.startsWith('.') ? `.${rawMetaStop}` : rawMetaStop;
     const stopSelector = config.stopElement || metaStop || CONFIG.selectors.stopElement || '';
     container.dataset.stopSelector = stopSelector;


### PR DESCRIPTION

## Summary

Fixes the Table of Contents (TOC) disappearing when previewing draft blog articles (MWPW-190552). The root cause was invisible stop elements (e.g. `.blog-posts-v2` with `offsetHeight` 0) being used to position the TOC, which pushed it off-screen. The fix filters out invisible stop elements and adds `.banner-bg` to the stop selector list.

---

## Jira Ticket

Resolves: [MWPW-190552](https://jira.corp.adobe.com/browse/MWPW-190552)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://toc-fix--da-express-milo--adobecom.aem.page/drafts/rebecaalvarado/2019-graphic-design-trends-and-spark-post-templates  |

---

## Verification Steps

1. Open the draft URL: https://toc-fix--da-express-milo--adobecom.aem.page/drafts/rebecaalvarado/2019-graphic-design-trends-and-spark-post-templates  
2. **Before:** TOC disappears when previewing the page.  
3. **After:** TOC remains visible and scrolls correctly when previewing and scrolling.

---

## Potential Regressions

- https://toc-fix--da-express-milo--adobecom.aem.page/drafts/rebecaalvarado/2019-graphic-design-trends-and-spark-post-templates?martech=off  
- 
1. https://toc-fix--da-express-milo--adobecom.aem.page/fr/express/discover/ideas/gift/wrapping?martech=off  
2. https://toc-fix--da-express-milo--adobecom.aem.page/express/discover/quotes/life/journey?martech=off  
3. https://toc-fix--da-express-milo--adobecom.aem.page/in/express/discover/captions/have-a-nice-day?martech=off  
4. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/examples/letter/resignation?martech=off  
5. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/letter/character-reference?martech=off  
7. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/tips/how-to-start-a-letter?martech=off  
9. https://toc-fix--da-express-milo--adobecom.aem.page/in/express/discover/wishes/birthday/boss?martech=off  
10. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/tips/how-to-write-press-release?martech=off  
11. https://toc-fix--da-express-milo--adobecom.aem.page/in/express/discover/wishes/birthday/boys?martech=off  
12. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/business/plan?martech=off  
13. https://toc-fix--da-express-milo--adobecom.aem.page/express/discover/messages/birthday/her?martech=off  
14. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/spinning-whee?martech=off  
15. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/logo/business?martech=off  
16. https://toc-fix--da-express-milo--adobecom.aem.page/br/express/discover/quotes/life?martech=off  
17. https://toc-fix--da-express-milo--adobecom.aem.page/express/discover/wishes/birthday/twenty-one?martech=off  
18. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/marketing-plan?martech=off  
19. https://toc-fix--da-express-milo--adobecom.aem.page/express/discover/wishes/birthday/fifty?martech=off  
20. https://toc-fix--da-express-milo--adobecom.aem.page/uk/express/discover/how-to/instagram/go-live?martech=off  

---

## Additional Notes

- Only one issue was confirmed: TOC disappearing; overlap was not reproducible.  
- Changes in `toc-seo.js`: (1) filter stop elements by `offsetHeight > 0`, (2) add `.banner-bg` to stop selectors, (3) support `stopelement` metadata and selector normalization.