### PR TITLE
[MWPW-187630] fix: bluelines for color-edit component

### DIFF
--- a/express/code/blocks/color-contrast-checker/renderers/components/createColorInput.js
+++ b/express/code/blocks/color-contrast-checker/renderers/components/createColorInput.js
@@ -250,21 +250,18 @@ export function createColorInput(config) {
     return colorEdit;
   }
 
-  function queueMobileEditorOpen(colorEdit, requestId, shouldAutoFocusInput) {
+  function queueMobileEditorOpen(colorEdit, requestId) {
     document.body.appendChild(colorEdit);
     activeEditor = colorEdit;
     completeOpenRequest(requestId);
 
-    requestAnimationFrame(async () => {
+    requestAnimationFrame(() => {
       if (!isActiveEditorRequest(requestId, colorEdit)) return;
       colorEdit.show();
-      if (shouldAutoFocusInput) {
-        await colorEdit.focusInput();
-      }
     });
   }
 
-  async function openDesktopEditor(colorEdit, requestId, shouldAutoFocusInput) {
+  async function openDesktopEditor(colorEdit, requestId) {
     await loadPicker();
     if (!isCurrentOpenRequest(requestId)) return;
 
@@ -291,9 +288,7 @@ export function createColorInput(config) {
       if (!isActiveEditorRequest(requestId, colorEdit)) return;
       await colorEdit.updateComplete;
       if (!isActiveEditorRequest(requestId, colorEdit)) return;
-      if (shouldAutoFocusInput) {
-        await colorEdit.focusInput();
-      }
+      await colorEdit.show();
       focusTrap = trapFocus(overlay);
 
       addDismissListener('keydown', (e) => {
@@ -316,14 +311,13 @@ export function createColorInput(config) {
       if (!isCurrentOpenRequest(requestId)) return;
 
       const colorEdit = createColorEdit();
-      const shouldAutoFocusInput = shouldAutoFocusColorEditInput();
 
       if (colorEdit.mobile) {
-        queueMobileEditorOpen(colorEdit, requestId, shouldAutoFocusInput);
+        queueMobileEditorOpen(colorEdit, requestId);
         return;
       }
 
-      await openDesktopEditor(colorEdit, requestId, shouldAutoFocusInput);
+      await openDesktopEditor(colorEdit, requestId);
     } catch (error) {
       if (isCurrentOpenRequest(requestId)) {
         pendingOpen = false;

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -754,8 +754,8 @@ class BaseColor extends LitElement {
             min="0"
             max="100"
             .value=${value}
-            label="Brightness/Contrast"
-            valuetext=${`Brightness: ${value}%`}
+            label="Lightness control handle"
+            valuetext=${`Lightness: ${value}%`}
             gradient=${gradient}
             @input=${(e) => this._onHSBChannelSliderInput(e, 'b')}
             @change=${() => this._emitColorChangeEnd()}
@@ -767,7 +767,7 @@ class BaseColor extends LitElement {
           size="s"
           maxlength="3"
           .value=${String(value)}
-          label="Brightness/Contrast"
+          label="Lightness amount value"
           label-visibility="none"
           @keydown=${(e) => this._onChannelKeyDown(e)}
           @input=${(e) => this._onHSBChannelTextInput(e, 'b')}
@@ -811,7 +811,7 @@ class BaseColor extends LitElement {
                 min=${ch.min}
                 max=${ch.max}
                 .value=${ch.value}
-                label=${ch.isIcon ? 'Brightness/Contrast' : ch.ariaLabel}
+                label=${ch.isIcon ? 'Lightness control handle' : ch.ariaLabel}
                 valuetext=${`${ch.ariaLabel}: ${ch.value}${ch.unit}`}
                 gradient=${this._getChannelGradient(ch.key)}
                 @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelSliderInput(e, 'b') : this._onRGBChannelSliderInput(e, ch.key)}
@@ -824,7 +824,7 @@ class BaseColor extends LitElement {
               size="s"
               maxlength=${ch.maxlength}
               .value=${String(ch.value)}
-              label=${ch.isIcon ? 'Brightness/Contrast' : ch.ariaLabel}
+              label=${ch.isIcon ? 'Lightness amount value' : ch.ariaLabel}
               label-visibility="none"
               @keydown=${(e) => this._onChannelKeyDown(e)}
               @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelTextInput(e, 'b') : this._onRGBChannelTextInput(e, ch.key)}
@@ -925,6 +925,7 @@ class BaseColor extends LitElement {
       <div class="bc-color-control">
         <div class="bc-color-area-wrapper ${this.colorMode !== 'HEX' || this.showBrightnessControl ? 'has-sliders' : ''}">
           <sp-color-area
+            aria-label="Color handle"
             .x=${this._saturation / 100}
             .y=${this._brightness / 100}
             .hue=${this._hue}
@@ -933,6 +934,7 @@ class BaseColor extends LitElement {
             @change=${this._onColorAreaChange}
           ></sp-color-area>
           <sp-color-slider
+            label="Hue control handle"
             gradient="hue"
             color=${currentColor}
             @pointerdown=${this._onPointerDown}

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -204,11 +204,14 @@ class ColorEdit extends LitElement {
     this._previouslyFocused = document.activeElement;
     this.open = true;
     if (this.mobile) disableBackgroundScroll();
-    this.updateComplete.then(() => {
-      const sheet = this.shadowRoot.querySelector('.ce-sheet');
-      const focusable = sheet?.querySelector('input, button, [tabindex]:not([tabindex="-1"]), sp-button');
-      if (focusable) focusable.focus();
-      if (sheet) this._focusTrap = trapFocus(sheet);
+    return this.updateComplete.then(() => {
+      const container = this.shadowRoot.querySelector('.ce-sheet') || this.shadowRoot.querySelector('.color-edit-panel');
+      if (!container) return;
+      container.focus();
+      this._focusTrap = trapFocus(container);
+      requestAnimationFrame(() => {
+        if (this.open) container.focus();
+      });
     });
   }
 
@@ -361,20 +364,26 @@ class ColorEdit extends LitElement {
         <span class="ce-palette-label">Palette colors</span>
         <sp-theme system="spectrum-two" color="light" scale="medium">
           <sp-swatch-group
+            role="listbox"
+            aria-label="Color palette colors"
             size="s"
             cornerRadius="partial"
+            @keydown=${this._onSwatchGroupKeyDown}
           >
             ${this.palette.map((hex, i) => {
               const validHex = hex.startsWith('#') ? hex : `#${hex}`;
               return html`
                 <sp-swatch
+                  role="option"
                   border="light"
                   cornerRounding="partial"
                   color=${validHex}
                   value=${String(i)}
                   ?selected=${i === this.selectedIndex}
+                  aria-selected=${i === this.selectedIndex ? 'true' : 'false'}
+                  tabindex=${i === this.selectedIndex ? '0' : '-1'}
                   @click=${() => this._onSwatchClick(i)}
-                  aria-label="Color ${validHex}"
+                  aria-label=${validHex}
                 ></sp-swatch>
               `;
             })}
@@ -382,6 +391,40 @@ class ColorEdit extends LitElement {
         </sp-theme>
       </div>
     `;
+  }
+
+  _onSwatchGroupKeyDown(e) {
+    const swatches = [...this.shadowRoot.querySelectorAll('sp-swatch')];
+    if (!swatches.length) return;
+    const idx = swatches.indexOf(e.target);
+    if (idx === -1) return;
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this._onSwatchClick(idx);
+      return;
+    }
+
+    let next = -1;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      next = (idx + 1) % swatches.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      next = (idx - 1 + swatches.length) % swatches.length;
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      next = 0;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      next = swatches.length - 1;
+    }
+
+    if (next !== -1) {
+      swatches[idx].setAttribute('tabindex', '-1');
+      swatches[next].setAttribute('tabindex', '0');
+      swatches[next].focus();
+    }
   }
 
   _onBaseColorChange(e) {
@@ -459,7 +502,7 @@ class ColorEdit extends LitElement {
           size="m"
           maxlength="7"
           .value=${this._hex}
-          label="HEX color value"
+          label="Color Hex Value"
           label-visibility="none"
           @input=${this._onHexInput}
           @paste=${this._onHexPaste}
@@ -474,7 +517,7 @@ class ColorEdit extends LitElement {
 
     return html`
       ${this._renderDragHandle()}
-      <div class="color-edit-panel">
+      <div class="color-edit-panel" tabindex="-1">
         <div class="ce-title-dropdown-colors">
           ${this._renderHeader()}
           ${this._renderPaletteSwatches()}
@@ -502,6 +545,7 @@ class ColorEdit extends LitElement {
               role="dialog"
               aria-modal="true"
               aria-label="Edit color"
+              tabindex="-1"
               @keydown=${this._onSheetKeyDown}
             >
               ${this._renderPanel()}

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -360,31 +360,34 @@ class ColorEdit extends LitElement {
       <div class="ce-palette-section">
         <span class="ce-palette-label">Palette colors</span>
         <sp-theme system="spectrum-two" color="light" scale="medium">
-          <sp-swatch-group
+          <div
             role="listbox"
             aria-label="Color palette colors"
-            size="s"
-            cornerRadius="partial"
             @keydown=${this._onSwatchGroupKeyDown}
           >
-            ${this.palette.map((hex, i) => {
-              const validHex = hex.startsWith('#') ? hex : `#${hex}`;
-              return html`
-                <sp-swatch
-                  role="option"
-                  border="light"
-                  cornerRounding="partial"
-                  color=${validHex}
-                  value=${String(i)}
-                  ?selected=${i === this.selectedIndex}
-                  aria-selected=${i === this.selectedIndex ? 'true' : 'false'}
-                  tabindex=${i === this.selectedIndex ? '0' : '-1'}
-                  @click=${() => this._onSwatchClick(i)}
-                  aria-label=${validHex}
-                ></sp-swatch>
-              `;
-            })}
-          </sp-swatch-group>
+            <sp-swatch-group
+              size="s"
+              cornerRadius="partial"
+            >
+              ${this.palette.map((hex, i) => {
+                const validHex = hex.startsWith('#') ? hex : `#${hex}`;
+                return html`
+                  <sp-swatch
+                    role="option"
+                    border="light"
+                    cornerRounding="partial"
+                    color=${validHex}
+                    value=${String(i)}
+                    ?selected=${i === this.selectedIndex}
+                    aria-selected=${i === this.selectedIndex ? 'true' : 'false'}
+                    tabindex=${i === this.selectedIndex ? '0' : '-1'}
+                    @click=${() => this._onSwatchClick(i)}
+                    aria-label=${validHex}
+                  ></sp-swatch>
+                `;
+              })}
+            </sp-swatch-group>
+          </div>
         </sp-theme>
       </div>
     `;

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -207,11 +207,8 @@ class ColorEdit extends LitElement {
     return this.updateComplete.then(() => {
       const container = this.shadowRoot.querySelector('.ce-sheet') || this.shadowRoot.querySelector('.color-edit-panel');
       if (!container) return;
-      container.focus();
       this._focusTrap = trapFocus(container);
-      requestAnimationFrame(() => {
-        if (this.open) container.focus();
-      });
+      container.focus();
     });
   }
 

--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -164,6 +164,12 @@ export const style = css`
         object-fit: contain;
     }
 
+    .ce-mode-trigger:focus-visible {
+        outline: var(--border-width-2) solid var(--color-blue-800);
+        outline-offset: var(--border-width-2);
+        border-radius: 4px;
+    }
+
     .ce-mode-wrap sp-menu {
         position: absolute;
         top: calc(100% - var(--spacing-50));

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -626,7 +626,11 @@ export function createStripContainerRenderer(options) {
     if (mobile) {
       document.body.appendChild(editorElement);
       activeColorEditor = { adapter, mobile: true };
-      requestAnimationFrame(() => adapter.show?.());
+      requestAnimationFrame(async () => {
+        await customElements.whenDefined('color-edit');
+        await editorElement.updateComplete;
+        adapter.show?.();
+      });
       return;
     }
 
@@ -640,7 +644,12 @@ export function createStripContainerRenderer(options) {
     document.body.appendChild(popover);
     const anchorRect = resolveAnchorRect(anchorElement, anchorRectFromDetail);
     positionPopover(popover, anchorRect);
-    requestAnimationFrame(() => positionPopover(popover, anchorRect));
+    requestAnimationFrame(async () => {
+      positionPopover(popover, anchorRect);
+      await customElements.whenDefined('color-edit');
+      await editorElement.updateComplete;
+      await adapter.show?.();
+    });
     Promise.resolve(editorElement.updateComplete)
       .then(() => positionPopover(popover, anchorRect))
       .catch(() => {});

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -627,9 +627,13 @@ export function createStripContainerRenderer(options) {
       document.body.appendChild(editorElement);
       activeColorEditor = { adapter, mobile: true };
       requestAnimationFrame(async () => {
-        await customElements.whenDefined('color-edit');
-        await editorElement.updateComplete;
-        adapter.show?.();
+        try {
+          await customElements.whenDefined('color-edit');
+          await editorElement.updateComplete;
+          adapter.show?.();
+        } catch (e) {
+          window.lana?.log(`[color-editor] mobile show failed: ${e.message}`, { tags: 'color-edit' });
+        }
       });
       return;
     }
@@ -645,10 +649,14 @@ export function createStripContainerRenderer(options) {
     const anchorRect = resolveAnchorRect(anchorElement, anchorRectFromDetail);
     positionPopover(popover, anchorRect);
     requestAnimationFrame(async () => {
-      positionPopover(popover, anchorRect);
-      await customElements.whenDefined('color-edit');
-      await editorElement.updateComplete;
-      await adapter.show?.();
+      try {
+        positionPopover(popover, anchorRect);
+        await customElements.whenDefined('color-edit');
+        await editorElement.updateComplete;
+        await adapter.show?.();
+      } catch (e) {
+        window.lana?.log(`[color-editor] desktop show failed: ${e.message}`, { tags: 'color-edit' });
+      }
     });
     Promise.resolve(editorElement.updateComplete)
       .then(() => positionPopover(popover, anchorRect))


### PR DESCRIPTION
## Summary

- Change aria-label as per bluelines for color edit
- Change tab navigation in color edit as per blulines
- Bluelines: https://www.figma.com/design/ns6IopCcOUMTy9gE8pvCTV/Bluelines-for-Color-Expansion-CCEX-221263?node-id=16048-152163&t=7NCZd42bzdtztU7N-11

---

## Jira Ticket

Resolves: [MWPW-187630](https://jira.corp.adobe.com/browse/MWPW-187630)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://MWPW-187630-color-edit-bluelines--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
