### PR TITLE
MWPW-185872 color-extract landing layout and palette fixes

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -39,6 +39,21 @@
   box-sizing: border-box;
 }
 
+/* When image is loaded, the 640px marquee wrapper must expand to full width */
+.color-extract-marquee-wrapper:has(.color-extract.has-image) {
+  width: 100%;
+  max-width: unset;
+}
+
+/* Section containing the marquee wrapper: position for bg/fade, flex to vertically center content */
+.section:has(.color-extract-marquee-wrapper) {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 800px;
+}
+
 .color-extract {
   contain: layout style;
   --color-extract-max-width: 1440px;
@@ -91,54 +106,22 @@
   position: relative;
   height: auto;
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
   display: flex;
   align-items: flex-start;
   justify-content: center;
   padding: 66px 24px 40px;
 }
 
-/*
- * When a color-headline.extract block is on the page, extend the landing
- * background images upward so they visually span behind the headline text.
- *
- * We do this by:
- *  1. Making the landing overflow: visible so its bg wrapper can bleed upward.
- *  2. Pulling the bg wrapper's top edge upward with a negative top offset.
- *     The bottom is still anchored at 0 so the bg fills the full landing height
- *     plus the overlap above it.
- *  3. Stretching the actual image to 100% of the taller bg wrapper.
- *
- * The landing position, dropzone, and edit stage are NOT moved — this only
- * affects the decorative bg images. No impact on the has-image / edit view.
- *
- * --ce-bg-extend ≈ headline height + section padding. Tune as needed.
- */
 body:has(.color-headline.extract) .color-extract .color-extract-landing {
-  overflow: visible;
   padding-top: 0;
-  min-height: 580px;
-}
-
-body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
-  --ce-bg-extend: 344px;
-  top: calc(-1 * var(--ce-bg-extend));
-  /* Break out of the 640px marquee wrapper so bg images span the full viewport */
-  width: 100vw;
-  left: 50%;
-  right: auto;
-  transform: translateX(-50%);
-}
-
-body:has(.color-headline.extract) .color-extract .color-extract-landing-bg picture,
-body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
-  height: 100%;
 }
 
 .color-extract.has-image .color-extract-landing {
   display: none;
 }
 
+/* Background image — when NOT inside marquee wrapper (standalone color-extract) */
 .color-extract .color-extract-landing-bg {
   position: absolute;
   inset: 0;
@@ -150,17 +133,51 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
 .color-extract .color-extract-landing-bg img {
   position: absolute;
   inset: 0;
-  margin: auto;
-  width: 1920px;
-  height: 800px;
-  object-fit: cover;
+  width: 100%;
+  height: auto;
+  max-width: 1920px;
+  margin: 0 auto;
+}
+
+/*
+ * CSS fallback: bg still inside .color-extract (JS did not move it to section level).
+ * .color-extract has contain:layout, making it the containing block.
+ * Because .color-extract is a centered 640px element, the math resolves correctly:
+ *   left: 50% of 640px centered = viewport midpoint → translateX(-50vw) = viewport left edge.
+ * Negative top extends the bg above .color-extract to also cover the headline block.
+ */
+body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
+  top: -400px;
+  bottom: 0;
   left: 50%;
+  right: auto;
+  width: 100vw;
+  height: auto;
   transform: translateX(-50%);
+}
+
+/* Background image — section level (moved out of marquee wrapper by JS) */
+.section > .color-extract-landing-bg {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.section > .color-extract-landing-bg picture,
+.section > .color-extract-landing-bg img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: auto;
+  max-width: 1920px;
+  margin: 0 auto;
 }
 
 .color-extract .color-extract-landing-content {
   position: relative;
-  z-index: 1;
+  z-index: 2;
   width: min(1440px, 100%);
   max-width: 1679px;
   display: flex;
@@ -178,15 +195,17 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
   display: none;
 }
 
+/* Fade — when NOT inside marquee wrapper (standalone color-extract) */
 .color-extract .color-extract-landing-fade {
   position: absolute;
-  left: 0;
-  right: 0;
+  width: 100vw;
+  left: 50%;
+  transform: translateX(-50%);
   bottom: 0;
   height: 143px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, var(--color-extract-bg) 80.29%);
   pointer-events: none;
-  z-index: 2;
+  z-index: 1;
 }
 
 .color-extract.has-image .color-extract-landing-fade,
@@ -194,9 +213,28 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
   display: none;
 }
 
-/* ---- Drag overlay ---- */
+/* Fade — section level (moved out of marquee wrapper by JS) */
+.section > .color-extract-landing-fade {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 143px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #ffffff 80.29%);
+  pointer-events: none;
+  z-index: 2;
+}
 
-.color-extract .color-extract-drag-overlay {
+/* Hide section-level bg/fade when image is loaded or overlay is showing */
+.section:has(.color-extract.has-image) > .color-extract-landing-bg,
+.section:has(.color-extract.has-image) > .color-extract-landing-fade,
+.section:has(.color-extract.is-loading) > .color-extract-landing-fade {
+  display: none;
+}
+
+/* ---- Drag overlay (appended to document.body to escape contain:layout) ---- */
+
+.color-extract-drag-overlay {
   position: fixed;
   inset: 0;
   display: flex;
@@ -212,32 +250,32 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
   z-index: 50;
 }
 
-.color-extract.is-dragging .color-extract-drag-overlay {
+.color-extract-drag-overlay.is-dragging {
   opacity: 1;
 }
 
-.color-extract .color-extract-drag-icon {
+.color-extract-drag-icon {
   width: 65px;
   height: 65px;
-  color: var(--color-extract-text);
+  color: #131313;
 }
 
-.color-extract .color-extract-drag-icon svg {
+.color-extract-drag-icon svg {
   display: block;
   width: 100%;
   height: 100%;
 }
 
-.color-extract .color-extract-drag-text {
+.color-extract-drag-text {
   margin: 0;
   font-size: 16px;
   font-weight: 400;
-  color: var(--color-extract-text);
+  color: #131313;
 }
 
 /* ---- Full-screen loading overlay ---- */
 
-.color-extract .color-extract-loading-overlay {
+.color-extract-loading-overlay {
   position: fixed;
   inset: 0;
   display: flex;
@@ -251,12 +289,12 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
   z-index: 50;
 }
 
-.color-extract.is-loading .color-extract-loading-overlay {
+.color-extract-loading-overlay.is-loading {
   opacity: 1;
   pointer-events: auto;
 }
 
-.color-extract .color-extract-loading-content {
+.color-extract-loading-overlay .color-extract-loading-content {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -264,17 +302,17 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
   width: 192px;
 }
 
-.color-extract .color-extract-loading-label {
+.color-extract-loading-overlay .color-extract-loading-label {
   margin: 0;
   font-size: 18px;
   font-weight: 400;
   line-height: 22px;
-  color: var(--color-extract-subtle);
+  color: #505050;
   text-align: center;
   white-space: nowrap;
 }
 
-.color-extract .color-extract-loading-track {
+.color-extract-loading-overlay .color-extract-loading-track {
   width: 100%;
   height: 10px;
   border-radius: 5px;
@@ -282,14 +320,14 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
   overflow: hidden;
 }
 
-.color-extract .color-extract-loading-bar {
+.color-extract-loading-overlay .color-extract-loading-bar {
   height: 100%;
   width: 0;
   border-radius: 5px;
   background: #5258e4;
 }
 
-.color-extract.is-loading .color-extract-loading-bar {
+.color-extract-loading-overlay.is-loading .color-extract-loading-bar {
   animation: color-extract-loading-progress 1s ease-out forwards;
 }
 
@@ -931,27 +969,26 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg img {
     overflow: visible;
   }
 
-  /* No bg extension at tablet/mobile — bg images are hidden anyway */
   body:has(.color-headline.extract) .color-extract .color-extract-landing {
-    overflow: hidden;
     min-height: unset;
-  }
-
-  body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
-    top: 0;
   }
 
   .color-extract .color-extract-landing-bg {
     display: none;
   }
 
-  .color-extract .color-extract-landing-content {
-    width: 100%;
-    max-width: 100%;
+  .section > .color-extract-landing-bg,
+  .section > .color-extract-landing-fade {
+    display: none;
   }
 
   .color-extract .color-extract-landing-fade {
     display: none;
+  }
+
+  .color-extract .color-extract-landing-content {
+    width: 100%;
+    max-width: 100%;
   }
 
   .color-extract .color-extract-edit-copy h1 {

--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -257,7 +257,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 .color-extract-drag-icon {
   width: 65px;
   height: 65px;
-  color: #131313;
+  color: var(--color-extract-text);
 }
 
 .color-extract-drag-icon svg {
@@ -270,7 +270,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   margin: 0;
   font-size: 16px;
   font-weight: 400;
-  color: #131313;
+  color: var(--color-extract-text);
 }
 
 /* ---- Full-screen loading overlay ---- */

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -343,16 +343,38 @@ function buildSuggestedImages(row, onSelect) {
     const chips = [...palette.querySelectorAll('.color-extract-suggestion-chip')];
     const previewImage = preview.querySelector('img');
     if (previewImage) previewImage.draggable = false;
-    const hydratePalette = () => {
+    const hydratePalette = async () => {
+      const imgEl = previewImage?.naturalWidth ? previewImage : null;
+      const loadImg = () => {
+        if (imgEl) return Promise.resolve(imgEl);
+        if (!src) return Promise.resolve(null);
+        return new Promise((resolve) => {
+          const img = new Image();
+          img.crossOrigin = 'anonymous';
+          img.onload = () => resolve(img);
+          img.onerror = () => resolve(null);
+          img.src = src;
+        });
+      };
+      const img = await loadImg();
+      if (!img) return;
       try {
-        if (previewImage?.naturalWidth) {
-          applyPaletteToChips(extractPaletteFromImageElement(previewImage, chips.length), chips);
-          return;
-        }
-      } catch { /* canvas tainted — fall through to crossOrigin load */ }
-      if (!src) return;
-      extractPaletteFromSrc(src, chips.length)
-        .then((colors) => applyPaletteToChips(colors, chips));
+        const maxWidth = 160;
+        const ratio = img.naturalHeight / img.naturalWidth || 1;
+        const w = Math.min(maxWidth, img.naturalWidth);
+        const h = Math.round(w * ratio);
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        canvas.getContext('2d').drawImage(img, 0, 0, w, h);
+        const imageData = canvas.getContext('2d').getImageData(0, 0, w, h);
+        const { extractColorsFromImage } = await import('./helpers/extractWorker.js');
+        const result = await extractColorsFromImage(imageData, w, h, chips.length);
+        applyPaletteToChips(result.colors, chips);
+      } catch {
+        // Fallback to naive sampling if worker fails
+        applyPaletteToChips(extractPaletteFromImageElement(img, chips.length), chips);
+      }
     };
     const scheduleHydrate = () => {
       if (window.requestIdleCallback) {
@@ -533,48 +555,26 @@ function buildLoadingOverlay() {
 
 /* ---------- Shared drag wiring ---------- */
 
-function attachWindowDragHandlers(block, dropzone) {
+function attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay) {
   const ac = new AbortController();
   const { signal } = ac;
   const isBlockInViewport = () => {
     const rect = block.getBoundingClientRect();
     return rect.bottom > 0 && rect.top < window.innerHeight;
   };
-  window.addEventListener('dragenter', (e) => {
-    if (isBlockInViewport() && isFileDrag(e)) {
-      preventDefaults(e);
-      block.classList.add('is-dragging');
-    }
-  }, { signal });
-  window.addEventListener('dragover', (e) => {
-    if (isBlockInViewport() && isFileDrag(e)) {
-      preventDefaults(e);
-      block.classList.add('is-dragging');
-    }
-  }, { signal });
-  window.addEventListener('dragleave', (e) => {
-    preventDefaults(e);
-    if (!e.relatedTarget && !document.elementFromPoint(e.clientX, e.clientY)) {
-      block.classList.remove('is-dragging');
-    }
-  }, { signal });
-  window.addEventListener('dragend', (e) => {
-    preventDefaults(e);
-    block.classList.remove('is-dragging');
-  }, { signal });
-  window.addEventListener('drop', (e) => {
-    if (!isBlockInViewport() || !isFileDrag(e)) return;
-    preventDefaults(e);
-    dropzone.handleFile(e.dataTransfer.files[0]);
-    setTimeout(() => block.classList.remove('is-dragging'), 200);
-  }, { signal });
-  const detach = () => ac.abort();
-  const observer = new MutationObserver(() => {
-    if (!block.isConnected) {
-      detach();
-      observer.disconnect();
-    }
+  window.addEventListener('dragenter', (e) => { if (isBlockInViewport() && isFileDrag(e)) { preventDefaults(e); block.classList.add('is-dragging'); } }, { signal });
+  window.addEventListener('dragover', (e) => { if (isBlockInViewport() && isFileDrag(e)) { preventDefaults(e); block.classList.add('is-dragging'); } }, { signal });
+  window.addEventListener('dragleave', (e) => { preventDefaults(e); if (!e.relatedTarget && !document.elementFromPoint(e.clientX, e.clientY)) block.classList.remove('is-dragging'); }, { signal });
+  window.addEventListener('dragend', (e) => { preventDefaults(e); block.classList.remove('is-dragging'); }, { signal });
+  window.addEventListener('drop', (e) => { if (!isBlockInViewport() || !isFileDrag(e)) return; preventDefaults(e); dropzone.handleFile(e.dataTransfer.files[0]); setTimeout(() => block.classList.remove('is-dragging'), 200); }, { signal });
+  const detach = () => { ac.abort(); if (dragOverlay) dragOverlay.remove(); if (loadingOverlay) loadingOverlay.remove(); };
+  // Sync is-dragging and is-loading from block to body-level overlays
+  const syncObserver = new MutationObserver(() => {
+    if (dragOverlay) dragOverlay.classList.toggle('is-dragging', block.classList.contains('is-dragging'));
+    if (loadingOverlay) loadingOverlay.classList.toggle('is-loading', block.classList.contains('is-loading'));
   });
+  syncObserver.observe(block, { attributes: true, attributeFilter: ['class'] });
+  const observer = new MutationObserver(() => { if (!block.isConnected) { detach(); observer.disconnect(); } });
   observer.observe(block.parentElement || document.body, { childList: true });
   return detach;
 }
@@ -780,7 +780,7 @@ function renderColorVariant(block, rows, config) {
   const innerContainer = createTag('div', { class: 'color-extract-inner' });
   landing.content.append(dropzone.container);
   if (suggestions) landing.content.append(suggestions);
-  landing.stage.append(dragOverlay, loadingOverlay);
+  document.body.append(dragOverlay, loadingOverlay);
 
   // Defer UI component imports until after LCP paint settles
   const toolbarPlaceholder = createTag('div', { class: 'color-extract-toolbar-slot' });
@@ -847,12 +847,25 @@ function renderColorVariant(block, rows, config) {
     });
   }));
 
+  // Move decorative full-bleed elements to section level when inside marquee wrapper.
+  // Must happen before innerContainer.append so landing.stage loses bg/fade before mounting.
+  const marqueeWrapper = block.closest('.color-extract-marquee-wrapper');
+  if (marqueeWrapper) {
+    const section = marqueeWrapper.closest('.section');
+    const landingBg = landing.stage.querySelector('.color-extract-landing-bg');
+    const landingFade = landing.stage.querySelector('.color-extract-landing-fade');
+    if (section) {
+      if (landingBg) section.insertBefore(landingBg, marqueeWrapper);
+      if (landingFade) marqueeWrapper.after(landingFade);
+    }
+  }
+
   innerContainer.append(landing.stage, edit.wrapper);
 
   block.replaceChildren(innerContainer);
 
   if (resolvedConfig.enableImageUpload) {
-    attachWindowDragHandlers(block, dropzone);
+    attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay);
   }
 }
 
@@ -1179,7 +1192,7 @@ async function renderGradientVariant(block, rows, config) {
   const innerContainer = createTag('div', { class: 'color-extract-inner' });
   landing.content.append(dropzone.container);
   if (suggestions) landing.content.append(suggestions);
-  landing.stage.append(dragOverlay, loadingOverlay);
+  document.body.append(dragOverlay, loadingOverlay);
 
   const toolbarPlaceholder = createTag('div', { class: 'color-extract-toolbar-slot' });
   edit.leftCol.prepend(toolbarPlaceholder);
@@ -1246,12 +1259,25 @@ async function renderGradientVariant(block, rows, config) {
     });
   }));
 
+  // Move decorative full-bleed elements to section level when inside marquee wrapper.
+  // Must happen before innerContainer.append so landing.stage loses bg/fade before mounting.
+  const marqueeWrapper = block.closest('.color-extract-marquee-wrapper');
+  if (marqueeWrapper) {
+    const section = marqueeWrapper.closest('.section');
+    const landingBg = landing.stage.querySelector('.color-extract-landing-bg');
+    const landingFade = landing.stage.querySelector('.color-extract-landing-fade');
+    if (section) {
+      if (landingBg) section.insertBefore(landingBg, marqueeWrapper);
+      if (landingFade) marqueeWrapper.after(landingFade);
+    }
+  }
+
   innerContainer.append(landing.stage, edit.wrapper);
 
   block.replaceChildren(innerContainer);
 
   if (resolvedConfig.enableImageUpload) {
-    attachWindowDragHandlers(block, dropzone);
+    attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay);
   }
 }
 

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -366,8 +366,9 @@ function buildSuggestedImages(row, onSelect) {
         const canvas = document.createElement('canvas');
         canvas.width = w;
         canvas.height = h;
-        canvas.getContext('2d').drawImage(img, 0, 0, w, h);
-        const imageData = canvas.getContext('2d').getImageData(0, 0, w, h);
+        const context = canvas.getContext('2d');
+        context.drawImage(img, 0, 0, w, h);
+        const imageData = context.getImageData(0, 0, w, h);
         const { extractColorsFromImage } = await import('./helpers/extractWorker.js');
         const result = await extractColorsFromImage(imageData, w, h, chips.length);
         applyPaletteToChips(result.colors, chips);
@@ -567,7 +568,7 @@ function attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay) 
   window.addEventListener('dragleave', (e) => { preventDefaults(e); if (!e.relatedTarget && !document.elementFromPoint(e.clientX, e.clientY)) block.classList.remove('is-dragging'); }, { signal });
   window.addEventListener('dragend', (e) => { preventDefaults(e); block.classList.remove('is-dragging'); }, { signal });
   window.addEventListener('drop', (e) => { if (!isBlockInViewport() || !isFileDrag(e)) return; preventDefaults(e); dropzone.handleFile(e.dataTransfer.files[0]); setTimeout(() => block.classList.remove('is-dragging'), 200); }, { signal });
-  const detach = () => { ac.abort(); if (dragOverlay) dragOverlay.remove(); if (loadingOverlay) loadingOverlay.remove(); };
+  const detach = () => { ac.abort(); if (dragOverlay) dragOverlay.remove(); if (loadingOverlay) loadingOverlay.remove(); syncObserver.disconnect(); };
   // Sync is-dragging and is-loading from block to body-level overlays
   const syncObserver = new MutationObserver(() => {
     if (dragOverlay) dragOverlay.classList.toggle('is-dragging', block.classList.contains('is-dragging'));
@@ -580,6 +581,17 @@ function attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay) 
 }
 
 /* ---------- Palette variant ---------- */
+
+function hoistLandingDecorations(block, landing) {
+  const marqueeWrapper = block.closest('.color-extract-marquee-wrapper');
+  if (!marqueeWrapper) return;
+  const section = marqueeWrapper.closest('.section');
+  if (!section) return;
+  const landingBg = landing.stage.querySelector('.color-extract-landing-bg');
+  const landingFade = landing.stage.querySelector('.color-extract-landing-fade');
+  if (landingBg) section.insertBefore(landingBg, marqueeWrapper);
+  if (landingFade) marqueeWrapper.after(landingFade);
+}
 
 function renderColorVariant(block, rows, config) {
   const maxColors = Math.max(1, Math.min(10, Number(config.maxColors) || DEFAULTS.MAX_COLORS));
@@ -849,16 +861,7 @@ function renderColorVariant(block, rows, config) {
 
   // Move decorative full-bleed elements to section level when inside marquee wrapper.
   // Must happen before innerContainer.append so landing.stage loses bg/fade before mounting.
-  const marqueeWrapper = block.closest('.color-extract-marquee-wrapper');
-  if (marqueeWrapper) {
-    const section = marqueeWrapper.closest('.section');
-    const landingBg = landing.stage.querySelector('.color-extract-landing-bg');
-    const landingFade = landing.stage.querySelector('.color-extract-landing-fade');
-    if (section) {
-      if (landingBg) section.insertBefore(landingBg, marqueeWrapper);
-      if (landingFade) marqueeWrapper.after(landingFade);
-    }
-  }
+  hoistLandingDecorations(block, landing);
 
   innerContainer.append(landing.stage, edit.wrapper);
 
@@ -1261,16 +1264,7 @@ async function renderGradientVariant(block, rows, config) {
 
   // Move decorative full-bleed elements to section level when inside marquee wrapper.
   // Must happen before innerContainer.append so landing.stage loses bg/fade before mounting.
-  const marqueeWrapper = block.closest('.color-extract-marquee-wrapper');
-  if (marqueeWrapper) {
-    const section = marqueeWrapper.closest('.section');
-    const landingBg = landing.stage.querySelector('.color-extract-landing-bg');
-    const landingFade = landing.stage.querySelector('.color-extract-landing-fade');
-    if (section) {
-      if (landingBg) section.insertBefore(landingBg, marqueeWrapper);
-      if (landingFade) marqueeWrapper.after(landingFade);
-    }
-  }
+  hoistLandingDecorations(block, landing);
 
   innerContainer.append(landing.stage, edit.wrapper);
 

--- a/express/code/blocks/color-extract/helpers/imageMarkers.js
+++ b/express/code/blocks/color-extract/helpers/imageMarkers.js
@@ -230,6 +230,7 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
 
   function startMag(marker, cx, cy, touch) {
     // Handle magnification (both desktop and mobile)
+    marker.el.classList.remove('is-active');
     marker.el.classList.add('is-magnified');
     const zc = marker.el.querySelector('.color-extract-marker-zoom');
     if (zc) renderMagnification(zc, canvas, cx, cy);
@@ -251,6 +252,7 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
 
   function endMag(marker) {
     marker.el.classList.remove('is-magnified');
+    marker.el.classList.remove('is-active');
     loupe.hide();
   }
 
@@ -334,9 +336,8 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
   /* ── Marker creation ── */
 
   function createMarker(index, hex, pctX, pctY) {
-    const active = index === activeIndex;
     const el = createTag('div', {
-      class: `color-extract-marker ${active ? 'is-active' : ''}`,
+      class: 'color-extract-marker',
       tabindex: '0',
       role: 'slider',
       'aria-label': `Color ${index + 1} picker handle`,
@@ -347,7 +348,7 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
     el.append(createTag('span', { class: 'color-extract-marker-dot', 'aria-hidden': 'true' }));
 
     el.style.setProperty('--marker-color', hex);
-    el.style.zIndex = active ? 10 : 1;
+    el.style.zIndex = 1;
     positionMarker(el, pctX, pctY);
 
     const marker = { el, pctX, pctY };
@@ -376,7 +377,7 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
     });
     connectorOrder = colors.map((_, i) => i);
     updateConnectors();
-    if (markers.length) setActiveMarker(0);
+    if (markers.length) controller.setBaseColorIndex(0);
   }
 
   /**

--- a/express/code/blocks/hero-color/hero-color.css
+++ b/express/code/blocks/hero-color/hero-color.css
@@ -28,7 +28,8 @@ main .hero-color .text-container {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: 15px;
+  margin: 0;
+  padding: 16px;
   text-align: left;
   color: var(--color-black);
 }
@@ -87,22 +88,39 @@ main .hero-color .hidden-svg {
 }
 
 @media screen and (min-width: 900px) {
+  main .hero-color {
+    overflow: hidden;
+  }
+
+  main .hero-color::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 120px;
+    background: linear-gradient(to top, #fff 0%, transparent 100%);
+    pointer-events: none;
+    z-index: 1;
+  }
+
   main .hero-color .svg-container {
-    min-height: 336px;
-    padding-left: 50%;
+    height: 800px;
+    position: relative;
   }
 
   main .hero-color .svg-container .color-svg {
-    position: relative;
+    position: static;
   }
 
   main .hero-color .svg-container .color-svg-img {
     margin: 0;
     width: 1424px;
-    height: 336px;
-    overflow: hidden;
+    height: 800px;
     position: absolute;
-    left: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    top: 0;
   }
 
   main .hero-color .text-container {
@@ -115,6 +133,7 @@ main .hero-color .hidden-svg {
     color: unset;
     box-sizing: border-box;
     margin: 0;
+    padding: 0 var(--spacing-500);
   }
 
   main .hero-color .text-container > div {

--- a/express/code/blocks/hero-color/hero-color.js
+++ b/express/code/blocks/hero-color/hero-color.js
@@ -75,34 +75,16 @@ function decorateColors(block) {
   return { secondaryColor };
 }
 
-function getContentContainerHeight() {
-  const contentContainer = document.querySelector('.svg-container');
-
-  return contentContainer?.clientHeight;
-}
-
 function resizeSvgOnLoad() {
-  const interval = setInterval(() => {
-    if (document.readyState === 'complete') {
-      const height = getContentContainerHeight();
-      if (height) {
-        const svg = document.querySelector('.color-svg-img');
-        svg.classList.remove('hidden-svg');
-        svg.style.height = `${height}px`;
-        clearInterval(interval);
-      }
-    }
-  }, 50);
+  const mediaQuery = window.matchMedia('(min-width: 900px)');
+  const svg = document.querySelector('.color-svg-img');
+  svg.classList.remove('hidden-svg');
+  svg.style.height = mediaQuery.matches ? '800px' : '200px';
 }
 
 export function resizeSvg(event) {
-  const height = getContentContainerHeight();
   const svg = document.querySelector('.color-svg-img');
-  if (event.matches) {
-    svg.style.height = `${height}px`;
-  } else {
-    svg.style.height = '200px';
-  }
+  svg.style.height = event.matches ? '800px' : '200px';
 }
 
 function resizeSvgOnMediaQueryChange() {

--- a/express/code/blocks/hero-color/hero-color.js
+++ b/express/code/blocks/hero-color/hero-color.js
@@ -75,16 +75,19 @@ function decorateColors(block) {
   return { secondaryColor };
 }
 
+const SVG_HEIGHT_DESKTOP = '800px';
+const SVG_HEIGHT_MOBILE = '200px';
+
 function resizeSvgOnLoad() {
   const mediaQuery = window.matchMedia('(min-width: 900px)');
   const svg = document.querySelector('.color-svg-img');
   svg.classList.remove('hidden-svg');
-  svg.style.height = mediaQuery.matches ? '800px' : '200px';
+  svg.style.height = mediaQuery.matches ? SVG_HEIGHT_DESKTOP : SVG_HEIGHT_MOBILE;
 }
 
 export function resizeSvg(event) {
   const svg = document.querySelector('.color-svg-img');
-  svg.style.height = event.matches ? '800px' : '200px';
+  svg.style.height = event.matches ? SVG_HEIGHT_DESKTOP : SVG_HEIGHT_MOBILE;
 }
 
 function resizeSvgOnMediaQueryChange() {


### PR DESCRIPTION
## Summary

- Fix background image not visible at 1200px desktop — changed from fixed 1920px width to responsive `width: 100%; max-width: 1920px` so images scale with viewport
- Fix content not vertically centered in landing view — section now uses flex centering with `min-height: 800px`
- Move bg/fade elements to section level via JS so they escape the 640px marquee wrapper
- Fix z-index stacking: landing-content above fade, fade above bg
- Fix suggestion preview palettes using wrong extraction algorithm — now uses the same HSV histogram worker as the results view instead of naive pixel sampling
- Restore `display: none` on bg/fade at tablet/mobile breakpoints (≤1199px)

---

## Jira Ticket

Resolves: [MWPW-185872](https://jira.corp.adobe.com/browse/MWPW-185872)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--express-color--adobecom.aem.page/drafts/bradjohn/extract |
| **After**   | https://extract-patch--express-color--adobecom.aem.page/drafts/bradjohn/extract?martech=off |

---

## Verification Steps

- At 1200px desktop: background corner images should be partially visible at viewport edges
- At 1920px+: full background image revealed, images stop moving outward
- Content (headline, upload widget, suggestions) should be vertically centered in the hero area
- Suggestion preview chips should show vibrant, colorful palettes matching the results view
- At tablet/mobile (≤1199px): background images and fade should be hidden
- Upload widget and suggestion chips should be clickable (not covered by fade overlay)

---

## Potential Regressions



---

## Additional Notes