### PR TITLE
MWPW-186675 Fix base marker and broken harmonies

### DIFF
--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -143,8 +143,7 @@ export class ColorWheelExpress extends ColorWheel {
     const markerLayer = this.shadowRoot.querySelector('.marker-layer');
     if (!markerLayer || !this.swatches.length) return;
 
-    // Fast path: during drag, only update the dragged marker's position
-    if (this._dragIndex >= 0) {
+    if (this.harmonyRule === 'CUSTOM' && this._dragIndex >= 0) {
       const swatch = this.swatches[this._dragIndex];
       if (!swatch?.hsv) return;
 
@@ -159,15 +158,6 @@ export class ColorWheelExpress extends ColorWheel {
         marker.style.left = `calc(50% + ${x}px)`;
         marker.style.top = `calc(50% + ${y}px)`;
         marker.style.setProperty('--wheel-marker-color', swatch.hex);
-      }
-
-      const spoke = markerLayer.querySelector(`.wheel-spoke[data-spoke="${this._dragIndex}"]`);
-      if (spoke) {
-        const showSpokes = this.harmonyRule !== 'CUSTOM';
-        if (radius > 0 && showSpokes) {
-          spoke.style.width = `${radius}px`;
-          spoke.style.transform = `rotate(${-smoothH}deg)`;
-        }
       }
 
       this.drawLines();
@@ -202,6 +192,9 @@ export class ColorWheelExpress extends ColorWheel {
       marker.style.setProperty('--wheel-marker-color', swatch.hex);
       marker.style.zIndex = index === this.baseColorIndex ? 10 : 5;
       marker.dataset.index = index;
+      if (index === this.baseColorIndex && this.harmonyRule !== 'CUSTOM') {
+        marker.classList.add('wheel-marker-overlay--base');
+      }
       marker.addEventListener('pointerdown', (e) => this.handleMarkerDown(e, index));
 
       markerLayer.appendChild(marker);

--- a/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
@@ -81,7 +81,7 @@ export const style = css`
         cursor: grabbing;
     }
 
-    .wheel-marker-overlay[data-index="0"]::before {
+    .wheel-marker-overlay--base::before {
         content: '';
         height: 4px;
         width: 4px;
@@ -93,7 +93,7 @@ export const style = css`
         border-radius: 15px;
     }
 
-    .wheel-marker-overlay[data-index="0"]::after {
+    .wheel-marker-overlay--base::after {
         content: '';
         height: 15px;
         width: 15px;


### PR DESCRIPTION
## Summary

Resolves two bugs in the color wheel that we introduced recently:

1. For the custom harmony (AKA no harmony), there shouldn't be a base color marker (bullseye).
2. For harmony modes other than custom, moving the markers should maintain the harmony relationship (markers move together).

---

## Jira Ticket

Related to: [MWPW-186675](https://jira.corp.adobe.com/browse/MWPW-186675)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/methomas/color/color-palette-sidebar |
| **After**   | https://methomas-wheel-bugs--da-express-milo--adobecom.aem.page/drafts/methomas/color/color-palette-sidebar |
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-sidebar |
| **After**   | https://methomas-wheel-bugs--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-sidebar |
---

## Verification Steps

- Go to: https://color--da-express-milo--adobecom.aem.page/drafts/methomas/color/color-palette-sidebar
- Note that on the "custom" harmony, there is a base color marker (bullseye).
- Switch the harmony to "analogous" (or anything other than custom) and move the markers around.
- Note that each marker only moves itself. The harmony relationship is not maintained when moving a marker.
- Go to: https://methomas-wheel-bugs--da-express-milo--adobecom.aem.page/drafts/methomas/color/color-palette-sidebar
- Note that on the "custom" harmony, there is no base color marker (bullseye).
- Switch the harmony to "analogous" (or anything other than custom).
- Note that there is a base color marker.
- Move the markers around.
- Note that the markers move together to retain the harmony relationship.

- Go to: https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-sidebar
- Note that there is a base color marker (bullseye).
- Got to: https://methomas-wheel-bugs--da-express-milo--adobecom.aem.page/drafts/vineesha/color-blindness-sidebar
- Note that there is no base color marker (bullseye).

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
