### PR TITLE
Discover Cards Carousel Control Aria Fix

### DIFF
--- a/express/code/blocks/discover-cards/discover-cards.js
+++ b/express/code/blocks/discover-cards/discover-cards.js
@@ -28,16 +28,16 @@ const prevSVGHTML = `<svg width="32" height="32" viewBox="0 0 32 32" fill="none"
 </svg>`;
 const scrollPadding = 16;
 
-function createControl(items, container) {
+function createControl(items, container, sectionLabel = 'cards') {
   const control = createTag('div', { class: 'gallery-control loading' });
   const status = createTag('div', { class: 'status' });
   const prevButton = createTag('button', {
     class: 'prev',
-    'aria-label': 'Next',
+    'aria-label': `Previous ${sectionLabel}`,
   }, prevSVGHTML);
   const nextButton = createTag('button', {
     class: 'next',
-    'aria-label': 'Previous',
+    'aria-label': `Next ${sectionLabel}`,
   }, nextSVGHTML);
 
   const intersecting = Array.from(items).fill(false);
@@ -159,7 +159,9 @@ export async function buildGallery(
   root = container?.parentNode,
 ) {
   if (!root) throw new Error('Invalid Gallery input');
-  const control = createControl([...items], container);
+  const heading = root.querySelector('h2, h3, h4, h5, h6');
+  const sectionLabel = heading ? heading.textContent.trim() : 'cards';
+  const control = createControl([...items], container, sectionLabel);
   container.classList.add('gallery');
   [...items].forEach((item) => {
     item.classList.add('gallery--item');

--- a/express/code/blocks/discover-cards/discover-cards.js
+++ b/express/code/blocks/discover-cards/discover-cards.js
@@ -13,14 +13,14 @@ async function syncMinHeights(groups) {
   }));
 }
 
-const nextSVGHTML = `<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+const nextSVGHTML = `<svg aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g id="Slider Button - Arrow - Right">
     <circle id="Ellipse 24477" cx="16" cy="16" r="16" fill="#FFFFFF"/>
     <path id="chevron-right" d="M14.6016 21.1996L19.4016 16.3996L14.6016 11.5996" stroke="#292929" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
 </svg>
 `;
-const prevSVGHTML = `<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+const prevSVGHTML = `<svg aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
   <g id="Slider Button - Arrow - Left">
     <circle id="Ellipse 24477" cx="16" cy="16" r="16" transform="matrix(-1 0 0 1 32 0)" fill="#FFFFFF"/>
     <path id="chevron-right" d="M17.3984 21.1996L12.5984 16.3996L17.3984 11.5996" stroke="#292929" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
@@ -54,7 +54,7 @@ function createControl(items, container, sectionLabel = 'cards') {
   nextButton.addEventListener('click', () => pageInc(1));
 
   const dots = items.map(() => {
-    const dot = createTag('div', { class: 'dot' });
+    const dot = createTag('div', { class: 'dot', 'aria-hidden': 'true' });
     status.append(dot);
     return dot;
   });
@@ -120,6 +120,7 @@ function decorateFlipCards(card, cardDivs) {
 
     card.setAttribute('tabindex', '0');
     card.setAttribute('role', 'button');
+    card.setAttribute('aria-pressed', 'false');
     card.setAttribute('aria-label', `Learn more about ${card.cardTitleText}`);
 
     const plusIconWrapper = createTag('div', { class: 'plus-icon-wrapper' });
@@ -138,6 +139,7 @@ function decorateFlipCards(card, cardDivs) {
     card.addEventListener('click', () => {
       card.classList.toggle('is-flipped');
       const isFlipped = card.classList.contains('is-flipped');
+      card.setAttribute('aria-pressed', isFlipped ? 'true' : 'false');
       card.setAttribute(
         'aria-label',
         isFlipped ? `Go back to ${card.cardTitleText}` : `Learn more about ${card.cardTitleText}`,
@@ -165,7 +167,6 @@ export async function buildGallery(
   container.classList.add('gallery');
   [...items].forEach((item) => {
     item.classList.add('gallery--item');
-    item.setAttribute('tabindex', '0');
   });
   root.append(control);
 }
@@ -176,11 +177,12 @@ export default async function decorate(block) {
     ({ createTag } = utils);
   });
   const firstChild = block.querySelector(':scope > div:first-child');
+  let headerText = '';
 
   if (firstChild && firstChild.querySelector('h2, h3, h4, h5, h6')) {
     const header = firstChild.querySelector('h2, h3, h4, h5, h6');
     header.classList.add('center-title');
-    header.setAttribute('aria-label', `${header.textContent.trim()} cards`);
+    headerText = header.textContent.trim();
     block.insertBefore(firstChild, block.firstChild);
   }
 
@@ -188,8 +190,7 @@ export default async function decorate(block) {
   cardsWrapper.setAttribute('role', 'region');
 
   const cards = block.querySelectorAll(':scope > div:not(:first-child)');
-  const numCards = cards.length;
-  cardsWrapper.setAttribute('aria-label', `${numCards} cards in this section`);
+  cardsWrapper.setAttribute('aria-label', headerText || `${cards.length} cards`);
 
   const cardParagraphs = [[]];
   cards.forEach((card) => {

--- a/express/code/blocks/discover-cards/discover-cards.js
+++ b/express/code/blocks/discover-cards/discover-cards.js
@@ -167,6 +167,7 @@ export async function buildGallery(
   container.classList.add('gallery');
   [...items].forEach((item) => {
     item.classList.add('gallery--item');
+    item.setAttribute('tabindex', '0');
   });
   root.append(control);
 }


### PR DESCRIPTION
## Summary

This PR fixes the **discover-cards** carousel controls on pages such as Express Spotlight Business. The previous and next buttons had **swapped** `aria-label` values (left control announced “Next” and right “Previous”), and labels were **not** scoped to each carousel, so multiple galleries sounded identical. The buttons now use **`Previous` / `Next`** aligned with the visual arrows, and each pair is labeled with the **section heading** (for example, “Previous [heading]” / “Next [heading]”) so screen reader users get unique, descriptive names per block—addressing **WCAG 2.4.6 Headings and Labels (AA)**.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-190533

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/spotlight/business |
| **After** | https://nav-button-aira--da-express-milo--adobecom.aem.page/express/spotlight/business?martech=off |

---

## Verification Steps

1. **Environment:** Windows 11 Pro, Chrome 145.x, **NVDA** 2025.3.2 (or any screen reader), **logged out**. Open the **After** URL above.
2. **First carousel:** Tab to the gallery **Previous** and **Next** controls (feature-style cards). Confirm NVDA announces **previous/next** in the same direction as the **left/right** arrows, and that the label includes **that section’s heading** (not a duplicated generic “Next” / “Previous” only).
3. **“Real customers. Real results.”** section: Tab to that block’s **Previous** and **Next** controls. Confirm announcements are **unique** from the first carousel and **descriptive** (heading-based), e.g. along the lines of “Previous Real customers. Real results.” / “Next Real customers. Real results.” (exact wording follows the live heading text).
4. **Before vs after:** On **main**, repro the original issue: same generic names across galleries and reversed names vs arrows. On the **branch**, expect **consistent** direction and **distinct** labels per section.

---

## Potential Regressions

- https://nav-button-aira--da-express-milo--adobecom.aem.live/express/spotlight/business?martech=off  
- Spot-check other pages that use the **discover-cards** block with multiple carousels or non-English headings, to ensure labels stay understandable when the heading is long or localized.

---

## Additional Notes

- **Screen / surface:** Express – Spotlight Business (`/express/spotlight/business`).
- **Affected audience:** Users relying on screen readers or other AT; aligns with the reported population (e.g. blind, low vision, motor/cognitive barriers where clear labels matter).
- **Prior behavior:** `aria-label` on `.prev` / `.next` did not match control purpose or visual affordance; duplicate “Next” / “Previous” across galleries.
- **Approach:** Programmatic labels via **`aria-label`** on each button, incorporating the section heading from `buildGallery` (`discover-cards.js`) so labels stay in sync with authored content—consistent with remediation option (1) in the defect.
- **Reference:** [Deque – meaningful labels](https://dequeuniversity.com/class/forms/labels/meaningful)

---