### PR TITLE
[shared component] color-headline block

### DIFF
--- a/express/code/blocks/color-headline/color-headline.css
+++ b/express/code/blocks/color-headline/color-headline.css
@@ -1,0 +1,60 @@
+.color-headline *,
+.color-headline *::before,
+.color-headline *::after {
+  box-sizing: border-box;
+}
+
+.color-headline.extract {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 32px 16px 0;
+  /* Sit above the color-extract landing background images */
+  position: relative;
+  z-index: 1;
+  /* Collapse any default bottom margin so the landing pulls up cleanly */
+  margin-bottom: 0;
+}
+
+/* Hide when the adjacent color-extract switches to the edit/results view */
+body:has(.color-extract.has-image) .color-headline.extract {
+  display: none;
+}
+
+.color-headline.extract > div > div {
+  width: 100%;
+  max-width: 640px;
+}
+
+.color-headline .express-logo {
+  display: block;
+  width: unset;
+  height: 30px;
+  padding: 0;
+  margin-bottom: 12px;
+}
+
+.color-headline.extract h1 {
+  font-size: 45px;
+  line-height: 1.04;
+  margin: 0 0 12px;
+}
+
+.color-headline.extract p {
+  margin: 0;
+  color: #505050;
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+@media (max-width: 1199px) {
+  .color-headline.extract h1 {
+    font-size: 32px;
+  }
+
+  .color-headline.extract p {
+    font-size: 16px;
+    line-height: 1.4;
+  }
+}

--- a/express/code/blocks/color-headline/color-headline.js
+++ b/express/code/blocks/color-headline/color-headline.js
@@ -1,0 +1,33 @@
+import { getIconElementDeprecated, getLibs } from '../../scripts/utils.js';
+
+const LOGO = 'adobe-express-logo';
+const PHOTO_LOGO = 'adobe-express-logo-photos';
+
+export default async function init(el) {
+  const heading = el.querySelector('h1, h2, h3, h4, h5, h6');
+
+  // extract variant always injects the logo — do this synchronously so it
+  // is guaranteed to render even if the async metadata import below fails.
+  if (el.classList.contains('extract') && heading) {
+    const logo = getIconElementDeprecated(LOGO);
+    logo.classList.add('express-logo');
+    heading.before(logo);
+  }
+
+  // Metadata-driven injection for non-extract variants (marquee-inject-logo /
+  // marquee-inject-photo-logo), matching the pattern used by ax-columns et al.
+  try {
+    const { getMetadata } = await import(`${getLibs()}/utils/utils.js`);
+    const injectPhotoLogo = ['on', 'yes'].includes(getMetadata('marquee-inject-photo-logo')?.toLowerCase());
+    const injectViaMetadata = !el.classList.contains('extract')
+      && ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase());
+
+    if ((injectViaMetadata || injectPhotoLogo) && heading && !el.querySelector('.express-logo')) {
+      const logo = getIconElementDeprecated(injectPhotoLogo ? PHOTO_LOGO : LOGO);
+      logo.classList.add('express-logo');
+      heading.before(logo);
+    }
+  } catch { /* milo utils unavailable — extract logo already injected above */ }
+
+  return el;
+}

--- a/nala/blocks/color-headline/color-headline.page.js
+++ b/nala/blocks/color-headline/color-headline.page.js
@@ -1,0 +1,21 @@
+export default class ColorHeadlinePage {
+  constructor(page) {
+    this.page = page;
+    this.block = page.locator('.color-headline');
+    this.extractBlock = page.locator('.color-headline.extract');
+    this.heading = this.block.locator('h1, h2, h3, h4, h5, h6').first();
+    this.paragraph = this.block.locator('p').first();
+    this.logo = this.block.locator('.express-logo');
+  }
+
+  async gotoURL(url) {
+    await this.page.goto(url);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async scrollIntoView() {
+    if (await this.block.count()) {
+      await this.block.first().scrollIntoViewIfNeeded();
+    }
+  }
+}

--- a/nala/blocks/color-headline/color-headline.spec.js
+++ b/nala/blocks/color-headline/color-headline.spec.js
@@ -1,0 +1,17 @@
+module.exports = {
+  name: 'Color Headline block',
+  features: [
+    {
+      tcid: '0',
+      name: '@color-headline',
+      path: '/express/tools/color-palette',
+      tags: '@express @regression @color-headline',
+    },
+    {
+      tcid: '1',
+      name: '@color-headline-extract',
+      path: '/express/tools/color-palette',
+      tags: '@express @regression @color-headline @color-headline-extract',
+    },
+  ],
+};

--- a/nala/blocks/color-headline/color-headline.test.js
+++ b/nala/blocks/color-headline/color-headline.test.js
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import { features } from './color-headline.spec.js';
+import ColorHeadlinePage from './color-headline.page.js';
+
+let colorHeadline;
+
+test.describe('Color Headline block test suite', () => {
+  test.beforeEach(async ({ page }) => {
+    colorHeadline = new ColorHeadlinePage(page);
+  });
+
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name}`, async ({ baseURL }) => {
+    await test.step('Navigate to page', async () => {
+      await colorHeadline.gotoURL(`${baseURL}${features[0].path}`);
+    });
+
+    await test.step('Scroll block into view', async () => {
+      await colorHeadline.scrollIntoView();
+      await expect(colorHeadline.block.first()).toBeVisible();
+    });
+
+    await test.step('Verify heading is non-empty', async () => {
+      const headingText = await colorHeadline.heading.innerText();
+      expect(headingText.length).toBeGreaterThan(0);
+    });
+
+    await test.step('Verify paragraph is non-empty', async () => {
+      const paragraphText = await colorHeadline.paragraph.innerText();
+      expect(paragraphText.length).toBeGreaterThan(0);
+    });
+  });
+
+  test(`[Test Id - ${features[1].tcid}] ${features[1].name}`, async ({ baseURL }) => {
+    await test.step('Navigate to page', async () => {
+      await colorHeadline.gotoURL(`${baseURL}${features[1].path}`);
+    });
+
+    await test.step('Extract variant is visible', async () => {
+      await colorHeadline.scrollIntoView();
+      await expect(colorHeadline.extractBlock).toBeVisible();
+    });
+
+    await test.step('Express logo is injected before the heading', async () => {
+      await expect(colorHeadline.logo).toBeVisible();
+    });
+
+    await test.step('Logo appears before the heading', async () => {
+      const logoPosition = await colorHeadline.logo.boundingBox();
+      const headingPosition = await colorHeadline.heading.boundingBox();
+      expect(logoPosition.y).toBeLessThan(headingPosition.y);
+    });
+  });
+});

--- a/test/blocks/color-headline/color-headline.test.js
+++ b/test/blocks/color-headline/color-headline.test.js
@@ -1,0 +1,150 @@
+/* eslint-env mocha */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const imports = await Promise.all([
+  import('../../../express/code/scripts/scripts.js'),
+  import('../../../express/code/blocks/color-headline/color-headline.js'),
+]);
+const { default: init } = imports[1];
+
+const basic = await readFile({ path: './mocks/basic.html' });
+const extract = await readFile({ path: './mocks/extract.html' });
+
+function addMeta(name, content) {
+  const meta = document.createElement('meta');
+  meta.name = name;
+  meta.content = content;
+  document.head.append(meta);
+  return meta;
+}
+
+describe('Color Headline', () => {
+  before(() => {
+    window.isTestEnv = true;
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('meta[name="marquee-inject-logo"], meta[name="marquee-inject-photo-logo"]').forEach((m) => m.remove());
+  });
+
+  describe('basic variant', () => {
+    it('block exists after init', async () => {
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block).to.exist;
+    });
+
+    it('heading is present', async () => {
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('h2')).to.exist;
+    });
+
+    it('paragraph is present', async () => {
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('p')).to.exist;
+    });
+
+    it('does not inject logo when marquee-inject-logo metadata is absent', async () => {
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('.express-logo')).to.not.exist;
+    });
+  });
+
+  describe('extract variant', () => {
+    it('block exists after init', async () => {
+      document.body.innerHTML = extract;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block).to.exist;
+    });
+
+    it('heading is present', async () => {
+      document.body.innerHTML = extract;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('h1')).to.exist;
+    });
+
+    it('paragraph is present', async () => {
+      document.body.innerHTML = extract;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('p')).to.exist;
+    });
+
+    it('always injects logo for extract variant (regardless of metadata)', async () => {
+      document.body.innerHTML = extract;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('.express-logo')).to.exist;
+    });
+  });
+
+  describe('logo injection via marquee-inject-logo metadata', () => {
+    it('injects logo when value is "on"', async () => {
+      addMeta('marquee-inject-logo', 'on');
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('.express-logo')).to.exist;
+    });
+
+    it('injects logo when value is "yes"', async () => {
+      addMeta('marquee-inject-logo', 'yes');
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('.express-logo')).to.exist;
+    });
+
+    it('does not inject logo for unrecognised values', async () => {
+      addMeta('marquee-inject-logo', 'true');
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      expect(block.querySelector('.express-logo')).to.not.exist;
+    });
+
+    it('logo appears immediately before the heading', async () => {
+      addMeta('marquee-inject-logo', 'on');
+      document.body.innerHTML = extract;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      const logo = block.querySelector('.express-logo');
+      const heading = block.querySelector('h1');
+      expect(logo).to.exist;
+      expect(logo.nextElementSibling).to.equal(heading);
+    });
+  });
+
+  describe('photo logo injection via marquee-inject-photo-logo metadata', () => {
+    it('injects photo logo when value is "on"', async () => {
+      addMeta('marquee-inject-photo-logo', 'on');
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      const logo = block.querySelector('.express-logo');
+      expect(logo).to.exist;
+      expect(logo.classList.contains('icon-adobe-express-logo-photos')).to.be.true;
+    });
+
+    it('prefers photo logo over standard logo when both metadata are set', async () => {
+      addMeta('marquee-inject-logo', 'on');
+      addMeta('marquee-inject-photo-logo', 'on');
+      document.body.innerHTML = basic;
+      const block = document.querySelector('.color-headline');
+      await init(block);
+      const logo = block.querySelector('.express-logo');
+      expect(logo.classList.contains('icon-adobe-express-logo-photos')).to.be.true;
+    });
+  });
+});

--- a/test/blocks/color-headline/mocks/basic.html
+++ b/test/blocks/color-headline/mocks/basic.html
@@ -1,0 +1,8 @@
+<div class="color-headline">
+  <div>
+    <div>
+      <h2>A Color Headline</h2>
+      <p>Some subtitle text for the block.</p>
+    </div>
+  </div>
+</div>

--- a/test/blocks/color-headline/mocks/extract.html
+++ b/test/blocks/color-headline/mocks/extract.html
@@ -1,0 +1,8 @@
+<div class="color-headline extract">
+  <div>
+    <div>
+      <h1>Extract a Color Palette from an image for free.</h1>
+      <p>Generate a downloadable palette you can use across your designs.</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- New `color-headline` block that renders the hero heading/copy for the color-extract tool page
- `extract` variant always injects the Adobe Express logo above the heading
- Metadata-driven logo injection (`marquee-inject-logo` / `marquee-inject-photo-logo`) for other variants

## Ticket: 
There's no ticket associated with this, we just need it for several components. You can now add your own variant. 

## Test plan
- [ ] Unit tests: `npx web-test-runner test/blocks/color-headline/**`
- [ ] Nala e2e: update spec path in `color-headline.spec.js` to the live page, then run `npx playwright test nala/blocks/color-headline`
- [ ] Manual: verify logo renders above h1 on a page using the `extract` variant
