### PR TITLE
[MWPW-189830] Update showPalette logic for color strips

### DIFF
--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -607,7 +607,7 @@ export function createStripContainerRenderer(options) {
       palette,
       selectedIndex,
       colorMode: 'HEX',
-      showPalette: mobile || !colorBlindness,
+      showPalette: mobile,
       mobile,
     }, {
       onColorChange: ({ hex, index }) => {


### PR DESCRIPTION
## Summary
When color-editor is opened in popup mode, it should not show the color palette as color strips already show the palette. Only in case of mobile drawer when the color strips are hidden, the palette should be shown.

---

## Jira Ticket

Resolves: [MWPW-189830](https://jira.corp.adobe.com/browse/MWPW-189830)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://color-edit-palette--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
