### PR TITLE
[MWPW-186751] Color Blindness DQA and Color Edit PopUp Position

### DIFF
--- a/express/code/libs/color-components/components/color-swatch-rail/index.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/index.js
@@ -1,6 +1,6 @@
 
 import { LitElement, html } from '../../../deps/lit-all.min.js';
-import { getContrastTextColor } from '../../utils/ColorConversions.js';
+import { getContrastTextColor, isSuperLight } from '../../utils/ColorConversions.js';
 import { getFirstFocusableInGroup } from '../../utils/util.js';
 import { style } from './styles.css.js';
 import { showExpressToast } from '../../../../scripts/color-shared/spectrum/components/express-toast.js';
@@ -1063,8 +1063,9 @@ export class ColorSwatchRail extends LitElement {
       if (isSimulatedCell) {
         const textColor = getContrastTextColor(swatch.hex);
         const shadow = textColor === '#ffffff' ? '0 0 2px rgba(0,0,0,0.5)' : '0 0 2px rgba(255,255,255,0.5)';
+        const simulatedSuperLight = isSuperLight(swatch.hex);
         return html`
-          <div class="swatch-column swatch-column--simulated" tabindex="-1" role="group" aria-label="Simulated color"
+          <div class="swatch-column swatch-column--simulated ${simulatedSuperLight ? 'swatch-column--super-light' : ''}" tabindex="-1" role="group" aria-label="Simulated color"
             style="background-color: ${swatch.hex}; --swatch-text-color: ${textColor}; --swatch-text-shadow: var(--swatch-text-shadow-override, ${shadow}); --swatch-icon-color: ${textColor};"
             data-swatch-index="${index}">
             ${swatch.conflict ? conflictIcon() : ''}
@@ -1083,6 +1084,7 @@ export class ColorSwatchRail extends LitElement {
       const effectiveLocked = isLocked || isBase;
       const textColor = getContrastTextColor(swatch.hex);
       const shadow = textColor === '#ffffff' ? '0 0 2px rgba(0,0,0,0.5)' : '0 0 2px rgba(255,255,255,0.5)';
+      const superLight = isSuperLight(swatch.hex);
       const showColorEdit = f.colorPicker && !editDisabled && !effectiveLocked;
       const showHexCopyButton = f.copy && f.copyFromHex !== false && !isBase;
       const tintMode = f.editTint && !f.colorPicker;
@@ -1163,7 +1165,7 @@ export class ColorSwatchRail extends LitElement {
       `;
 
       return html`
-        <div class="swatch-column ${effectiveLocked ? 'locked' : ''} ${isBase ? 'base-color' : ''} ${tintMode ? 'swatch-column--tint-mode' : ''} ${isTintSelected ? 'swatch-column--tint-selected' : ''} ${f.drag && !effectiveLocked ? 'swatch-column--draggable' : ''}"
+        <div class="swatch-column ${effectiveLocked ? 'locked' : ''} ${isBase ? 'base-color' : ''} ${tintMode ? 'swatch-column--tint-mode' : ''} ${isTintSelected ? 'swatch-column--tint-selected' : ''} ${f.drag && !effectiveLocked ? 'swatch-column--draggable' : ''} ${superLight ? 'swatch-column--super-light' : ''}"
           data-contrast="${textColor.toLowerCase() === '#ffffff' ? 'dark' : 'light'}"
           style="background-color: ${swatch.hex}; --swatch-base-color: ${swatch.hex}; --swatch-text-color: ${textColor}; --swatch-text-shadow: var(--swatch-text-shadow-override, ${shadow}); --swatch-icon-filter: ${textColor.toLowerCase() === '#ffffff' ? 'brightness(0) invert(1)' : 'brightness(0)'}"
           data-swatch-index="${index}"

--- a/express/code/libs/color-components/components/color-swatch-rail/index.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/index.js
@@ -1164,8 +1164,18 @@ export class ColorSwatchRail extends LitElement {
         ${stackedIcons}
       `;
 
+      const swatchClasses = [
+        'swatch-column',
+        effectiveLocked && 'locked',
+        isBase && 'base-color',
+        tintMode && 'swatch-column--tint-mode',
+        isTintSelected && 'swatch-column--tint-selected',
+        f.drag && !effectiveLocked && 'swatch-column--draggable',
+        superLight && 'swatch-column--super-light',
+      ].filter(Boolean).join(' ');
+
       return html`
-        <div class="swatch-column ${effectiveLocked ? 'locked' : ''} ${isBase ? 'base-color' : ''} ${tintMode ? 'swatch-column--tint-mode' : ''} ${isTintSelected ? 'swatch-column--tint-selected' : ''} ${f.drag && !effectiveLocked ? 'swatch-column--draggable' : ''} ${superLight ? 'swatch-column--super-light' : ''}"
+        <div class="${swatchClasses}"
           data-contrast="${textColor.toLowerCase() === '#ffffff' ? 'dark' : 'light'}"
           style="background-color: ${swatch.hex}; --swatch-base-color: ${swatch.hex}; --swatch-text-color: ${textColor}; --swatch-text-shadow: var(--swatch-text-shadow-override, ${shadow}); --swatch-icon-filter: ${textColor.toLowerCase() === '#ffffff' ? 'brightness(0) invert(1)' : 'brightness(0)'}"
           data-swatch-index="${index}"

--- a/express/code/libs/color-components/components/color-swatch-rail/index.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/index.js
@@ -211,6 +211,12 @@ export class ColorSwatchRail extends LitElement {
     this._tooltipsInitialized = false;
     this._nativePickerOpen = false;
     this._nativePickerCloseTimer = null;
+    this._activeEditIndex = null;
+  }
+
+  setActiveEditIndex(index) {
+    this._activeEditIndex = index ?? null;
+    this.requestUpdate();
   }
 
   get _features() {
@@ -1205,7 +1211,7 @@ export class ColorSwatchRail extends LitElement {
           ` : html`<div class="stacked-row">${stackedContent}</div>`}
           ${!isStacked ? html`<div class="bottom-info" part="bottom-info">
             ${showColorEdit && showHexCopyForThisSwatch ? html`<input type="color" id="edit-input-${index}" class="edit-input-native" tabindex="-1" aria-hidden="true" value=${swatch.hex} @input=${(ev) => this._onNativePickerChange(index, ev)} @change=${() => this._markNativePickerClosedSoon(50)} @blur=${() => this._markNativePickerClosedSoon(50)} />` : ''}
-            ${f.hexCode && showHexCopyForThisSwatch ? (showColorEdit || showHexCopyButton ? html`<button type="button" class="hex-code hex-code--${showColorEdit ? 'editable' : 'copyable'} swatch-column-focusable" tabindex="-1" @click=${showColorEdit ? (ev) => this._handleColorPicker(index, ev.currentTarget) : (ev) => this._handleCopy(swatch.hex, ev.currentTarget)} aria-label=${showColorEdit ? 'Edit color' : 'Copy hex'} title=${showColorEdit ? 'Edit color' : 'Copy hex'}>${swatch.hex}</button>` : html`<span class="hex-code hex-code--static" aria-label="Hex code" title="Hex code">${swatch.hex}</span>`) : ''}
+            ${f.hexCode && showHexCopyForThisSwatch ? (showColorEdit || showHexCopyButton ? html`<button type="button" class="hex-code hex-code--${showColorEdit ? 'editable' : 'copyable'} swatch-column-focusable${this._activeEditIndex === index ? ' hex-code--editor-open' : ''}" tabindex="-1" @click=${showColorEdit ? (ev) => this._handleColorPicker(index, ev.currentTarget) : (ev) => this._handleCopy(swatch.hex, ev.currentTarget)} aria-label=${showColorEdit ? 'Edit color' : 'Copy hex'} title=${showColorEdit ? 'Edit color' : 'Copy hex'}>${swatch.hex}</button>` : html`<span class="hex-code hex-code--static" aria-label="Hex code" title="Hex code">${swatch.hex}</span>`) : ''}
             <div class="bottom-info__actions">
               ${f.copy && showHexCopyForThisSwatch ? html`<button type="button" class="icon-button icon-button--copy swatch-column-focusable" tabindex="-1" @click=${(e) => this._handleCopy(swatch.hex, e.currentTarget)} aria-label="Copy hex" title="Copy hex">${icon('copy')}</button>` : ''}
             </div>

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -897,6 +897,14 @@ export const style = css`
   .swatch-column[data-contrast="light"] button.hex-code:hover {
     background-color: rgba(0, 0, 0, 0.12);
   }
+  .swatch-column[data-contrast="light"] button.hex-code:active {
+    border-radius: 5px;
+    border: 1px solid var(--color-gray-950);
+  }
+  .swatch-column[data-contrast="dark"] button.hex-code:active {
+    border-radius: 5px;
+    border: 1px solid var(--color-gray-400-variant);
+  }
   button.hex-code:focus-visible {
     outline: 2px solid var(--color-blue-800);
     outline-offset: 2px;

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -897,13 +897,15 @@ export const style = css`
   .swatch-column[data-contrast="light"] button.hex-code:hover {
     background-color: rgba(0, 0, 0, 0.12);
   }
-  .swatch-column[data-contrast="light"] button.hex-code:active {
+  .swatch-column[data-contrast="light"] button.hex-code.hex-code--editor-open {
     border-radius: 5px;
     border: 1px solid var(--color-gray-950);
+    background: transparent;
   }
-  .swatch-column[data-contrast="dark"] button.hex-code:active {
+  .swatch-column[data-contrast="dark"] button.hex-code.hex-code--editor-open {
     border-radius: 5px;
     border: 1px solid var(--color-gray-400-variant);
+    background: transparent;
   }
   button.hex-code:focus-visible {
     outline: 2px solid var(--color-blue-800);

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -44,6 +44,10 @@ export const style = css`
     container-type: inline-size;
   }
 
+  .swatch-column--super-light {
+    box-shadow: inset 0 0 0 1px var(--color-gray-300-variant);
+  }
+
   .swatch-column--tint-mode {
     --swatch-base-color: #808080;
     --swatch-tint-overlay: rgba(0, 0, 0, 0.18);
@@ -1008,5 +1012,11 @@ export const style = css`
   sp-tooltip,
   sp-tooltip * {
     text-transform: none !important;
+  }
+
+  @media (max-width: 899px) {
+    .swatch-column--super-light {
+      box-shadow: none;
+    }
   }
 `;

--- a/express/code/libs/color-components/utils/ColorConversions.js
+++ b/express/code/libs/color-components/utils/ColorConversions.js
@@ -361,3 +361,14 @@ export const getContrastTextColor = (hex) => {
     const luminance = (0.299 * rgb.red + 0.587 * rgb.green + 0.114 * rgb.blue) / 255;
     return luminance > 0.5 ? '#000000' : '#FFFFFF';
 };
+
+export const isSuperLight = (hex) => {
+    const rgb = hexToRGB(hex);
+    if (!rgb) return false;
+    const toLinear = (c) => {
+        const s = c / 255;
+        return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    };
+    const L = 0.2126 * toLinear(rgb.red) + 0.7152 * toLinear(rgb.green) + 0.0722 * toLinear(rgb.blue);
+    return (1.05 / (L + 0.05)) < 1.5;
+};

--- a/express/code/scripts/color-shared/components/color-conflicts/index.js
+++ b/express/code/scripts/color-shared/components/color-conflicts/index.js
@@ -23,13 +23,72 @@ class ColorConflicts extends LitElement {
     this.conflictsFound = false;
     this.label = 'Potential color blind conflicts';
     this._hasRendered = false;
+    this._tooltipOpen = false;
+    this._isTouchDevice = false;
+    this._removeOutsideClickHandler = null;
+    this._cleanupPointerBlockers = null;
   }
 
   async connectedCallback() {
     super.connectedCallback();
+    this._isTouchDevice = window.matchMedia?.('(hover: none)')?.matches ?? false;
     loadBadge();
     loadTooltip();
     await this.#loadTooltipStyles();
+  }
+
+  firstUpdated() {
+    if (!this._isTouchDevice) return;
+    const wrap = this.shadowRoot.querySelector('.cc-label-wrap');
+    if (!wrap) return;
+    const blockTouchPointer = (e) => {
+      if (e.pointerType === 'touch') e.stopImmediatePropagation();
+    };
+    wrap.addEventListener('pointerenter', blockTouchPointer, { capture: true });
+    wrap.addEventListener('pointerleave', blockTouchPointer, { capture: true });
+    this._cleanupPointerBlockers = () => {
+      wrap.removeEventListener('pointerenter', blockTouchPointer, { capture: true });
+      wrap.removeEventListener('pointerleave', blockTouchPointer, { capture: true });
+    };
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#closeTooltip();
+    this._cleanupPointerBlockers?.();
+  }
+
+  #closeTooltip() {
+    const tooltipEl = this.shadowRoot?.querySelector('sp-tooltip');
+    tooltipEl?.removeAttribute('open');
+    this._tooltipOpen = false;
+    if (this._removeOutsideClickHandler) {
+      this._removeOutsideClickHandler();
+      this._removeOutsideClickHandler = null;
+    }
+  }
+
+  #handleLabelClick() {
+    if (!this._isTouchDevice) return;
+    const tooltipEl = this.shadowRoot?.querySelector('sp-tooltip');
+    if (!tooltipEl) return;
+    if (this._tooltipOpen) {
+      this.#closeTooltip();
+      return;
+    }
+    tooltipEl.setAttribute('open', '');
+    this._tooltipOpen = true;
+    setTimeout(() => {
+      const outsideHandler = (evt) => {
+        const path = evt.composedPath?.() || [];
+        const wrap = this.shadowRoot?.querySelector('.cc-label-wrap');
+        if (wrap && !path.includes(wrap)) {
+          this.#closeTooltip();
+        }
+      };
+      document.addEventListener('click', outsideHandler, true);
+      this._removeOutsideClickHandler = () => document.removeEventListener('click', outsideHandler, true);
+    }, 0);
   }
 
   async #loadTooltipStyles() {
@@ -73,7 +132,8 @@ class ColorConflicts extends LitElement {
       <sp-theme system="spectrum-two" color="light" scale="medium">
         <div class="cc-container" role="group"
           aria-label="${tooltipContent}">
-          <span class="cc-label-wrap" tabindex="0">
+          <span class="cc-label-wrap" tabindex="0"
+            @click="${() => this.#handleLabelClick()}">
             <sp-tooltip self-managed placement="top">${tooltipContent}</sp-tooltip>
             <span class="cc-label">${this.label}</span>
           </span>

--- a/express/code/scripts/color-shared/components/strips/color-strip.css
+++ b/express/code/scripts/color-shared/components/strips/color-strip.css
@@ -1594,6 +1594,10 @@ color-swatch-rail {
   transition: border-color 0.15s ease, opacity 0.15s ease;
 }
 
+.strip-cb-mobile-row__palette.super-light {
+  border-color: var(--color-gray-300-variant);
+}
+
 .strip-cb-mobile-row__palette:hover {
   border-color: rgba(0, 0, 0, 0.25);
 }
@@ -1621,6 +1625,9 @@ color-swatch-rail {
   position: relative;
   min-width: 0;
   min-height: 0;
+}
+
+.strip-cb-mobile-row__sim.super-light {
   border: 1px solid var(--color-gray-300-variant);
 }
 

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -1,7 +1,7 @@
 import { createTag } from '../../utils.js';
 import createBaseRenderer from './createBaseRenderer.js';
 import { createSwatchRailAdapter, createColorEditAdapter } from '../adapters/litComponentAdapters.js';
-import { getContrastTextColor } from '../../../libs/color-components/utils/ColorConversions.js';
+import { getContrastTextColor, isSuperLight } from '../../../libs/color-components/utils/ColorConversions.js';
 import {
   TYPE_ORDER,
   TYPE_LABELS,
@@ -245,7 +245,7 @@ function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS) {
 
       const textColor = getContrastTextColor(hex);
       const paletteCell = createTag('div', {
-        class: 'strip-cb-mobile-row__palette',
+        class: `strip-cb-mobile-row__palette${isSuperLight(hex) ? ' super-light' : ''}`,
         style: `background-color: ${hex};`,
         role: 'button',
         tabindex: '0',
@@ -278,7 +278,7 @@ function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS) {
         const sim = simulateHex(hex, type);
         const conflicting = conflictsByType[type];
         const simCell = createTag('div', {
-          class: `strip-cb-mobile-row__sim${conflicting.has(colorIndex) ? ' conflict' : ''}`,
+          class: `strip-cb-mobile-row__sim${conflicting.has(colorIndex) ? ' conflict' : ''}${isSuperLight(sim) ? ' super-light' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
           role: 'img',
           'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -550,7 +550,10 @@ export function createStripContainerRenderer(options) {
     }
     top = Math.max(gap, top);
 
-    let left = anchorRect.left + (anchorRect.width - popRect.width) / 2;
+    let left = anchorRect.left;
+    if (left + popRect.width > window.innerWidth - gap) {
+      left = anchorRect.right - popRect.width;
+    }
     left = Math.max(gap, Math.min(left, window.innerWidth - popRect.width - gap));
 
     popover.style.top = `${top}px`;

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -566,6 +566,7 @@ export function createStripContainerRenderer(options) {
       outsideHandler,
       escapeHandler,
       scrollHandler,
+      railElement: activeRailElement,
     } = activeColorEditor;
     if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
@@ -579,6 +580,7 @@ export function createStripContainerRenderer(options) {
     }
     adapter.destroy?.();
     popover?.remove();
+    activeRailElement?.setActiveEditIndex?.(null);
     activeColorEditor = null;
   }
 
@@ -622,10 +624,12 @@ export function createStripContainerRenderer(options) {
       },
     });
 
+    railElement.setActiveEditIndex?.(selectedIndex);
+
     const editorElement = adapter.getElement?.() || adapter.element;
     if (mobile) {
       document.body.appendChild(editorElement);
-      activeColorEditor = { adapter, mobile: true };
+      activeColorEditor = { adapter, mobile: true, railElement };
       requestAnimationFrame(() => adapter.show?.());
       return;
     }
@@ -669,6 +673,7 @@ export function createStripContainerRenderer(options) {
       outsideHandler,
       escapeHandler,
       scrollHandler,
+      railElement,
     };
   }
 

--- a/express/code/scripts/color-shared/spectrum/components/express-tooltip.js
+++ b/express/code/scripts/color-shared/spectrum/components/express-tooltip.js
@@ -46,6 +46,8 @@ export async function createExpressTooltip(config) {
   await loadOverrideStyles('tooltip', STYLES_PATH);
   await customElements.whenDefined('sp-tooltip');
 
+  const isTouchDevice = window.matchMedia?.('(hover: none)')?.matches ?? false;
+
   const theme = createThemeWrapper();
   const tooltip = document.createElement('sp-tooltip');
   tooltip.setAttribute('placement', placement);
@@ -71,6 +73,15 @@ export async function createExpressTooltip(config) {
   const { signal } = controller;
   let showTimer = null;
   let visible = false;
+  let removeOutsideClickHandler = null;
+
+  function hide() {
+    clearTimeout(showTimer);
+    tooltip.removeAttribute('open');
+    visible = false;
+    removeOutsideClickHandler?.();
+    removeOutsideClickHandler = null;
+  }
 
   function show() {
     clearTimeout(showTimer);
@@ -80,14 +91,36 @@ export async function createExpressTooltip(config) {
     }, delay);
   }
 
-  function hide() {
-    clearTimeout(showTimer);
-    tooltip.removeAttribute('open');
-    visible = false;
-  }
+  if (isTouchDevice) {
+    const blockTouchPointer = (e) => {
+      if (e.pointerType === 'touch') e.stopImmediatePropagation();
+    };
+    targetEl.addEventListener('pointerenter', blockTouchPointer, { capture: true, signal });
+    targetEl.addEventListener('pointerleave', blockTouchPointer, { capture: true, signal });
 
-  targetEl.addEventListener('pointerenter', show, { signal });
-  targetEl.addEventListener('pointerleave', hide, { signal });
+    const toggleTouch = () => {
+      if (visible) {
+        hide();
+        return;
+      }
+      tooltip.setAttribute('open', '');
+      visible = true;
+      setTimeout(() => {
+        const outsideHandler = (evt) => {
+          const path = evt.composedPath?.() || [];
+          if (!path.includes(targetEl) && !path.includes(theme)) {
+            hide();
+          }
+        };
+        document.addEventListener('click', outsideHandler, true);
+        removeOutsideClickHandler = () => document.removeEventListener('click', outsideHandler, true);
+      }, 0);
+    };
+    targetEl.addEventListener('click', toggleTouch, { signal });
+  } else {
+    targetEl.addEventListener('pointerenter', show, { signal });
+    targetEl.addEventListener('pointerleave', hide, { signal });
+  }
 
   targetEl.addEventListener('focusin', () => {
     if (targetEl.matches(':focus-visible')) show();
@@ -119,6 +152,7 @@ export async function createExpressTooltip(config) {
     destroy() {
       controller.abort();
       clearTimeout(showTimer);
+      removeOutsideClickHandler?.();
       ariaLink?.release();
       theme.remove();
     },

--- a/express/code/scripts/color-shared/spectrum/components/express-tooltip.js
+++ b/express/code/scripts/color-shared/spectrum/components/express-tooltip.js
@@ -122,10 +122,12 @@ export async function createExpressTooltip(config) {
     targetEl.addEventListener('pointerleave', hide, { signal });
   }
 
-  targetEl.addEventListener('focusin', () => {
-    if (targetEl.matches(':focus-visible')) show();
-  }, { signal });
-  targetEl.addEventListener('focusout', hide, { signal });
+  if (!isTouchDevice) {
+    targetEl.addEventListener('focusin', () => {
+      if (targetEl.matches(':focus-visible')) show();
+    }, { signal });
+    targetEl.addEventListener('focusout', hide, { signal });
+  }
 
   targetEl.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && visible) hide();


### PR DESCRIPTION
## Summary

- Add focus/active state for hex code in color strips
- Fix Color Edit popup position as per figma
- Fix tooltip behaviour on touch devices, the tooltip now appears on touch on labels and disappears when tapped elsewhere
- Add border for super light color strips (colors with contrast ratio < 1.5 with white) and remove from dark and light colors.

---

## Jira Ticket

Resolves: [MWPW-186751](https://jira.corp.adobe.com/browse/MWPW-186751)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://MWPW-186751-cb-color-edit--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
