### PR TITLE
[MWPW-189370] [Color] Refactor drawer tag chips into dedicated tag field with pill UI and a11y  

### DIFF
--- a/express/code/blocks/color-contrast-checker/color-contrast-checker.js
+++ b/express/code/blocks/color-contrast-checker/color-contrast-checker.js
@@ -4,11 +4,10 @@ import { createContrastRenderer } from './factory/createContrastRenderer.js';
 import loadContrastCheckerPlaceholders from './utils/placeholders.js';
 import { createPreviewRenderer } from './renderers/createPreviewRenderer.js';
 import createContrastDataService from './services/createContrastDataService.js';
-import { CONTRAST_PRESETS, createDefaultActionMenuConfig } from './utils/contrastConstants.js';
-import { hsvToRgb, rgbToHex } from './utils/contrastUtils.js';
+import { createDefaultActionMenuConfig } from './utils/contrastConstants.js';
 import parseContent from './utils/parseContent.js';
 import syncPaletteSelections from './utils/paletteState.js';
-import { isMobileOrTabletViewport } from '../../scripts/color-shared/utils/utilities.js';
+import { isMobileOrTabletViewport, createColorPaletteParamApi } from '../../scripts/color-shared/utils/utilities.js';
 import adoptHeadline from '../../scripts/color-shared/utils/adoptHeadline.js';
 
 const blockInstances = new WeakMap();
@@ -20,28 +19,20 @@ function getDefaultConfig() {
   };
 }
 
-function pickRandomPreset(strings) {
-  const preset = CONTRAST_PRESETS[Math.floor(Math.random() * CONTRAST_PRESETS.length)];
-  const toHex = ([h, s, v]) => {
-    const { r, g, b } = hsvToRgb(h, s / 100, v / 100);
-    return rgbToHex(r, g, b);
+function getPalette(strings) {
+  const { getResolvedPalette, getResolvedPaletteName } = createColorPaletteParamApi();
+  const colors = getResolvedPalette();
+  const name = getResolvedPaletteName() || strings.randomPresetName;
+
+  const dataService = createContrastDataService();
+  const { brightest, darkest } = dataService.findBrightestAndDarkest(colors);
+
+  return {
+    foreground: brightest || colors[0],
+    background: darkest || colors[1],
+    colors,
+    name,
   };
-  const colors = [toHex(preset.fg), toHex(preset.bg)];
-  return { foreground: colors[0], background: colors[1], colors, name: strings.randomPresetName };
-}
-
-function getPalette(config, strings) {
-  if (config.foreground && config.background) {
-    const colors = [config.foreground, config.background];
-    return {
-      foreground: colors[0],
-      background: colors[1],
-      colors,
-      name: strings.customPaletteName,
-    };
-  }
-
-  return pickRandomPreset(strings);
 }
 
 async function mountContrastChecker(slot, { config, layout, initialPalette }) {
@@ -156,7 +147,7 @@ export default async function decorate(block) {
     };
     block.replaceChildren();
 
-    const initialPalette = getPalette(config, strings);
+    const initialPalette = getPalette(strings);
     layoutInstance = await createColorToolLayout(block, {
       layoutSpans: {
         tablet: { sidebar: 6, canvas: 6 },

--- a/express/code/blocks/color-contrast-checker/renderers/createCheckerRenderer.js
+++ b/express/code/blocks/color-contrast-checker/renderers/createCheckerRenderer.js
@@ -146,6 +146,14 @@ function buildResultCell(pass, strings) {
   return cell;
 }
 
+function generateTintScale(hex) {
+  return ['#000000', ...generateTints(hex, TINT_COUNT - 1)];
+}
+
+function clampTintIndex(index) {
+  return Math.max(0, Math.min(MAX_TINT_INDEX, Number(index) || 0));
+}
+
 function buildTintGradient(hex) {
   const tints = generateTintScale(hex);
   const stops = tints.map((t, i) => {
@@ -155,18 +163,10 @@ function buildTintGradient(hex) {
   return `linear-gradient(to right, ${stops.join(', ')})`;
 }
 
-function generateTintScale(hex) {
-  return ['#000000', ...generateTints(hex, TINT_COUNT - 1)];
-}
-
 function findTintIndex(hex) {
   const { r, g, b } = hexToRgb(hex);
   const { v } = rgbToHsv(r, g, b);
   return clampTintIndex(Math.round(v * MAX_TINT_INDEX));
-}
-
-function clampTintIndex(index) {
-  return Math.max(0, Math.min(MAX_TINT_INDEX, Number(index) || 0));
 }
 
 function tintIndexToPercentValue(index) {
@@ -330,6 +330,11 @@ function syncColorControl(input, slider, hex) {
   slider?.updatePosition(hex);
 }
 
+function isSameHistoryState(a, b) {
+  return a?.[0]?.toUpperCase() === b?.[0]?.toUpperCase()
+    && a?.[1]?.toUpperCase() === b?.[1]?.toUpperCase();
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export function createCheckerRenderer(options) {
   const {
@@ -378,7 +383,9 @@ export function createCheckerRenderer(options) {
     const selectedColor = type === 'fg'
       ? palette?.selectedForeground ?? currentValue
       : palette?.selectedBackground ?? currentValue;
-    const selectedIndex = colors.findIndex((hex) => hex?.toUpperCase() === selectedColor?.toUpperCase());
+    const selectedIndex = colors.findIndex(
+      (hex) => hex?.toUpperCase() === selectedColor?.toUpperCase(),
+    );
 
     if (!colors.length || selectedIndex === -1) {
       return {
@@ -397,11 +404,6 @@ export function createCheckerRenderer(options) {
 
   function getHistoryState() {
     return [foreground, background];
-  }
-
-  function isSameHistoryState(a, b) {
-    return a?.[0]?.toUpperCase() === b?.[0]?.toUpperCase()
-      && a?.[1]?.toUpperCase() === b?.[1]?.toUpperCase();
   }
 
   function clearHistoryTimer() {
@@ -625,13 +627,15 @@ export function createCheckerRenderer(options) {
       const { createActionMenuComponent } = await import(
         '../../../scripts/color-shared/components/createActionMenuComponent.js'
       );
+      const fullMenuEl = actionMenuApi?.element;
       mobileActionMenu = await createActionMenuComponent({
         ...createDefaultActionMenuConfig(strings),
         id: ACTION_MENU_ID,
         type: 'controls-only',
-        enableState: true,
-        onUndo: () => actionMenuState.onUndo(),
-        onRedo: () => actionMenuState.onRedo(),
+        activeId: 'contrast',
+        enableState: false,
+        onUndo: () => fullMenuEl?.querySelector('.undo-btn')?.click(),
+        onRedo: () => fullMenuEl?.querySelector('.redo-btn')?.click(),
       });
       if (mobileActionMenu?.element) {
         top.appendChild(mobileActionMenu.element);

--- a/express/code/blocks/color-contrast-checker/renderers/createCheckerRenderer.js
+++ b/express/code/blocks/color-contrast-checker/renderers/createCheckerRenderer.js
@@ -9,7 +9,6 @@ import { createColorInput } from './components/createColorInput.js';
 import { createExpressTabs } from '../../../scripts/color-shared/spectrum/components/express-tabs.js';
 import { loadActionButton, loadBadge, loadTooltip } from '../../../scripts/color-shared/spectrum/load-spectrum.js';
 import { createThemeWrapper } from '../../../scripts/color-shared/spectrum/utils/theme.js';
-import { createActionMenuState } from '../../../scripts/color-shared/components/createActionMenuState.js';
 import { createContrastCheckerPlaceholders } from '../utils/placeholders.js';
 import { FAIL, createDefaultActionMenuConfig } from '../utils/contrastConstants.js';
 import '../../../scripts/color-shared/components/color-channel-slider/index.js';
@@ -350,7 +349,6 @@ export function createCheckerRenderer(options) {
   const { recommendation: recommendationService } = services;
   const strings = createContrastCheckerPlaceholders(config.strings);
   const tabs = config.tabs || strings.tabs;
-  const actionMenuState = createActionMenuState(ACTION_MENU_ID);
 
   let foreground = config.initialForeground;
   let background = config.initialBackground;

--- a/express/code/blocks/color-contrast-checker/renderers/createCheckerRenderer.js
+++ b/express/code/blocks/color-contrast-checker/renderers/createCheckerRenderer.js
@@ -625,15 +625,14 @@ export function createCheckerRenderer(options) {
       const { createActionMenuComponent } = await import(
         '../../../scripts/color-shared/components/createActionMenuComponent.js'
       );
-      const fullMenuEl = actionMenuApi?.element;
       mobileActionMenu = await createActionMenuComponent({
         ...createDefaultActionMenuConfig(strings),
         id: ACTION_MENU_ID,
         type: 'controls-only',
         activeId: 'contrast',
         enableState: false,
-        onUndo: () => fullMenuEl?.querySelector('.undo-btn')?.click(),
-        onRedo: () => fullMenuEl?.querySelector('.redo-btn')?.click(),
+        onUndo: () => actionMenuApi?.undo?.(),
+        onRedo: () => actionMenuApi?.redo?.(),
       });
       if (mobileActionMenu?.element) {
         top.appendChild(mobileActionMenu.element);

--- a/express/code/blocks/color-contrast-checker/utils/contrastConstants.js
+++ b/express/code/blocks/color-contrast-checker/utils/contrastConstants.js
@@ -15,16 +15,6 @@ export const WCAG_THRESHOLDS = {
   UI_AA: 3,
 };
 
-// Random preset color pairs in HSV format [h, s, v]
-// Picked on initial load to provide variety
-export const CONTRAST_PRESETS = [
-  { bg: [16, 81, 86], fg: [0, 0, 100] },
-  { bg: [326, 52, 90], fg: [192, 100, 29] },
-  { bg: [176, 100, 75], fg: [219, 79, 54] },
-  { bg: [210, 36, 77], fg: [215, 71, 36] },
-  { bg: [179, 100, 48], fg: [42, 73, 100] },
-];
-
 export function createDefaultActionMenuConfig(placeholders = {}) {
   return {
     navLinks: [

--- a/express/code/libs/services/middlewares/auth.middleware.js
+++ b/express/code/libs/services/middlewares/auth.middleware.js
@@ -1,5 +1,5 @@
 import { AuthenticationError } from '../core/Errors.js';
-import { getMetadata } from '../../../scripts/utils.js';
+import { getMetadata, getLibs } from '../../../scripts/utils.js';
 
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const DEFAULT_IMS_TIMEOUT_MS = 10_000;
@@ -61,7 +61,6 @@ function notifyImsReady() {
  * @returns {Promise<void>}
  */
 async function loadImsFromMilo() {
-  const { getLibs } = await import('../../../scripts/utils.js');
   const { loadIms } = await import(`${getLibs()}/utils/utils.js`);
   return loadIms();
 }
@@ -140,7 +139,6 @@ export async function triggerSignInFlow() {
   const susiTarget = getMetadata('susi-target');
   if (susiTarget) {
     const [path, hash] = susiTarget.split('#');
-    const { getLibs } = await import('../../../scripts/utils.js');
     const { getModal } = await import(`${getLibs()}/blocks/modal/modal.js`);
     await getModal({ id: hash, path });
   }

--- a/express/code/libs/services/middlewares/auth.middleware.js
+++ b/express/code/libs/services/middlewares/auth.middleware.js
@@ -139,7 +139,10 @@ export async function triggerSignInFlow() {
   const susiTarget = getMetadata('susi-target');
   if (susiTarget) {
     const [path, hash] = susiTarget.split('#');
-    const { getModal } = await import(`${getLibs()}/blocks/modal/modal.js`);
+    const libs = getLibs();
+    const { loadStyle } = await import(`${libs}/utils/utils.js`);
+    loadStyle(`${libs}/blocks/modal/modal.css`);
+    const { getModal } = await import(`${libs}/blocks/modal/modal.js`);
     await getModal({ id: hash, path });
   }
   return false;

--- a/express/code/scripts/color-shared/components/createActionMenuComponent.js
+++ b/express/code/scripts/color-shared/components/createActionMenuComponent.js
@@ -342,6 +342,8 @@ export async function createActionMenuComponent(options = {}) {
     element: container,
     pushState: pushStateFn,
     getCurrentPalette: getCurrentPaletteFn,
+    undo: handleUndoState,
+    redo: handleRedoState,
     destroy() {
       document.removeEventListener(eventName, handleHistoryIndexChanged);
       container.remove();

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -1,5 +1,11 @@
 import { createSpectrumIcon } from '../utils/icons.js';
 import {
+  createTagField,
+  getTagValues,
+  addTagFromInput as addTagFromInputHelper,
+  createTagPill,
+} from './createTagField.js';
+import {
   isMobileViewport,
   createCurtain,
   addSwipeToClose,
@@ -57,10 +63,11 @@ const DRAWER_DEFAULTS = {
   paletteLabel: 'Color palette',
   keywordSuggestions: 'Blue,Green,Bold,Bright,Beige',
   yourLibrary: 'Your Library',
+  tagFieldHelp: 'Press return \u21B5 to create tag',
+  tagRemove: 'Remove {{tag}}',
 };
 
 const DRAWER_CSS_PATH = 'scripts/color-shared/toolbar/drawer.css';
-const COLOR_TOKENS_CSS_PATH = 'scripts/color-shared/color-tokens.css';
 
 /* ── Authentication Helpers ──────────────────────────────────── */
 
@@ -76,7 +83,6 @@ async function checkIsSignedIn() {
 /* ── Dependency Loading ───────────────────────────────────────── */
 async function loadDrawerDeps() {
   const results = await Promise.allSettled([
-    loadMiloStyle(COLOR_TOKENS_CSS_PATH),
     loadMiloStyle(DRAWER_CSS_PATH),
     loadButton(),
     loadMenu(),
@@ -345,82 +351,9 @@ function createLibraryPickerField(
   };
 }
 
-/* ── Tag Chips (sp-button variant=primary) ───────────────────── */
+/* ── Keyword suggestion pills ────────────────────────────────── */
 
-function normalizeTagText(t) {
-  if (typeof t === 'string') return t;
-  return t?.tag ?? t?.name ?? '';
-}
-
-/**
- * Create a tag chip using sp-button.
- *
- * @param {string}  text     — visible label
- * @param {Object}  [opts]
- * @param {string}  [opts.size='s']        — Spectrum size token
- * @param {boolean} [opts.deletable=true]  — shows a Close icon; removes on click
- */
-function createTagButton(text, opts = {}) {
-  const { size = 's', deletable = true } = opts;
-  const btn = document.createElement('sp-button');
-  btn.setAttribute('variant', 'primary');
-  btn.setAttribute('size', size);
-  btn.classList.add('ax-drawer-tag-btn');
-  btn.dataset.tagValue = text;
-  btn.textContent = text;
-
-  if (deletable) {
-    const closeIcon = createSpectrumIcon('Cross75');
-    closeIcon.setAttribute('slot', 'icon');
-    closeIcon.setAttribute('aria-hidden', 'true');
-    btn.prepend(closeIcon);
-
-    closeIcon.addEventListener('click', (e) => {
-      e.stopPropagation();
-      btn.remove();
-    });
-  }
-
-  return btn;
-}
-
-function getTagValues(container) {
-  return [...container.querySelectorAll('sp-button.ax-drawer-tag-btn')]
-    .map((el) => el.dataset.tagValue ?? '')
-    .filter(Boolean);
-}
-
-function createTagsField(label, tags, placeholder) {
-  const wrapper = createTag('div', { class: 'ax-drawer-tag-section' });
-
-  const fieldGroup = createTag('div', { class: 'ax-drawer-field' });
-  const labelEl = createTag('label', { class: 'ax-drawer-field-label' }, label);
-  const input = createTag('input', {
-    type: 'text',
-    class: 'ax-drawer-field-input',
-    placeholder,
-    'aria-label': placeholder,
-  });
-  fieldGroup.append(labelEl, input);
-
-  const tagsContainer = createTag('div', { class: 'ax-drawer-added-tags' });
-  (tags ?? []).forEach((t) => {
-    const text = normalizeTagText(t);
-    if (text) tagsContainer.appendChild(createTagButton(text));
-  });
-
-  wrapper.append(fieldGroup, tagsContainer);
-  return { wrapper, container: tagsContainer, input };
-}
-
-function addTagFromInput(tagsInput, tagsContainer, mobile) {
-  const text = tagsInput.value.trim();
-  if (!text) return;
-  tagsInput.value = '';
-  tagsContainer.appendChild(createTagButton(text, { size: mobile ? 'm' : 's' }));
-}
-
-function createKeywordSuggestions(keywords, mobile) {
+function createKeywordSuggestions(keywords, mobile, { onSuggestionClick } = {}) {
   const wrapper = createTag('div', { class: 'ax-drawer-keyword-suggestions' });
   const size = mobile ? 'm' : 's';
   keywords.forEach((keyword) => {
@@ -432,6 +365,9 @@ function createKeywordSuggestions(keywords, mobile) {
     const icon = createSpectrumIcon('Add');
     icon.setAttribute('slot', 'icon');
     btn.prepend(icon);
+    if (onSuggestionClick) {
+      btn.addEventListener('click', () => onSuggestionClick(keyword));
+    }
     wrapper.appendChild(btn);
   });
   return wrapper;
@@ -664,21 +600,40 @@ function buildDrawerDOM(mobile, titleId, palette, libs, ccLibProvider, isSignedI
   );
   formFields.appendChild(libraryPicker.wrapper);
 
-  const {
-    wrapper: tagsWrapper, container: tagsContainerEl, input: tagsInputEl,
-  } = createTagsField(
+  const tagFieldResult = createTagField(
     t.tags,
     palette?.tags ?? [],
     t.tagsPlaceholder,
+    { helpTextStr: t.tagFieldHelp },
   );
-  tagsWrapper.appendChild(createKeywordSuggestions(t.keywordSuggestions.split(',').map((s) => s.trim()), mobile));
+  const {
+    wrapper: tagsWrapper,
+    tagsContainer: tagsContainerEl,
+    input: tagsInputEl,
+    syncState: syncTagState,
+  } = tagFieldResult;
+
+  const onSuggestionClick = (keyword) => {
+    const existing = getTagValues(tagsContainerEl).map((v) => v.toLowerCase());
+    if (existing.includes(keyword.toLowerCase())) return;
+    const pill = createTagPill(keyword, { onRemove: syncTagState });
+    tagsContainerEl.appendChild(pill);
+    tagsInputEl.focus();
+    syncTagState();
+  };
+
+  tagsWrapper.appendChild(createKeywordSuggestions(
+    t.keywordSuggestions.split(',').map((s) => s.trim()),
+    mobile,
+    { onSuggestionClick },
+  ));
   formFields.appendChild(tagsWrapper);
   content.appendChild(formFields);
 
   tagsInputEl.addEventListener('keydown', (e) => {
     if (e.key !== 'Enter') return;
     e.preventDefault();
-    addTagFromInput(tagsInputEl, tagsContainerEl, mobile);
+    addTagFromInputHelper(tagsInputEl, tagsContainerEl, { onStateChange: syncTagState });
   });
 
   const saveBtnEl = document.createElement('sp-button');

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -64,7 +64,6 @@ const DRAWER_DEFAULTS = {
   keywordSuggestions: 'Blue,Green,Bold,Bright,Beige',
   yourLibrary: 'Your Library',
   tagFieldHelp: 'Press return \u21B5 to create tag',
-  tagRemove: 'Remove {{tag}}',
 };
 
 const DRAWER_CSS_PATH = 'scripts/color-shared/toolbar/drawer.css';

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -58,6 +58,8 @@ const DRAWER_I18N_MAP = {
   paletteLabel: 'color-drawer-palette-label',
   keywordSuggestions: 'color-drawer-keyword-suggestions',
   yourLibrary: 'color-drawer-your-library',
+  tagFieldHelp: 'color-drawer-tag-field-help',
+  tagRemove: 'color-drawer-tag-remove',
 };
 
 async function loadI18nStrings() {

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -59,7 +59,6 @@ const DRAWER_I18N_MAP = {
   keywordSuggestions: 'color-drawer-keyword-suggestions',
   yourLibrary: 'color-drawer-your-library',
   tagFieldHelp: 'color-drawer-tag-field-help',
-  tagRemove: 'color-drawer-tag-remove',
 };
 
 async function loadI18nStrings() {

--- a/express/code/scripts/color-shared/toolbar/createTagField.js
+++ b/express/code/scripts/color-shared/toolbar/createTagField.js
@@ -1,0 +1,159 @@
+import { createSpectrumIcon } from '../utils/icons.js';
+import { createTag } from '../../utils.js';
+
+/* ── Tag text helpers ─────────────────────────────────────────── */
+
+export function normalizeTagText(t) {
+  if (typeof t === 'string') return t;
+  return t?.tag ?? t?.name ?? '';
+}
+
+/* ── Tag pill (selected tag inside field) ─────────────────────── */
+
+export function createTagPill(text, { onRemove, removeLabel } = {}) {
+  const pill = createTag('div', { class: 'ax-tag-pill', 'data-tag-value': text });
+
+  const label = createTag('span', { class: 'ax-tag-pill-label' }, text);
+
+  const closeBtn = createTag('button', {
+    type: 'button',
+    class: 'ax-tag-pill-close',
+    'aria-label': removeLabel || `Remove ${text}`,
+  });
+  const closeIcon = createSpectrumIcon('Close');
+  closeIcon.setAttribute('aria-hidden', 'true');
+  closeBtn.appendChild(closeIcon);
+
+  closeBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    pill.remove();
+    onRemove?.();
+  });
+
+  pill.append(label, closeBtn);
+  return pill;
+}
+
+/* ── Tag value extraction ─────────────────────────────────────── */
+
+export function getTagValues(container) {
+  return [...container.querySelectorAll('.ax-tag-pill')]
+    .map((el) => el.dataset.tagValue ?? '')
+    .filter(Boolean);
+}
+
+/* ── State sync ───────────────────────────────────────────────── */
+
+export function syncTagFieldState(field, input, tagsContainer, helpText) {
+  const hasTags = tagsContainer.children.length > 0;
+  const hasFocus = field.contains(document.activeElement);
+
+  field.classList.toggle('ax-tag-field-active', hasFocus || hasTags);
+  field.classList.toggle('ax-tag-field-has-tags', hasTags);
+
+  if (hasTags || input.value.trim()) {
+    input.removeAttribute('placeholder');
+  } else {
+    input.setAttribute('placeholder', input.dataset.placeholder || '');
+  }
+
+  if (helpText) {
+    helpText.hidden = !(hasFocus || hasTags);
+  }
+}
+
+/* ── Add tag from input ───────────────────────────────────────── */
+
+export function addTagFromInput(input, tagsContainer, { onStateChange, removeLabel } = {}) {
+  const text = input.value.trim();
+  if (!text) return;
+  const existing = getTagValues(tagsContainer)
+    .map((v) => v.toLowerCase());
+  if (existing.includes(text.toLowerCase())) {
+    input.value = '';
+    input.focus();
+    return;
+  }
+  input.value = '';
+  const pill = createTagPill(text, {
+    removeLabel,
+    onRemove: () => onStateChange?.(),
+  });
+  tagsContainer.appendChild(pill);
+  input.focus();
+  onStateChange?.();
+}
+
+/* ── Main factory ─────────────────────────────────────────────── */
+
+export function createTagField(label, tags, placeholder, {
+  helpTextStr,
+  removeLabel,
+} = {}) {
+  const wrapper = createTag('div', { class: 'ax-drawer-tag-section' });
+
+  const inputId = 'ax-tag-field-input';
+  const helpId = 'ax-tag-field-help';
+
+  const labelEl = createTag('label', {
+    class: 'ax-drawer-field-label',
+    for: inputId,
+  }, label);
+
+  const field = createTag('div', { class: 'ax-tag-field' });
+  const tagsContainer = createTag('div', { class: 'ax-tag-field-tags' });
+  const input = createTag('input', {
+    type: 'text',
+    class: 'ax-tag-field-input',
+    id: inputId,
+    placeholder,
+    'data-placeholder': placeholder,
+    'aria-label': placeholder,
+    'aria-describedby': helpId,
+  });
+
+  const doSync = () => syncTagFieldState(field, input, tagsContainer, helpText);
+
+  (tags ?? []).forEach((t) => {
+    const text = normalizeTagText(t);
+    if (text) {
+      tagsContainer.appendChild(createTagPill(text, {
+        removeLabel,
+        onRemove: doSync,
+      }));
+    }
+  });
+
+  field.append(tagsContainer, input);
+
+  const helpText = createTag('span', {
+    class: 'ax-tag-field-help',
+    id: helpId,
+    hidden: '',
+  }, helpTextStr || '');
+
+  field.addEventListener('click', (e) => {
+    if (e.target === field || e.target === tagsContainer) {
+      input.focus();
+    }
+  });
+
+  input.addEventListener('focus', doSync);
+  input.addEventListener('blur', () => {
+    requestAnimationFrame(doSync);
+  });
+  input.addEventListener('input', doSync);
+
+  wrapper.append(labelEl, field, helpText);
+
+  doSync();
+
+  return {
+    wrapper,
+    field,
+    tagsContainer,
+    input,
+    helpText,
+    syncState: doSync,
+  };
+}

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -1,5 +1,5 @@
 import { announceToScreenReader } from '../spectrum/index.js';
-import { isMobileViewport } from '../utils/utilities.js';
+import { isMobileViewport, buildPaletteEditUrl } from '../utils/utilities.js';
 import { createIconButton } from '../utils/icons.js';
 import { createEventBus } from '../utils/createEventBus.js';
 import { createTag } from '../../utils.js';
@@ -325,7 +325,6 @@ export function createToolbar(options) {
     editPaletteName = false,
     editPaletteLink = null,
     getLibraryContext,
-    onEdit,
     onCTA,
     i18n = {},
     drawerI18n = {},
@@ -379,13 +378,14 @@ export function createToolbar(options) {
 
   const main = createTag('div', { class: 'ax-toolbar-main' });
 
+  const DEFAULT_EDIT_BASE_PATH = '/express/colors/color-palette-generator';
+
   const paletteSummary = buildPaletteSummary(colors, type, palette.angle, effectiveShowEdit, () => {
-    if (editPaletteLink) {
-      window.location.href = editPaletteLink;
-    } else {
-      onEdit?.(getPaletteWithName());
-    }
-    emit('edit', { palette: getPaletteWithName() });
+    const currentPalette = getPaletteWithName();
+    const editUrl = editPaletteLink
+      || buildPaletteEditUrl(DEFAULT_EDIT_BASE_PATH, currentPalette.colors, currentPalette.name);
+    window.location.href = editUrl;
+    emit('edit', { palette: currentPalette });
   }, t);
 
   const { actions, ccLibBtn } = buildActionButtons({

--- a/express/code/scripts/color-shared/toolbar/drawer.css
+++ b/express/code/scripts/color-shared/toolbar/drawer.css
@@ -461,7 +461,7 @@
   padding-inline: 0;
   flex: 1 1 0;
   overflow-y: auto;
-  min-block-size: calc(3 * 40px);
+  min-block-size: calc(3 * var(--ax-drawer-input-height));
 }
 
 .ax-lib-picker-divider {

--- a/express/code/scripts/color-shared/toolbar/drawer.css
+++ b/express/code/scripts/color-shared/toolbar/drawer.css
@@ -6,7 +6,6 @@
   background: rgba(0, 0, 0, 0.4);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.3s ease-out;
 }
 
 @supports (backdrop-filter: blur(10px)) {
@@ -27,7 +26,7 @@
   /* ── Scoped vars ── */
   --ax-drawer-max-height: 90dvh;
   --ax-drawer-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
-  --ax-drawer-transition: transform 300ms ease-out;
+  --ax-drawer-transition: transform 200ms ease;
   --ax-drawer-panel-width-tablet: 307px;
   --ax-drawer-max-height-tablet: 90vh;
   --ax-drawer-transition-tablet: opacity 150ms ease, box-shadow 150ms ease;
@@ -59,6 +58,16 @@
   --ax-drawer-tag-min-width-mobile: 27px;
   --ax-drawer-tag-height-mobile: 32px;
   --ax-drawer-tag-max-inline-size-mobile: 224px;
+  --ax-tag-field-min-height: 56px;
+  --ax-tag-field-gap: 6px;
+  --ax-tag-pill-max-width: 224px;
+  --ax-tag-pill-min-width: 27px;
+  --ax-tag-pill-icon-size: 10px;
+  --ax-drawer-line-height-s: 18px;
+  --ax-drawer-line-height-l: 20px;
+  --ax-drawer-label-padding-block-s: 7px;
+  --ax-drawer-label-padding-block-l: 10px;
+  --ax-drawer-font-weight-medium: 500;
 
   inset-inline-start: 0;
   inline-size: 100%;
@@ -156,9 +165,9 @@
 .ax-drawer-picker-label {
   font-size: var(--ax-body-s-size);
   font-weight: var(--ax-body-weight);
-  line-height: var(--line-height-200);
+  line-height: var(--ax-drawer-line-height-l);
   color: var(--color-dark-gray);
-  padding-block: var(--component-padding-vertical-200);
+  padding-block: var(--ax-drawer-label-padding-block-l);
   padding-inline: 0;
   box-sizing: border-box;
 }
@@ -224,13 +233,105 @@
   gap: var(--spacing-100);
 }
 
-/* ── Tag chip buttons (sp-button.ax-drawer-tag-btn) ──────────── */
+/* ── Tag field (bordered container) ─────────────────────────── */
 
-.ax-drawer-added-tags {
-  display: inline-flex;
+.ax-tag-field {
+  display: flex;
   flex-wrap: wrap;
-  gap: var(--spacing-100);
+  align-items: center;
+  gap: var(--ax-tag-field-gap);
+  min-block-size: var(--ax-tag-field-min-height);
+  padding: var(--spacing-200);
+  background: var(--color-white);
+  border: var(--border-width-2) solid var(--color-gray-300-variant);
+  border-radius: var(--Corner-radius-corner-radius-100);
+  box-sizing: border-box;
+  cursor: text;
 }
+
+.ax-tag-field.ax-tag-field-active,
+.ax-tag-field.ax-tag-field-has-tags {
+  border-color: var(--color-gray-950);
+}
+
+.ax-tag-field-tags {
+  display: contents;
+}
+
+.ax-tag-field-input {
+  flex: 1;
+  min-inline-size: 80px;
+  border: none;
+  background: transparent;
+  padding: 0;
+  font-family: var(--body-font-family);
+  font-size: var(--ax-body-s-size);
+  font-weight: var(--ax-body-weight);
+  line-height: var(--ax-drawer-line-height-l);
+  color: var(--color-gray-800-variant);
+  outline: none;
+}
+
+.ax-tag-field-input::placeholder {
+  color: var(--color-gray-800-variant);
+}
+
+/* ── Tag pills (inside field) ──────────────────────────────────── */
+
+.ax-tag-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-200);
+  block-size: var(--spacing-500);
+  padding-inline: var(--spacing-200);
+  background: var(--color-light-gray);
+  border-radius: var(--Corner-radius-corner-radius-100);
+  font-family: var(--body-font-family);
+  font-size: var(--ax-body-xs-size);
+  font-weight: var(--ax-drawer-font-weight-medium);
+  color: var(--color-gray-800-variant);
+  max-inline-size: var(--ax-tag-pill-max-width);
+  min-inline-size: var(--ax-tag-pill-min-width);
+  box-sizing: border-box;
+}
+
+.ax-tag-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ax-tag-pill-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--color-black);
+  flex-shrink: 0;
+  --mod-icon-inline-size: var(--ax-tag-pill-icon-size);
+  --mod-icon-block-size: var(--ax-tag-pill-icon-size);
+}
+
+/* ── Helper text below field ──────────────────────────────────── */
+
+.ax-tag-field-help {
+  font-family: var(--body-font-family);
+  font-size: var(--ax-body-s-size);
+  font-weight: var(--ax-body-weight);
+  line-height: var(--ax-drawer-line-height-l);
+  color: var(--color-dark-gray);
+  padding-block: var(--ax-drawer-label-padding-block-s);
+  padding-inline: 0;
+}
+
+.ax-tag-field-help[hidden] {
+  display: none;
+}
+
+/* ── Tag chip buttons (sp-button.ax-drawer-tag-btn — suggestions) ── */
 
 .ax-drawer-tag-btn {
   --mod-button-border-radius: 7px;
@@ -286,7 +387,7 @@
   padding-inline: var(--ax-drawer-trigger-padding-start) var(--ax-drawer-trigger-padding-end);
   font-family: var(--body-font-family);
   font-size: var(--ax-body-s-size);
-  line-height: var(--line-height-200);
+  line-height: var(--ax-drawer-line-height-l);
   color: var(--color-gray-800-variant);
   background: var(--color-light-gray);
   border: none;
@@ -360,7 +461,7 @@
   padding-inline: 0;
   flex: 1 1 0;
   overflow-y: auto;
-  min-block-size: fit-content;
+  min-block-size: calc(3 * 40px);
 }
 
 .ax-lib-picker-divider {
@@ -386,7 +487,7 @@
   font-family: var(--body-font-family);
   font-size: var(--ax-body-xs-size);
   font-weight: var(--ax-body-weight);
-  line-height: var(--line-height-100);
+  line-height: var(--ax-drawer-line-height-s);
   color: var(--color-dark-gray);
 }
 
@@ -397,7 +498,7 @@
   padding-inline: var(--spacing-200);
   font-family: var(--body-font-family);
   font-size: var(--ax-body-xs-size);
-  line-height: var(--line-height-100);
+  line-height: var(--ax-drawer-line-height-s);
   color: var(--color-gray-800-variant);
   border: var(--border-width-2) solid var(--color-gray-300-variant);
   border-radius: var(--Corner-radius-corner-radius-100);
@@ -449,7 +550,7 @@
   --mod-icon-size: var(--ax-drawer-tag-icon-size-mobile);
   --mod-button-border-radius: var(--Corner-radius-corner-radius-100);
   --mod-button-edge-to-text: var(--spacing-200);
-  font-weight: var(--Font-weight-medium);
+  font-weight: var(--ax-drawer-font-weight-medium);
 }
 
 .ax-drawer-mobile .ax-lib-picker-create-section {
@@ -492,7 +593,7 @@
     max-block-size: var(--ax-drawer-max-height-tablet);
     overflow-y: auto;
     border-radius: var(--Corner-radius-corner-radius-100);
-    box-shadow: var(--Elevation-handle);
+    box-shadow: var(--Modal-close-shadow-tablet);
     transform: none;
     opacity: 0;
     transition: var(--ax-drawer-transition-tablet);
@@ -523,16 +624,15 @@
     max-height: none;
   }
 
-  .ax-drawer-panel .ax-lib-picker-popover sp-menu {
-    min-height: fit-content;
-    max-height: none;
+  .ax-lib-picker-popover sp-menu {
+    min-block-size: fit-content;
   }
 
   .ax-drawer-field-label,
   .ax-drawer-picker-label {
     font-size: var(--ax-body-xs-size);
-    line-height: var(--line-height-100);
-    padding-block: var(--component-padding-vertical-100);
+    line-height: var(--ax-drawer-line-height-s);
+    padding-block: var(--ax-drawer-label-padding-block-s);
     padding-inline: 0;
   }
 
@@ -556,6 +656,16 @@
     block-size: var(--ax-drawer-input-height-compact);
   }
 
+  .ax-tag-field-input {
+    font-size: var(--ax-body-xs-size);
+    line-height: var(--ax-drawer-line-height-s);
+  }
+
+  .ax-tag-field-help {
+    font-size: var(--ax-body-xs-size);
+    line-height: var(--ax-drawer-line-height-s);
+  }
+
   .ax-drawer-save-btn {
     inline-size: auto;
     min-inline-size: 108px;
@@ -572,6 +682,12 @@
       margin-block-end: var(--spacing-100);
       position-try-fallbacks: flip-block;
     }
+  }
+}
+
+@media (max-width: 1200px) {
+  .ax-drawer-panel {
+    box-shadow: var(--Modal-close-shadow-desktop);
   }
 }
 

--- a/express/code/scripts/color-shared/utils/utilities.js
+++ b/express/code/scripts/color-shared/utils/utilities.js
@@ -237,6 +237,13 @@ export function createColorPaletteParamApi() {
   };
 }
 
+export function buildPaletteEditUrl(basePath, colors, name) {
+  const url = new URL(basePath, window.location.origin);
+  const { setOnUrl } = createColorPaletteParamApi();
+  setOnUrl(url, colors, { name });
+  return `${url.pathname}${url.search}`;
+}
+
 export function normalizeTheme(theme) {
   return {
     id: theme.id ?? '',

--- a/test/scripts/color-shared/toolbar/createDrawerComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createDrawerComponent.test.js
@@ -502,7 +502,7 @@ describe('createDrawer', function drawerSuite() {
       const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
       await openDrawer(drawer);
 
-      const tags = document.querySelectorAll('.ax-drawer-added-tags sp-button.ax-drawer-tag-btn');
+      const tags = document.querySelectorAll('.ax-tag-field-tags .ax-tag-pill');
       expect(tags.length).to.equal(2);
       expect(tags[0].dataset.tagValue).to.equal('bold');
       expect(tags[1].dataset.tagValue).to.equal('bright');
@@ -516,13 +516,13 @@ describe('createDrawer', function drawerSuite() {
       const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
       await openDrawer(drawer);
 
-      const tagsInput = document.querySelector('.ax-drawer-tag-section .ax-drawer-field-input');
+      const tagsInput = document.querySelector('.ax-drawer-tag-section .ax-tag-field-input');
       expect(tagsInput).to.exist;
 
       tagsInput.value = 'NewTag';
       tagsInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
-      const tags = document.querySelectorAll('.ax-drawer-added-tags sp-button.ax-drawer-tag-btn');
+      const tags = document.querySelectorAll('.ax-tag-field-tags .ax-tag-pill');
       expect(tags.length).to.equal(3);
       expect(tags[2].dataset.tagValue).to.equal('NewTag');
       expect(tagsInput.value).to.equal('');
@@ -536,14 +536,14 @@ describe('createDrawer', function drawerSuite() {
       const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
       await openDrawer(drawer);
 
-      let tags = document.querySelectorAll('.ax-drawer-added-tags sp-button.ax-drawer-tag-btn');
+      let tags = document.querySelectorAll('.ax-tag-field-tags .ax-tag-pill');
       expect(tags.length).to.equal(2);
 
-      const closeIcon = tags[0].querySelector('sp-icon-cross75');
-      expect(closeIcon).to.exist;
-      closeIcon.click();
+      const closeBtn = tags[0].querySelector('.ax-tag-pill-close');
+      expect(closeBtn).to.exist;
+      closeBtn.click();
 
-      tags = document.querySelectorAll('.ax-drawer-added-tags sp-button.ax-drawer-tag-btn');
+      tags = document.querySelectorAll('.ax-tag-field-tags .ax-tag-pill');
       expect(tags.length).to.equal(1);
       expect(tags[0].dataset.tagValue).to.equal('bright');
 
@@ -572,6 +572,328 @@ describe('createDrawer', function drawerSuite() {
       expect(labels).to.include('Bold');
       expect(labels).to.include('Bright');
       expect(labels).to.include('Beige');
+
+      drawer.close();
+      await waitForClose();
+    });
+  });
+
+  describe('save payload — tag extraction', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    });
+
+    it('palette save payload includes initial tags from palette data', async () => {
+      anchor = createAnchor();
+      const provider = createMockCCLibraryProvider();
+      const drawer = await createDrawer(defaultOptions({
+        anchorElement: anchor,
+        type: 'palette',
+        libraries: MOCK_LIBRARIES,
+        ccLibraryProvider: provider,
+        deps: signedInDeps,
+      }));
+      await openDrawer(drawer);
+
+      const saveBtn = document.querySelector('.ax-drawer-save-btn');
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(provider.saveTheme.calledOnce).to.be.true;
+      const [, payload] = provider.saveTheme.firstCall.args;
+      const tags = payload.representations[0]['colortheme#data'].tags;
+      expect(tags).to.deep.equal(['bold', 'bright']);
+
+      await waitForClose();
+    });
+
+    it('palette save payload includes tags added via Enter key', async () => {
+      anchor = createAnchor();
+      const provider = createMockCCLibraryProvider();
+      const drawer = await createDrawer(defaultOptions({
+        anchorElement: anchor,
+        type: 'palette',
+        libraries: MOCK_LIBRARIES,
+        ccLibraryProvider: provider,
+        deps: signedInDeps,
+      }));
+      await openDrawer(drawer);
+
+      const tagsInput = document.querySelector('.ax-drawer-tag-section input');
+      tagsInput.value = 'NewTag';
+      tagsInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      const saveBtn = document.querySelector('.ax-drawer-save-btn');
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [, payload] = provider.saveTheme.firstCall.args;
+      const tags = payload.representations[0]['colortheme#data'].tags;
+      expect(tags).to.include('NewTag');
+      expect(tags).to.include('bold');
+      expect(tags).to.include('bright');
+
+      await waitForClose();
+    });
+
+    it('contrast save payload includes tags from contrast palette data', async () => {
+      anchor = createAnchor();
+      const provider = createMockCCLibraryProvider();
+      const contrastPalette = {
+        name: 'Contrast Pair',
+        colors: ['#1B1B1B', '#FFFFFF'],
+        tags: ['ContrastChecked', 'VisualAccessibility'],
+        accessibilityData: { wcagLevel: 'AAA' },
+      };
+      const drawer = await createDrawer(defaultOptions({
+        anchorElement: anchor,
+        type: 'contrast',
+        paletteData: contrastPalette,
+        libraries: MOCK_LIBRARIES,
+        ccLibraryProvider: provider,
+        deps: signedInDeps,
+      }));
+      await openDrawer(drawer);
+
+      const saveBtn = document.querySelector('.ax-drawer-save-btn');
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [, payload] = provider.saveTheme.firstCall.args;
+      const tags = payload.representations[0]['colortheme#data'].tags;
+      expect(tags).to.deep.equal(['ContrastChecked', 'VisualAccessibility']);
+
+      await waitForClose();
+    });
+
+    it('tag removal is reflected in saved payload', async () => {
+      anchor = createAnchor();
+      const provider = createMockCCLibraryProvider();
+      const drawer = await createDrawer(defaultOptions({
+        anchorElement: anchor,
+        type: 'palette',
+        libraries: MOCK_LIBRARIES,
+        ccLibraryProvider: provider,
+        deps: signedInDeps,
+      }));
+      await openDrawer(drawer);
+
+      // Remove the first tag
+      const tags = document.querySelectorAll('.ax-drawer-tag-section [data-tag-value]');
+      expect(tags.length).to.be.at.least(1);
+      const closeIcon = tags[0].querySelector('sp-icon-cross75') || tags[0].querySelector('.ax-tag-pill-close');
+      if (closeIcon) closeIcon.click();
+
+      const saveBtn = document.querySelector('.ax-drawer-save-btn');
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [, payload] = provider.saveTheme.firstCall.args;
+      const savedTags = payload.representations[0]['colortheme#data'].tags;
+      expect(savedTags).to.not.include('bold');
+      expect(savedTags).to.include('bright');
+
+      await waitForClose();
+    });
+
+    it('empty tag input on Enter does not add a tag to the payload', async () => {
+      anchor = createAnchor();
+      const provider = createMockCCLibraryProvider();
+      const drawer = await createDrawer(defaultOptions({
+        anchorElement: anchor,
+        type: 'palette',
+        libraries: MOCK_LIBRARIES,
+        ccLibraryProvider: provider,
+        deps: signedInDeps,
+      }));
+      await openDrawer(drawer);
+
+      const tagsInput = document.querySelector('.ax-drawer-tag-section input');
+      tagsInput.value = '   ';
+      tagsInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      const saveBtn = document.querySelector('.ax-drawer-save-btn');
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const [, payload] = provider.saveTheme.firstCall.args;
+      const tags = payload.representations[0]['colortheme#data'].tags;
+      expect(tags).to.deep.equal(['bold', 'bright']);
+
+      await waitForClose();
+    });
+  });
+
+  describe('tag field structure', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    });
+
+    it('tags render inside .ax-tag-field-tags within .ax-tag-field', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const field = document.querySelector('.ax-tag-field');
+      expect(field).to.exist;
+      const tagsContainer = field.querySelector('.ax-tag-field-tags');
+      expect(tagsContainer).to.exist;
+      const pills = tagsContainer.querySelectorAll('.ax-tag-pill');
+      expect(pills.length).to.equal(2);
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('input is inside .ax-tag-field as .ax-tag-field-input', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const field = document.querySelector('.ax-tag-field');
+      const input = field.querySelector('.ax-tag-field-input');
+      expect(input).to.exist;
+      expect(input.type).to.equal('text');
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('tag pills have data-tag-value attribute', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const pills = document.querySelectorAll('.ax-tag-pill');
+      expect(pills[0].dataset.tagValue).to.equal('bold');
+      expect(pills[1].dataset.tagValue).to.equal('bright');
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('helper text element exists with ax-tag-field-help class', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const help = document.querySelector('.ax-tag-field-help');
+      expect(help).to.exist;
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('label is associated with input via for/id', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const label = document.querySelector('.ax-drawer-tag-section .ax-drawer-field-label');
+      const input = document.querySelector('.ax-tag-field-input');
+      expect(label.getAttribute('for')).to.equal(input.id);
+
+      drawer.close();
+      await waitForClose();
+    });
+  });
+
+  describe('tag field interactions', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    });
+
+    it('Enter creates a tag pill and clears input', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+      input.value = 'Custom';
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      const pills = document.querySelectorAll('.ax-tag-pill');
+      expect(pills.length).to.equal(3);
+      expect(pills[2].dataset.tagValue).to.equal('Custom');
+      expect(input.value).to.equal('');
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('blank and whitespace-only input does not create tags', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+      input.value = '   ';
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      const pills = document.querySelectorAll('.ax-tag-pill');
+      expect(pills.length).to.equal(2);
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('clicking a keyword suggestion adds a tag pill', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const suggestions = document.querySelectorAll('.ax-drawer-keyword-suggestions .ax-drawer-tag-btn');
+      suggestions[0].click();
+
+      const pills = document.querySelectorAll('.ax-tag-pill');
+      expect(pills.length).to.equal(3);
+      expect(pills[2].dataset.tagValue).to.equal('Blue');
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('clicking .ax-tag-pill-close removes the tag', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      let pills = document.querySelectorAll('.ax-tag-pill');
+      expect(pills.length).to.equal(2);
+
+      pills[0].querySelector('.ax-tag-pill-close').click();
+
+      pills = document.querySelectorAll('.ax-tag-pill');
+      expect(pills.length).to.equal(1);
+      expect(pills[0].dataset.tagValue).to.equal('bright');
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('tag pill close button is a real <button> with aria-label', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const closeBtn = document.querySelector('.ax-tag-pill-close');
+      expect(closeBtn).to.exist;
+      expect(closeBtn.tagName.toLowerCase()).to.equal('button');
+      expect(closeBtn.type).to.equal('button');
+      expect(closeBtn.getAttribute('aria-label')).to.be.a('string').and.not.be.empty;
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('input has aria-describedby pointing to helper text', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+      const help = document.querySelector('.ax-tag-field-help');
+      expect(input.getAttribute('aria-describedby')).to.equal(help.id);
 
       drawer.close();
       await waitForClose();
@@ -768,7 +1090,7 @@ describe('createDrawer', function drawerSuite() {
       }));
       await openDrawer(drawer);
 
-      const tags = document.querySelectorAll('.ax-drawer-added-tags sp-button.ax-drawer-tag-btn');
+      const tags = document.querySelectorAll('.ax-tag-field-tags .ax-tag-pill');
       expect(tags.length).to.equal(3);
       expect(tags[0].dataset.tagValue).to.equal('ContrastChecked');
       expect(tags[1].dataset.tagValue).to.equal('VisualAccessibility');


### PR DESCRIPTION
## Summary                                                                                                                                                      
                                                                                                                                                                  
  Extracts tag handling from `createDrawerComponent.js` into a dedicated `createTagField.js` module and replaces Spectrum `sp-button` tag chips with custom       
  `.ax-tag-pill` elements. The new tag field is a bordered, input-integrated container with pill-style tags, helper text, focus/state management, and proper a11y 
  (`label[for]`, `aria-label` on close, `aria-describedby` for help text). Keyword suggestions now insert pills directly into the tag field. Duplicate tags       
  (case-insensitive) are prevented. Removes unused `color-tokens.css` import from drawer deps. Minor CSS cleanup: replaces raw Spectrum tokens (`--line-height-*`,
   `--Font-weight-medium`, `--Elevation-handle`, `--component-padding-vertical-*`) with scoped `--ax-drawer-*` custom properties for consistency.                 

  Also adds `getLibs` to the top-level import in `auth.middleware.js`, removing two redundant dynamic `import('../../../scripts/utils.js')` calls.

  ---

  ## Pre-merge checklist                                                                                                                                          
   
  - [x] Imports: no illegal or circular imports; prod/shared do not import from dev-only paths                                                                    
  - [x] Contract & scope: public APIs and block contracts unchanged unless intended
  - [x] Shared vs page: shared code in appropriate place; no page-specific logic in shared                                                                        
  - [x] Deployability: no hardcoded env URLs; config via sheet or env                                                                                             
  - [x] Testing: manual or automated verification steps documented or run
  - [x] Hygiene: lint and tests pass; no stray console or debug code                                                                                              
                                                            
  ---

  ## Jira Ticket                                                                                                                                                  
   
  Resolves: [MWPW-189370](https://jira.corp.adobe.com/browse/MWPW-189370)                                                                                         
                                                            
  ---

  ## Test URLs

  | Env | URL |
  |-------------|-----|
  | **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/esallee/color-gwp/contrast-checker |
  | **After**   | https://floating-toolbar-color-tags--da-express-milo--adobecom.aem.page/drafts/esallee/color-gwp/contrast-checker?martech=off |                 
                                                                                                                                                                  
  ---                                                                                                                                                             
                                                                                                                                                                  
  ## Verification Steps                                     

  1. Open the **After** URL and click the **Save** button in the floating toolbar to open the drawer.                                                             
  2. Verify tags render as pill-style elements (`.ax-tag-pill`) inside a bordered field, not as `sp-button` elements.
  3. Type text in the tag input and press Enter — a new pill should appear; input clears. Whitespace-only input should be ignored.                                
  4. Click the × on a pill — it should be removed.                                                                                                                
  5. Click a keyword suggestion (e.g. "Blue") — a pill is added to the field. Clicking the same suggestion again should not add a duplicate.                      
  6. Confirm helper text ("Press return ↵ to create tag") appears below the field when focused or when tags exist.                                                
  7. Save a palette — verify the payload includes correct tags (open DevTools Network tab, inspect the CC Libraries save request body).                           
  8. Test on mobile viewport (≤ 600px) — drawer should still open full-screen and tags should render correctly.
                                                                                                                                                                  
  ---                                                       
                                                                                                                                                                  
  ## Potential Regressions                                  

  - https://floating-toolbar-color-tags--da-express-milo--adobecom.aem.live/drafts/esallee/color-gwp/contrast-checker?martech=off                                 
   
  ---                                                                                                                                                             
                                                            
  ## Additional Notes

  - `createTagField.js` exports `createTagField`, `createTagPill`, `getTagValues`, `addTagFromInput`, `normalizeTagText`, and `syncTagFieldState` — all consumed  
  only by `createDrawerComponent.js` for now but available for reuse in other drawer/toolbar contexts.
  - New i18n keys added: `color-drawer-tag-field-help`, `color-drawer-tag-remove`.                                                                                
  - 328 new lines of test coverage in `createDrawerComponent.test.js` covering tag field structure, interactions, save payload extraction, a11y attributes, and   
  keyword suggestion→pill flow. 