### PR TITLE
Pin Axios Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@web/test-runner-commands": "^0.9.0",
     "axe-core": "^4.10.3",
     "axe-html-reporter": "^2.2.11",
-    "axios": "^1.9.0",
+    "axios": "1.9.0",
     "chai": "4.3.6",
     "chalk": "^4.1.2",
     "commander": "^13.1.0",


### PR DESCRIPTION
Pin the axios version until the supply chain attack for this package is resolved. Affected versions are 1.14.1 and 0.30.4, so we are not affected currently.