### PR TITLE
add url param support for hardcoded links

### DIFF
--- a/express/code/scripts/color-shared/components/createActionMenuComponent.js
+++ b/express/code/scripts/color-shared/components/createActionMenuComponent.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import { createTag } from '../../utils.js';
+import { createTag, getLibs } from '../../utils.js';
 import loadMiloStyle from '../utils/loadMiloStyle.js';
 import { createExpressButton, createExpressTooltip } from '../spectrum/index.js';
 import { createActionMenuState } from './createActionMenuState.js';
@@ -266,6 +266,17 @@ async function createControls(
   return controlContainer;
 }
 
+async function applyNavLinkParamOverrides(navLinks) {
+  const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
+  const { env } = getConfig();
+  if (env === 'prod') return navLinks;
+  const params = new URLSearchParams(window.location.search);
+  return navLinks.map((link) => {
+    const override = params.get(`${link.id}-link`);
+    return override ? { ...link, href: override } : link;
+  });
+}
+
 export async function createActionMenuComponent(options = {}) {
   const {
     id = 'action-menu',
@@ -321,7 +332,10 @@ export async function createActionMenuComponent(options = {}) {
   const buttonRefs = {};
   const sections = [];
 
-  if (type !== 'controls-only') sections.push(await createNav(navLinks, activeId, getCurrentPaletteFn));
+  if (type !== 'controls-only') {
+    const processedLinks = await applyNavLinkParamOverrides(navLinks);
+    sections.push(await createNav(processedLinks, activeId, getCurrentPaletteFn));
+  }
   if (type !== 'nav-only') {
     sections.push(await createControls(
       controls,

--- a/express/code/scripts/color-shared/components/createActionMenuComponent.js
+++ b/express/code/scripts/color-shared/components/createActionMenuComponent.js
@@ -269,7 +269,7 @@ async function createControls(
 async function applyNavLinkParamOverrides(navLinks) {
   const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
   const { env } = getConfig();
-  if (env === 'prod') return navLinks;
+  if (env.name === 'prod') return navLinks;
   const params = new URLSearchParams(window.location.search);
   return navLinks.map((link) => {
     const override = params.get(`${link.id}-link`);

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -2,7 +2,7 @@ import { announceToScreenReader } from '../spectrum/index.js';
 import { isMobileViewport, buildPaletteEditUrl } from '../utils/utilities.js';
 import { createIconButton } from '../utils/icons.js';
 import { createEventBus } from '../utils/createEventBus.js';
-import { createTag } from '../../utils.js';
+import { createTag, getLibs } from '../../utils.js';
 import { loadButton, loadActionButton, loadTooltip } from '../spectrum/load-spectrum.js';
 import { createThemeWrapper } from '../spectrum/utils/theme.js';
 import { paletteToThemeData } from '../../../libs/services/providers/transforms.js';
@@ -309,6 +309,15 @@ function loadSpectrumDeps() {
   });
 }
 
+async function applyLinkParamOverride(link) {
+  const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
+  const { env } = getConfig();
+  if (env === 'prod') return link;
+  const params = new URLSearchParams(window.location.search);
+  const override = params.get('palette-link');
+  return override || link;
+}
+
 /* ── Main Export ──────────────────────────────────────────────── */
 
 // eslint-disable-next-line import/prefer-default-export
@@ -380,13 +389,28 @@ export function createToolbar(options) {
 
   const DEFAULT_EDIT_BASE_PATH = '/express/colors/color-palette-generator';
 
-  const paletteSummary = buildPaletteSummary(colors, type, palette.angle, effectiveShowEdit, () => {
-    const currentPalette = getPaletteWithName();
-    const editUrl = editPaletteLink
-      || buildPaletteEditUrl(DEFAULT_EDIT_BASE_PATH, currentPalette.colors, currentPalette.name);
-    window.location.href = editUrl;
-    emit('edit', { palette: currentPalette });
-  }, t);
+  const paletteSummary = buildPaletteSummary(
+    colors,
+    type,
+    palette.angle,
+    effectiveShowEdit,
+    async () => {
+      const currentPalette = getPaletteWithName();
+      if (editPaletteLink) {
+        window.location.href = editPaletteLink;
+      } else {
+        const processedLink = await applyLinkParamOverride(DEFAULT_EDIT_BASE_PATH);
+        const editUrl = buildPaletteEditUrl(
+          processedLink,
+          currentPalette.colors,
+          currentPalette.name,
+        );
+        window.location.href = editUrl;
+      }
+      emit('edit', { palette: currentPalette });
+    },
+    t,
+  );
 
   const { actions, ccLibBtn } = buildActionButtons({
     onShare: async () => {

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -312,7 +312,7 @@ function loadSpectrumDeps() {
 async function applyLinkParamOverride(link) {
   const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
   const { env } = getConfig();
-  if (env === 'prod') return link;
+  if (env.name === 'prod') return link;
   const params = new URLSearchParams(window.location.search);
   const override = params.get('palette-link');
   return override || link;


### PR DESCRIPTION
## Summary

- Allows devs to override the action menu and toolbar edit links with url params for testing purposes
- URL param keys: `palette-link`, `contrast-link`, and `color-blindness-link`
- Disallowed when `env = prod`

---

## Jira Ticket

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--express-color--adobecom.aem.page/drafts/methomas/color-wheel |
| **After**   | https://color-link-params--express-color--adobecom.aem.page/drafts/methomas/color-wheel?palette-link=/drafts/methomas/color-wheel&contrast-link=/drafts/dhananjay/contrast-checker&color-blindness-link=/drafts/methomas/color-blindness |

- https://color-link-params--express-color--adobecom.aem.page/drafts/dhananjay/contrast-checker?palette-link=/drafts/methomas/color-wheel&contrast-link=/drafts/dhananjay/contrast-checker&color-blindness-link=/drafts/methomas/color-blindness
- https://color-link-params--express-color--adobecom.aem.page/drafts/methomas/color-blindness?palette-link=/drafts/methomas/color-wheel&contrast-link=/drafts/dhananjay/contrast-checker&color-blindness-link=/drafts/methomas/color-blindness
- https://color-link-params--da-express-milo--adobecom.aem.page/drafts/yeiber/color/phase-one/palettes?palette-link=/drafts/methomas/color/color-wheel-2

---

## Verification Steps

- On color wheel, contrast checker, or color blindness pages:
- Click on a link in the action menu nav and the palette should follow you
- On palette page:
- Click "Summer", click "Edit palette", in the modal, click "Edit". The palette from the modal should populate in the color wheel page
- Go to a page with ?env=prod, such as https://color-link-params--express-color--adobecom.aem.page/drafts/methomas/color-wheel?env=prod&palette-link=/drafts/methomas/color-wheel&contrast-link=/drafts/dhananjay/contrast-checker&color-blindness-link=/drafts/methomas/color-blindness
- You should see the hardcoded urls, not the param urls


---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
