### PR TITLE
CN Redirect Update

### DIFF
--- a/404.html
+++ b/404.html
@@ -162,7 +162,10 @@
         else {
           [_, userLocale] = pathname.split('/');
           valueInMap = redirectMap.get(userLocale);
-          valueInMap ? win.location.replace( href.replace(`/${userLocale}/`, valueInMap)) : noop;
+          if (valueInMap) {
+            const normalizedHref = href.endsWith('/') ? href : `${href}/`;
+            win.location.replace(normalizedHref.replace(`/${userLocale}/`, valueInMap));
+          }
         }
       }(window));
 

--- a/404.html
+++ b/404.html
@@ -162,10 +162,7 @@
         else {
           [_, userLocale] = pathname.split('/');
           valueInMap = redirectMap.get(userLocale);
-          if (valueInMap) {
-            const normalizedHref = href.endsWith('/') ? href : `${href}/`;
-            win.location.replace(normalizedHref.replace(`/${userLocale}/`, valueInMap));
-          }
+          valueInMap ? win.location.replace( href.replace(`/${userLocale}/`, valueInMap)) : noop;
         }
       }(window));
 

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -403,12 +403,12 @@ async function loadPage() {
   }
 
   /* region based redirect to homepage */
-  import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then(async (country) => {
-    if (country === 'cn' && !window.location.pathname.startsWith('/cn')) {
-      const resp = await fetch('/cn', { method: 'HEAD' });
+  const isCnParam = new URLSearchParams(window.location.search).get('country') === 'cn';
+  if ((isCnParam) && !window.location.pathname.startsWith('/cn')) {
+    fetch('/cn', { method: 'HEAD' }).then((resp) => {
       window.location.href = resp.ok ? '/cn' : '/404';
-    }
-  });
+    });
+  }
 
   document.head.querySelectorAll('meta').forEach((meta) => {
     if (meta.content && meta.content.includes('--none--')) {

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -406,7 +406,7 @@ async function loadPage() {
   import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then(async (country) => {
     if (country === 'cn' && !window.location.pathname.startsWith('/cn')) {
       const resp = await fetch('/cn', { method: 'HEAD' });
-      if (resp.ok) window.location.href = '/cn';
+      window.location.href = resp.ok ? '/cn' : '/404';
     }
   });
 

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -403,8 +403,11 @@ async function loadPage() {
   }
 
   /* region based redirect to homepage */
-  import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then((country) => {
-    if (country === 'cn') { window.location.href = '/cn'; }
+  import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then(async (country) => {
+    if (country === 'cn' && !window.location.pathname.startsWith('/cn')) {
+      const resp = await fetch('/cn', { method: 'HEAD' });
+      if (resp.ok) window.location.href = '/cn';
+    }
   });
 
   document.head.querySelectorAll('meta').forEach((meta) => {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Gracefully redirect user to 404 page if the country param is `cn` and the content does not exist.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-191183

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://cn-redirect-fix--da-express-milo--adobecom.aem.page/express/drafts/lingo/selector?milolibs=acommarketselector&country=cn |
| **After**   | https://cn-redirect-fix--da-express-milo--adobecom.aem.page/express/dradsfdsfts/lingo/selector?milolibs=acommarketselector&country=cn |
| **After**   | https://cn-redirect-fix--da-express-milo--adobecom.aem.page/cn/express/|
| **After**   | https://cn-redirect-fix--da-express-milo--adobecom.aem.page/express/drafts/lingo/selector?milolibs=acommarketselector&country=fr |



---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the first link. The user should be directed to a 404
- Visit the second link, an obviously malformed one. This should also gracefully redirect.
- Visit the third one, this should still function normally
- Fourth one is the original French link, should work normally

---

