### PR TITLE
Content Replace Null Check Fix

### DIFF
--- a/express/code/scripts/utils/content-replace.js
+++ b/express/code/scripts/utils/content-replace.js
@@ -246,7 +246,7 @@ async function getReplacementsFromSearch() {
 const bladeRegex = /\{\{[a-zA-Z_-]+\}\}/g;
 
 function replaceBladesInStr(str, replacements) {
-  if (!replacements) return str;
+  if (!replacements || str === null) return str;
   return str.replaceAll(bladeRegex, (match) => {
     if (match in replacements) {
       return replacements[match];


### PR DESCRIPTION
## Summary

Resolves the graceless crash in content-replace.js that happens if a metadata tag with no content is parsed. Function only affects template block pages.

Related PR to stage: #274

---

## Jira Ticket

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://hotfix-content-replace--da-express-milo--adobecom.aem.page/express/templates/search?tasks=&tasksx=&phformat=2:3&topics=apple&q=apple&searchId=537614 |

---

## Verification Steps

- Visit the template page to verify that the content loads. Use the template search function (type in a custom search query) to verify that the page navigation works again

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
