### PR TITLE
Remove Template CKG Double Encoding

### DIFF
--- a/express/code/scripts/utils/template-ckg.js
+++ b/express/code/scripts/utils/template-ckg.js
@@ -40,7 +40,7 @@ async function fetchLinkList() {
       return {
         parent: formattedTasks,
         ckgID: ckgItem.metadata.ckgId,
-        displayValue: sanitizeHTML(ckgItem.canonicalName),
+        displayValue: ckgItem.canonicalName,
         value: sanitizeHTML(ckgItem.metadata.link),
       };
     });
@@ -53,11 +53,21 @@ function isSearch(pathname) {
   return searchRegex.test(pathname);
 }
 
+function replaceTextInNode(node, search, replacement) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    if (node.textContent.includes(search)) {
+      node.textContent = node.textContent.replaceAll(search, replacement);
+    }
+  } else {
+    node.childNodes.forEach((child) => replaceTextInNode(child, search, replacement));
+  }
+}
+
 function replaceLinkPill(linkPill, data) {
   const clone = linkPill.cloneNode(true);
   if (data) {
     const a = clone.querySelector('a');
-    a.innerHTML = a.innerHTML.replaceAll('Default', data['short-title']);
+    replaceTextInNode(a, 'Default', data['short-title']);
     a.title = a.textContent;
     a.href = a.href.replace('/express/templates/default', data.url);
   }


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Fixes the improper formatting of CKG pills without doing double HTML encoding or setting innerHTML directly

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-190595

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://template-ckg-html-fix--da-express-milo--adobecom.aem.page/express/templates/card?ckg-env=prod |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page and scroll the ckg pill list in the search marquee to the `Mothers Day` pill, verify there are no extra characters in it.

---

## Potential Regressions

-  https://template-ckg-html-fix--da-express-milo--adobecom.aem.page/express/templates/card?ckg-env=prod
-  https://template-ckg-html-fix--da-express-milo--adobecom.aem.page/express/templates/?ckg-env=prod

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
