### PR TITLE
Filter Empty Content For FaqV2 Block

### DIFF
--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -8,7 +8,7 @@
   --icon-color: #05834E;
   --cell-width: var(--ax-grid-5-col-width);
   --plan-cell-background-color: #F5F5F5;
-  --gnav-offset-height: 64px;
+  --gnav-offset-height: var(--spacing-800);
   --plan-cell-height: 65px;
   --header-cell-width: var(--ax-grid-12-col-width);
   
@@ -36,7 +36,7 @@
 }
 
 .comparison-table-v2.padding-top {
-  padding-top: 32px;
+  padding-top: var(--spacing-500);
 } 
 
 .comparison-table-v2>* {
@@ -202,7 +202,7 @@ body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-of
 }
 
 .comparison-table-v2 .sticky-header.is-stuck-initial .plan-cell {
-  width: calc(var(--cell-width) - 2px);
+  width: calc(var(--cell-width) - var(--spacing-50));
 }
 
 
@@ -300,7 +300,7 @@ padding-bottom: 0;
 
 .comparison-table-v2 .sticky-header .plan-cell a.con-button {
   margin: var(--spacing-100) 0 0;
-  padding: 5px var(--spacing-100) 6px;
+  padding: 5px var(--spacing-100) var(--spacing-80);
   box-sizing: border-box;
   width: 100%;
   min-height: var(--min-button-height);
@@ -325,7 +325,7 @@ padding-bottom: 0;
 }
 
 .comparison-table-v2 .sticky-header .premium .plan-cell-wrapper {
-min-height: calc(var(--plan-cell-height) - 4px);
+min-height: calc(var(--plan-cell-height) - var(--spacing-75));
 }
 
 
@@ -516,7 +516,7 @@ main .comparison-table-v2 .sticky-header .plan-cell-wrapper:not(:has(p)) > :is(h
   font-size: var(--ax-heading-xs-size);
   font-style: normal;
   font-weight: var(--ax-heading-weight);
-  line-height: 20px;
+  line-height: var(--spacing-350);
   padding-left: 36px;
 }
 
@@ -540,7 +540,7 @@ display: block;
 
 width: var(--header-cell-width);
 align-items: flex-start;
-gap: var(--Spacing-spacing-50, 2px);
+gap: var(--Spacing-spacing-50, var(--spacing-50));
 align-self: stretch;
 box-sizing: content-box;
 text-align: center;
@@ -585,7 +585,7 @@ flex-grow: 1;
   font-family: var(--body-font-family);
   font-size: var(--ax-body-xs-size);
   font-weight: var(--ax-body-weight-bold);
-  line-height: 18px;
+  line-height: var(--spacing-325);
 }
 
 
@@ -626,7 +626,7 @@ flex-grow: 1;
   line-height: var(--heading-line-height);
   color: var(--color-dark-gray);
   display: inline;
-  padding-top: 2px;
+  padding-top: var(--spacing-50);
 }
 
 /* Invisible/hidden elements */
@@ -694,11 +694,11 @@ flex-grow: 1;
 .comparison-table-v2 .icon-chevron-down {
   position: absolute;
   display: block;
-  bottom: -2px;
+  bottom: -var(--spacing-50);
   z-index: 6;
   margin: auto;
   pointer-events: none;
-  left: calc(50% - 12px);
+  left: calc(50% - var(--spacing-200));
   width: var(--chevron-size);
   height: var(--chevron-size);
 }
@@ -755,7 +755,7 @@ flex-grow: 1;
 
 @media (max-width: 767px) {
   .comparison-table-v2 .plan-selector-choices.right-aligned {
-      right: 0px;
+      right: var(--spacing-0);
       left: auto;
   }
 }
@@ -839,7 +839,7 @@ flex-grow: 1;
   background-position: center;
   width: 19px;
   min-width: 19px;
-  height: 18px;
+  height: var(--spacing-325);
   display: block;
 }
 
@@ -1039,6 +1039,7 @@ color: var(--color-gray-700-variant);
       flex-wrap: nowrap;
       max-width: 1300px; 
       text-align: left;
+      margin-left: -var(--spacing-50);
       display: flex;
   }
 
@@ -1292,7 +1293,7 @@ color: var(--color-gray-700-variant);
 /* removed empty media queries to reduce CSS size */
 
 .comparison-table-v2 .tooltip {
-  gap: 0px;
+  gap: var(--spacing-0);
   flex-direction: row;
 }
 

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -8,7 +8,7 @@
   --icon-color: #05834E;
   --cell-width: var(--ax-grid-5-col-width);
   --plan-cell-background-color: #F5F5F5;
-  --gnav-offset-height: var(--spacing-800);
+  --gnav-offset-height: 64px;
   --plan-cell-height: 65px;
   --header-cell-width: var(--ax-grid-12-col-width);
   
@@ -36,7 +36,7 @@
 }
 
 .comparison-table-v2.padding-top {
-  padding-top: var(--spacing-500);
+  padding-top: 32px;
 } 
 
 .comparison-table-v2>* {
@@ -202,7 +202,7 @@ body[data-device="desktop"] .comparison-table-v2 .sticky-header.is-stuck.gnav-of
 }
 
 .comparison-table-v2 .sticky-header.is-stuck-initial .plan-cell {
-  width: calc(var(--cell-width) - var(--spacing-50));
+  width: calc(var(--cell-width) - 2px);
 }
 
 
@@ -300,7 +300,7 @@ padding-bottom: 0;
 
 .comparison-table-v2 .sticky-header .plan-cell a.con-button {
   margin: var(--spacing-100) 0 0;
-  padding: 5px var(--spacing-100) var(--spacing-80);
+  padding: 5px var(--spacing-100) 6px;
   box-sizing: border-box;
   width: 100%;
   min-height: var(--min-button-height);
@@ -325,7 +325,7 @@ padding-bottom: 0;
 }
 
 .comparison-table-v2 .sticky-header .premium .plan-cell-wrapper {
-min-height: calc(var(--plan-cell-height) - var(--spacing-75));
+min-height: calc(var(--plan-cell-height) - 4px);
 }
 
 
@@ -516,7 +516,7 @@ main .comparison-table-v2 .sticky-header .plan-cell-wrapper:not(:has(p)) > :is(h
   font-size: var(--ax-heading-xs-size);
   font-style: normal;
   font-weight: var(--ax-heading-weight);
-  line-height: var(--spacing-350);
+  line-height: 20px;
   padding-left: 36px;
 }
 
@@ -540,7 +540,7 @@ display: block;
 
 width: var(--header-cell-width);
 align-items: flex-start;
-gap: var(--Spacing-spacing-50, var(--spacing-50));
+gap: var(--Spacing-spacing-50, 2px);
 align-self: stretch;
 box-sizing: content-box;
 text-align: center;
@@ -585,7 +585,7 @@ flex-grow: 1;
   font-family: var(--body-font-family);
   font-size: var(--ax-body-xs-size);
   font-weight: var(--ax-body-weight-bold);
-  line-height: var(--spacing-325);
+  line-height: 18px;
 }
 
 
@@ -626,7 +626,7 @@ flex-grow: 1;
   line-height: var(--heading-line-height);
   color: var(--color-dark-gray);
   display: inline;
-  padding-top: var(--spacing-50);
+  padding-top: 2px;
 }
 
 /* Invisible/hidden elements */
@@ -694,11 +694,11 @@ flex-grow: 1;
 .comparison-table-v2 .icon-chevron-down {
   position: absolute;
   display: block;
-  bottom: -var(--spacing-50);
+  bottom: -2px;
   z-index: 6;
   margin: auto;
   pointer-events: none;
-  left: calc(50% - var(--spacing-200));
+  left: calc(50% - 12px);
   width: var(--chevron-size);
   height: var(--chevron-size);
 }
@@ -755,7 +755,7 @@ flex-grow: 1;
 
 @media (max-width: 767px) {
   .comparison-table-v2 .plan-selector-choices.right-aligned {
-      right: var(--spacing-0);
+      right: 0px;
       left: auto;
   }
 }
@@ -839,7 +839,7 @@ flex-grow: 1;
   background-position: center;
   width: 19px;
   min-width: 19px;
-  height: var(--spacing-325);
+  height: 18px;
   display: block;
 }
 
@@ -1039,7 +1039,6 @@ color: var(--color-gray-700-variant);
       flex-wrap: nowrap;
       max-width: 1300px; 
       text-align: left;
-      margin-left: -var(--spacing-50);
       display: flex;
   }
 
@@ -1293,7 +1292,7 @@ color: var(--color-gray-700-variant);
 /* removed empty media queries to reduce CSS size */
 
 .comparison-table-v2 .tooltip {
-  gap: var(--spacing-0);
+  gap: 0px;
   flex-direction: row;
 }
 

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -64,7 +64,8 @@ function buildTableLayout(block) {
     return;
   }
 
-  collapsibleRows.forEach(({ header, subHeader }, index) => {
+  const filteredRows = collapsibleRows.filter((row) => row.header || row.subHeader);
+  filteredRows.forEach(({ header, subHeader }, index) => {
     const rowWrapper = createTag('div', { class: 'faqv2-wrapper' });
     container.appendChild(rowWrapper);
 
@@ -311,7 +312,8 @@ async function buildOriginalLayout(block) {
   const visibleCount = 3;
   let isExpanded = false;
 
-  collapsibleRows.forEach((row, index) => {
+  const filteredRows = collapsibleRows.filter((row) => row.header || row.subHeader);
+  filteredRows.forEach((row, index) => {
     const { header, subHeader } = row;
 
     const accordion = createTag('div', { class: 'faqv2-accordion' });
@@ -334,7 +336,7 @@ async function buildOriginalLayout(block) {
     }
   });
 
-  const hiddenCount = collapsibleRows.length - visibleCount;
+  const hiddenCount = filteredRows.length - visibleCount;
   const toggleButton = createTag('a', {
     class: 'faqv2-toggle-btn button',
     'aria-expanded': false,
@@ -344,7 +346,7 @@ async function buildOriginalLayout(block) {
   });
 
   toggleButton.textContent = viewMoreText;
-  if (collapsibleRows.length > visibleCount) {
+  if (filteredRows.length > visibleCount) {
     block.append(toggleButton);
   }
 

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -382,7 +382,7 @@ export default async function decorate(block) {
   if (isExpandableVariant) {
     buildTableLayout(block);
   } else {
-    buildOriginalLayout(block);
+    await buildOriginalLayout(block);
   }
 
   const hideSchemaPageLevel = getMetadata('show-faq-schema') === 'no';

--- a/test/blocks/faqv2/faqv2.test.js
+++ b/test/blocks/faqv2/faqv2.test.js
@@ -206,6 +206,40 @@ describe('FAQv2', () => {
     expect(block.style.display).to.equal('none');
   });
 
+  it('should skip empty rows in a mixed content block (expandable layout)', async () => {
+    const mixedExpandable = `
+      <div class="faqv2 expandable">
+        <div><div>Frequently Asked Questions</div></div>
+        <div><div>Question 1</div><div>Answer 1</div></div>
+        <div><div></div><div></div></div>
+        <div><div>Question 2</div><div>Answer 2</div></div>
+      </div>
+    `;
+    document.body.innerHTML = mixedExpandable;
+    const block = document.querySelector('.faqv2');
+    await decorate(block);
+
+    const wrappers = block.querySelectorAll('.faqv2-wrapper');
+    expect(wrappers.length).to.equal(2);
+  });
+
+  it('should skip empty rows in a mixed content block (original layout)', async () => {
+    const mixedBody = `
+      <div class="faqv2">
+        <div><div>Question 1</div><div>Answer 1</div></div>
+        <div><div></div><div></div></div>
+        <div><div>Question 2</div><div>Answer 2</div></div>
+        <div><div></div><div></div></div>
+      </div>
+    `;
+    document.body.innerHTML = mixedBody;
+    const block = document.querySelector('.faqv2');
+    await decorate(block);
+
+    const accordions = block.querySelectorAll('.faqv2-accordion');
+    expect(accordions.length).to.equal(2);
+  });
+
   it('should hide block when there is no content (original layout)', async () => {
     const emptyBody = `
       <div class="faqv2">


### PR DESCRIPTION
## Summary

The FAQ v2 block could still render when every row was empty (no header and no subheader), so the block appeared on template child pages with no real FAQ content. This change filters collapsible rows to those that have at least a header or subheader before building both the table and original layouts, and uses that filtered list for the “view more” toggle so the block stays aligned with visible items.

---

## Jira Ticket

Resolves: [MWPW-191326](https://jira.corp.adobe.com/browse/MWPW-191326)

---

## Test URLs

| Env | URL |
|-----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/in/express/templates/announcement/wedding-draft |
| **After** | https://faq-v2-empty-content--da-express-milo--adobecom.aem.page/in/express/templates/announcement/wedding-draft?martech=off |

---

## Verification Steps

1. Open the **Before** URL on a template child page where FAQs are optional and no FAQ copy is authored (e.g. wedding announcement draft).
2. **Before:** The FAQ block can appear even though there is no FAQ content.
3. Open the **After** URL for the same path.
4. **After:** With no FAQ rows that have header or subheader text, the block should not surface visible FAQ UI (behavior should match “optional — if there’s no content, block should not appear”).
5. Spot-check a page that **does** have FAQ content to confirm accordions still render and “view more” still works when there are more than three items.

---

## Potential Regressions

- https://faq-v2-empty-content--da-express-milo--adobecom.aem.live/in/express/templates/announcement/wedding-draft?martech=off
- https://faq-v2-empty-content--da-express-milo--adobecom.aem.live/docs/library/kitchen-sink/faqv2

---

## Additional Notes

- Related background: [MWPW-178667](https://jira.corp.adobe.com/browse/MWPW-178667).
- Code change is limited to `express/code/blocks/faqv2/faqv2.js` (filter rows with `row.header || row.subHeader` in both layout paths).
