### PR TITLE
Content Replace Null Check Fix

### DIFF
--- a/express/code/scripts/utils/content-replace.js
+++ b/express/code/scripts/utils/content-replace.js
@@ -246,7 +246,7 @@ async function getReplacementsFromSearch() {
 const bladeRegex = /\{\{[a-zA-Z_-]+\}\}/g;
 
 function replaceBladesInStr(str, replacements) {
-  if (!replacements) return str;
+  if (!replacements || str === null) return str;
   return str.replaceAll(bladeRegex, (match) => {
     if (match in replacements) {
       return replacements[match];


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves the graceless crash in `content-replace.js` that happens if a metadata tag with no content is parsed. Function only affects template block pages.

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://content-replace-null-check--da-express-milo--adobecom.aem.page/express/templates/search?tasks=&tasksx=&phformat=2:3&topics=apple&q=apple&searchId=537614 |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the template page to verify that the content loads. Use the template search function (type in a custom search query) to verify that the page navigation works again

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
