### PR TITLE
MWPW-189007 Action menu tablet and mobile style fixes

### DIFF
--- a/express/code/scripts/color-shared/action-menu.css
+++ b/express/code/scripts/color-shared/action-menu.css
@@ -1,13 +1,12 @@
-.action-menu-full {
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: space-between;
-}
-
+.action-menu-full,
 .action-menu-nav-only {
   display: flex;
   padding-block: var(--spacing-100);
-  border-bottom: var(--Palette-gray-100);
+  border-bottom: 1px solid var(--Palette-gray-100);
+}
+
+.action-menu-full .action-menu-controls {
+  display: none;
 }
 
 .action-menu-nav {
@@ -69,6 +68,7 @@
 .color-action-button svg {
   width: 20px;
   height: 20px;
+  display: flex;
 }
 
 .color-action-button svg :is(path, rect) {
@@ -121,4 +121,35 @@
 .action-menu-full.expanded .contrast-link,
 .action-menu-full.expanded .color-blindness-link {
   display: none;
+}
+
+@media (min-width: 600px) {
+  .action-menu-full,
+  .action-menu-nav-only {
+    padding-block: 0 var(--spacing-100);
+  }
+}
+
+@media (min-width: 888px) {
+  .action-menu-full {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    padding-block: 0;
+    border-bottom: none;
+  }
+
+  .action-menu-full .action-menu-controls {
+    display: flex;
+  }
+}
+
+@media (min-width: 1200px) {
+  .action-menu-full {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    padding-block: 0;
+    border-bottom: none;
+  }
 }


### PR DESCRIPTION
## Summary

- New padding styles for tablet (this is the "M" size in figma)
- Fix bottom border on mobile/tablet
- Fix icon alignment on mobile
- Make sure "full" type can be used as "nav-only" on tablet and mobile (adopts those styles).

---

## Jira Ticket

Resolves: [MWPW-189007](https://jira.corp.adobe.com/browse/MWPW-189007)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/esallee/color-gwp/contrast-checker|
| **After**   | https://methomas-action-menu-mobile--da-express-milo--adobecom.aem.page/drafts/esallee/color-gwp/contrast-checker|
| **Before**  |https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://methomas-action-menu-mobile--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |

---

## Verification Steps

- Desktop (1440px): should remain the same
- Large tablet (1024px): should remain the same
- Small tablet (768px): should have bottom border, no top padding, and no undo/redo arrows
- Mobile (425px): should have bottom border, no top padding, no undo/redo arrows, and icons should be perfectly centered in buttons

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
