### PR TITLE
[MWPW-185797] sticky search-bar should remain only in bounds of color-explore block

### DIFF
--- a/express/code/blocks/color-search-marquee/color-search-marquee.css
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.css
@@ -231,3 +231,9 @@
   }
 }
 
+.search-bar-sticky-wrapper.is-sticky-clone.is-past-boundary {
+  opacity: 0 !important;
+  pointer-events: none !important;
+  visibility: hidden !important;
+}
+

--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -8,6 +8,44 @@ const CHEVRON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22"
   <path d="M8.5 4.5L15 11L8.5 17.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>`;
 
+function setupExploreBoundary() {
+  const getExploreBlock = () => document.querySelector('.color-explore');
+  const getStickyWrapper = () => document.querySelector('.search-bar-sticky-wrapper.is-sticky-clone');
+  let resizeObserver = null;
+  let observedExplore = null;
+
+  const update = () => {
+    const wrapper = getStickyWrapper();
+    const explore = getExploreBlock();
+    if (!wrapper || !explore) return;
+
+    if (explore !== observedExplore) {
+      resizeObserver?.disconnect();
+      resizeObserver = new ResizeObserver(update);
+      resizeObserver.observe(explore);
+      observedExplore = explore;
+    }
+
+    const exploreBottom = explore.getBoundingClientRect().bottom;
+    const viewportHeight = window.innerHeight;
+    const barAreaTop = viewportHeight - wrapper.offsetHeight - (viewportHeight * 0.05);
+    wrapper.classList.toggle('is-past-boundary', exploreBottom < barAreaTop);
+  };
+
+  window.addEventListener('scroll', update, { passive: true });
+  window.addEventListener('resize', update, { passive: true });
+
+  return () => {
+    window.removeEventListener('scroll', update);
+    window.removeEventListener('resize', update);
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    observedExplore = null;
+    const wrapper = getStickyWrapper();
+    if (wrapper) wrapper.classList.remove('is-past-boundary');
+  };
+}
+
 function parseTagsRow(row) {
   const text = row?.textContent?.trim();
   if (!text) return [];
@@ -189,6 +227,7 @@ export default async function decorate(block) {
   );
 
   block.append(searchBar.element);
+  const cleanupBoundary = setupExploreBoundary();
 
   const emptyResult = createEmptyResultElements(block, searchBar.element);
 
@@ -242,6 +281,7 @@ export default async function decorate(block) {
       emptyResult.description.textContent = '';
     },
     destroy: () => {
+      cleanupBoundary();
       cleanupPopState();
       searchBar.destroy();
     },


### PR DESCRIPTION
## Summary

Color Search bar in sticky mode should remain in the bounds of explore block. If explore block is expanded, the search bar appears again.

---

## Jira Ticket

Resolves: [MWPW-185797](https://jira.corp.adobe.com/browse/MWPW-185797)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/dhananjay/color/gradients |
| **After**   | https://MWPW-185797-search-marquee--da-express-milo--adobecom.aem.page/drafts/dhananjay/color/gradients?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
