### PR TITLE
[MWPW-190468] Color Page Analytics MVP Only

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -1,4 +1,5 @@
 import { createTag } from '../../scripts/utils.js';
+import { trackColorBlockLoad } from '../../scripts/instrument.js';
 import createColorToolLayout from '../../scripts/color-shared/shell/layouts/createColorToolLayout.js';
 import { createColorConflictsAdapter } from '../../scripts/color-shared/adapters/litComponentAdapters.js';
 import ColorThemeExpressController from '../../scripts/color-shared/controllers/ColorThemeExpressController.js';
@@ -254,6 +255,7 @@ export default async function decorate(block) {
 
     block.classList.add('ax-shell-host');
     block.dataset.blockStatus = 'loaded';
+    trackColorBlockLoad('color-blindness');
   } catch (error) {
     block.dataset.blockStatus = 'error';
     window.lana?.log(`color-blindness block failed: ${error.message}`, {

--- a/express/code/blocks/color-contrast-checker/color-contrast-checker.js
+++ b/express/code/blocks/color-contrast-checker/color-contrast-checker.js
@@ -1,4 +1,5 @@
 import { createTag } from '../../scripts/utils.js';
+import { trackColorBlockLoad } from '../../scripts/instrument.js';
 import createColorToolLayout from '../../scripts/color-shared/shell/layouts/createColorToolLayout.js';
 import { createContrastRenderer } from './factory/createContrastRenderer.js';
 import loadContrastCheckerPlaceholders from './utils/placeholders.js';
@@ -202,6 +203,7 @@ export default async function decorate(block) {
     block.classList.add('ax-shell-host', `color-contrast-checker-${config.variant}`);
     block.dataset.shellState = 'ready';
     block.dataset.blockStatus = 'loaded';
+    trackColorBlockLoad('color-contrast-checker');
   } catch (error) {
     window.lana?.log(`Contrast Checker init error: ${error.message}`, {
       tags: 'color-contrast-checker,init',

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -1,3 +1,4 @@
+import { trackColorBlockLoad } from '../../scripts/instrument.js';
 import { parseBlockConfig } from './helpers/parseConfig.js';
 import { createColorRenderer } from './factory/createColorRenderer.js';
 import BlockMediator from '../../scripts/block-mediator.min.js';
@@ -744,6 +745,7 @@ export default async function decorate(block) {
     }
 
     block.dataset.blockStatus = 'loaded';
+    trackColorBlockLoad('color-explore');
   } catch (error) {
     window.lana?.log(`[ColorExplore] ❌ Error: ${error}`, { tags: 'color-explore', severity: 'error' });
     block.classList.add(CSS_CLASSES.ERROR);

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -1,4 +1,5 @@
 import { createTag, getIconElementDeprecated, getLibs } from '../../scripts/utils.js';
+import { trackColorBlockLoad } from '../../scripts/instrument.js';
 import {
   CSS_CLASSES, DEFAULTS, EVENTS, MOODS, VARIANTS,
 } from './helpers/constants.js';
@@ -1314,4 +1315,5 @@ export default async function decorate(block) {
   } else {
     await renderGradientVariant(block, contentRows, config);
   }
+  trackColorBlockLoad('color-extract');
 }

--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -1,4 +1,5 @@
 import { createTag, getLibs } from '../../scripts/utils.js';
+import { trackColorBlockLoad } from '../../scripts/instrument.js';
 import createColorToolLayout from '../../scripts/color-shared/shell/layouts/createColorToolLayout.js';
 import { createExpressTabs } from '../../scripts/color-shared/spectrum/components/express-tabs.js';
 import createColorWheelExpressAdapter from '../../scripts/color-shared/adapters/createColorWheelExpressAdapter.js';
@@ -950,6 +951,7 @@ export default async function decorate(block) {
 
       block.classList.add('ax-shell-host');
       block.dataset.shellState = 'ready';
+      trackColorBlockLoad('color-wheel');
     } catch (error) {
       window.lana?.log(`Color Wheel init error: ${error.message}`, {
         tags: 'color-wheel,init',

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -328,6 +328,42 @@ function trackColorPageLoad() {
   safelyFireAnalyticsEvent(fireEvent);
 }
 
+export function trackColorBlockLoad(blockType) {
+  const eventName = 'view-color-block';
+  const fireEvent = () => {
+    _satellite.track('event', {
+      xdm: {},
+      data: {
+        eventType: 'web.webinteraction.linkClicks',
+        web: {
+          webInteraction: {
+            name: eventName,
+            linkClicks: { value: 1 },
+            type: 'other',
+          },
+        },
+        _adobe_corpnew: {
+          sdm: {
+            event: {
+              pagename: eventName,
+              url: loc.href,
+            },
+            custom: {
+              ui: {
+                location: pathname,
+              },
+              block: {
+                type: blockType,
+              },
+            },
+          },
+        },
+      },
+    });
+  };
+  safelyFireAnalyticsEvent(fireEvent);
+}
+
 export function textToName(text) {
   const splits = text.toLowerCase().split(' ');
   const camelCase = splits.map((s, i) => (i ? s.charAt(0).toUpperCase() + s.substr(1) : s)).join('');

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -278,90 +278,98 @@ function trackTemplatePageLoad() {
 }
 
 function trackColorPageLoad() {
-  if (getMetadata('pagetype') !== 'color') return;
-
-  const eventName = 'view-color-page';
-  let refDomain = '';
-  let previousPagename = '';
   try {
-    const referrerUrl = new URL(document.referrer);
-    refDomain = referrerUrl.hostname;
-    previousPagename = referrerUrl.pathname;
-  } catch { /* no referrer or invalid */ }
+    if (getMetadata('pagetype') !== 'color') return;
 
-  const fireEvent = () => {
-    _satellite.track('event', {
-      xdm: {},
-      data: {
-        eventType: 'web.webinteraction.linkClicks',
-        web: {
-          webInteraction: {
-            name: eventName,
-            linkClicks: { value: 1 },
-            type: 'other',
-          },
-        },
-        _adobe_corpnew: {
-          sdm: {
-            event: {
-              pagename: eventName,
-              url: loc.href,
-            },
-            custom: {
-              aa: {
-                page_name: getPageName(),
-                ref_domain: refDomain,
-                previous_pagename: previousPagename,
-              },
-              link: {
-                page_url: loc.href,
-              },
-              ui: {
-                location: pathname,
-              },
+    const eventName = 'view-color-page';
+    let refDomain = '';
+    let previousPagename = '';
+    try {
+      const referrerUrl = new URL(document.referrer);
+      refDomain = referrerUrl.hostname;
+      previousPagename = referrerUrl.pathname;
+    } catch { /* no referrer or invalid */ }
+
+    const fireEvent = () => {
+      _satellite.track('event', {
+        xdm: {},
+        data: {
+          eventType: 'web.webinteraction.linkClicks',
+          web: {
+            webInteraction: {
+              name: eventName,
+              linkClicks: { value: 1 },
+              type: 'other',
             },
           },
+          _adobe_corpnew: {
+            sdm: {
+              event: {
+                pagename: eventName,
+                url: loc.href,
+              },
+              custom: {
+                aa: {
+                  page_name: getPageName(),
+                  ref_domain: refDomain,
+                  previous_pagename: previousPagename,
+                },
+                link: {
+                  page_url: loc.href,
+                },
+                ui: {
+                  location: pathname,
+                },
+              },
+            },
+          },
         },
-      },
-    });
-  };
-  safelyFireAnalyticsEvent(fireEvent);
+      });
+    };
+    safelyFireAnalyticsEvent(fireEvent);
+  } catch (error) {
+    window.lana?.log(`Failed to track color page load: ${error}`, { tags: 'color, analytics', errorType: 'e', severity: 'warning', sampleRate: '1' });
+  }
 }
 
 export function trackColorBlockLoad(blockType) {
-  const eventName = 'view-color-block';
-  const fireEvent = () => {
-    _satellite.track('event', {
-      xdm: {},
-      data: {
-        eventType: 'web.webinteraction.linkClicks',
-        web: {
-          webInteraction: {
-            name: eventName,
-            linkClicks: { value: 1 },
-            type: 'other',
-          },
-        },
-        _adobe_corpnew: {
-          sdm: {
-            event: {
-              pagename: eventName,
-              url: loc.href,
-            },
-            custom: {
-              ui: {
-                location: pathname,
-              },
-              block: {
-                type: blockType,
-              },
+  try {
+    const eventName = 'view-color-block';
+    const fireEvent = () => {
+      _satellite.track('event', {
+        xdm: {},
+        data: {
+          eventType: 'web.webinteraction.linkClicks',
+          web: {
+            webInteraction: {
+              name: eventName,
+              linkClicks: { value: 1 },
+              type: 'other',
             },
           },
+          _adobe_corpnew: {
+            sdm: {
+              event: {
+                pagename: eventName,
+                url: loc.href,
+              },
+              custom: {
+                ui: {
+                  location: pathname,
+                },
+                block: {
+                  type: blockType,
+                },
+              },
+            },
+          },
         },
-      },
-    });
-  };
-  safelyFireAnalyticsEvent(fireEvent);
+      });
+    };
+    safelyFireAnalyticsEvent(fireEvent);
+  } catch (error) {
+    window.lana?.log(`Failed to track color block load: ${error}`, { tags: 'color, analytics', errorType: 'e', severity: 'warning', sampleRate: '1' });
+  }
 }
 
 export function textToName(text) {

--- a/express/code/scripts/instrument.js
+++ b/express/code/scripts/instrument.js
@@ -277,6 +277,57 @@ function trackTemplatePageLoad() {
   }
 }
 
+function trackColorPageLoad() {
+  if (getMetadata('pagetype') !== 'color') return;
+
+  const eventName = 'view-color-page';
+  let refDomain = '';
+  let previousPagename = '';
+  try {
+    const referrerUrl = new URL(document.referrer);
+    refDomain = referrerUrl.hostname;
+    previousPagename = referrerUrl.pathname;
+  } catch { /* no referrer or invalid */ }
+
+  const fireEvent = () => {
+    _satellite.track('event', {
+      xdm: {},
+      data: {
+        eventType: 'web.webinteraction.linkClicks',
+        web: {
+          webInteraction: {
+            name: eventName,
+            linkClicks: { value: 1 },
+            type: 'other',
+          },
+        },
+        _adobe_corpnew: {
+          sdm: {
+            event: {
+              pagename: eventName,
+              url: loc.href,
+            },
+            custom: {
+              aa: {
+                page_name: getPageName(),
+                ref_domain: refDomain,
+                previous_pagename: previousPagename,
+              },
+              link: {
+                page_url: loc.href,
+              },
+              ui: {
+                location: pathname,
+              },
+            },
+          },
+        },
+      },
+    });
+  };
+  safelyFireAnalyticsEvent(fireEvent);
+}
+
 export function textToName(text) {
   const splits = text.toLowerCase().split(' ');
   const camelCase = splits.map((s, i) => (i ? s.charAt(0).toUpperCase() + s.substr(1) : s)).join('');
@@ -474,6 +525,7 @@ export default async function martechLoadedCB() {
   setDataAnalyticsAttributesForMartech();
   decorateAnalyticsEvents();
   trackTemplatePageLoad();
+  trackColorPageLoad();
 
   // TODO Start of section to be removed after Jingle finishes adding xlg to old express Repo
   // this piece of code is necessary for the ratings block atm so that the right user


### PR DESCRIPTION
## Summary

- Added `trackColorPageLoad` in `instrument.js` that fires a `view-color-page` SDM event on pages with `pagetype=color` metadata, sending `page_name`, `ref_domain`, `previous_pagename`, `page_url`, and `ui.location`
- Added `trackColorBlockLoad` exported helper in `instrument.js` that fires a `view-color-block` SDM event with `ui.location` and `block.type`
- Integrated `trackColorBlockLoad` into all five color blocks (`color-wheel`, `color-blindness`, `color-explore`, `color-extract`, `color-contrast-checker`), firing after successful block decoration

---

## Jira Ticket

Resolves: [MWPW-190468](https://jira.corp.adobe.com/browse/MWPW-190468), [MWPW-189943](https://jira.corp.adobe.com/browse/MWPW-189943), [MWPW-189940](https://jira.corp.adobe.com/browse/MWPW-189940), [MWPW-189941](https://jira.corp.adobe.com/browse/MWPW-189941), [MWPW-189942](https://jira.corp.adobe.com/browse/MWPW-189942), [MWPW-189943](https://jira.corp.adobe.com/browse/MWPW-189943), [MWPW-189944](https://jira.corp.adobe.com/browse/MWPW-189944), [MWPW-189945](https://jira.corp.adobe.com/browse/MWPW-189945)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://color-analytics--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |

---

## Verification Steps
- Open the URL
- Observe network calls
- view-color-page <img width="717" height="376" alt="image" src="https://github.com/user-attachments/assets/feb143ed-c85c-4e47-8404-acc2dbd11ce1" />
- view-color-block <img width="715" height="409" alt="Screenshot 2026-04-07 at 12 48 11 PM" src="https://github.com/user-attachments/assets/2c3f1c5f-f313-4c66-b14a-dc4fb5e4807f" />


---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
