### PR TITLE
[MWPW-185800] Integrate like service in palette modal

### DIFF
--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -343,9 +343,9 @@ export default async function decorate(block) {
           content: () => createGradientPickerRebuildContent(content, {
             likesCount: content.likes ?? content.likesCount ?? 0,
             liked: content.liked ?? false,
-            creatorName: content.creator?.name ?? 'nicolagilroy',
+            creatorName: content.creator?.name ?? '',
             creatorImageUrl: content.creator?.imageUrl ?? content.creatorImageUrl,
-            tags: ['Orange', 'Cinematic', 'Summer', 'Water'],
+            tags: item.tags ?? [],
             onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
           }),
         });
@@ -552,13 +552,19 @@ export default async function decorate(block) {
           activeRenderer.on(EVENTS.PALETTE_CLICK, async (palette) => {
             await modalManager.openPaletteSwatchesModal(
               palette || {},
-              { verticalMaxPerRow: config.swatchVerticalMaxPerRow },
+              {
+                verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+                onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
+              },
             );
           });
           activeRenderer.on(EVENTS.SHARE, async ({ palette }) => {
             await modalManager.openPaletteSwatchesModal(
               palette || {},
-              { verticalMaxPerRow: config.swatchVerticalMaxPerRow },
+              {
+                verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+                onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
+              },
             );
           });
 
@@ -672,13 +678,19 @@ export default async function decorate(block) {
       renderer.on(EVENTS.PALETTE_CLICK, async (palette) => {
         await modalManager.openPaletteSwatchesModal(
           palette || {},
-          { verticalMaxPerRow: config.swatchVerticalMaxPerRow },
+          {
+            verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+            onLikeToggle: async ({ id, liked }) => dataService.toggleLike({ id, liked }),
+          },
         );
       });
       renderer.on(EVENTS.SHARE, async ({ palette }) => {
         await modalManager.openPaletteSwatchesModal(
           palette || {},
-          { verticalMaxPerRow: config.swatchVerticalMaxPerRow },
+          {
+            verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+            onLikeToggle: async ({ id, liked }) => dataService.toggleLike({ id, liked }),
+          },
         );
       });
 

--- a/express/code/libs/services/config.js
+++ b/express/code/libs/services/config.js
@@ -21,6 +21,7 @@ const PROD_CONFIG = {
       baseUrl: 'https://search.adobe.io/api/v2',
       exploreBaseUrl: 'https://themesb3.adobe.io',
       apiKey: 'AdobeExpressWeb',
+      middleware: [{ name: 'auth', topics: ['kuler.like.*'] }],
       endpoints: {
         search: '/search',
         api: '/api/v2',

--- a/express/code/libs/services/plugins/kuler/actions/KulerActions.js
+++ b/express/code/libs/services/plugins/kuler/actions/KulerActions.js
@@ -501,8 +501,7 @@ export class LikeActions extends BaseActionGroup {
    */
   buildThemeLikeUrl(themeId) {
     const { serviceConfig, endpoints } = this.plugin;
-    const { likeBaseUrl } = serviceConfig;
-    const { themePath } = endpoints;
+    const { themePath, likeBaseUrl } = endpoints;
     BaseActionGroup.requireConfig({ likeBaseUrl, themePath }, 'Kuler');
     return `${likeBaseUrl}${themePath}/${themeId}/likeDuplicate`;
   }

--- a/express/code/libs/services/plugins/kuler/actions/KulerActions.js
+++ b/express/code/libs/services/plugins/kuler/actions/KulerActions.js
@@ -500,7 +500,7 @@ export class LikeActions extends BaseActionGroup {
    * @returns {string}
    */
   buildThemeLikeUrl(themeId) {
-    const { serviceConfig, endpoints } = this.plugin;
+    const { endpoints } = this.plugin;
     const { themePath, likeBaseUrl } = endpoints;
     BaseActionGroup.requireConfig({ likeBaseUrl, themePath }, 'Kuler');
     return `${likeBaseUrl}${themePath}/${themeId}/likeDuplicate`;
@@ -511,9 +511,8 @@ export class LikeActions extends BaseActionGroup {
    * @returns {string}
    */
   buildThemeUnlikeUrl(themeId) {
-    const { serviceConfig, endpoints } = this.plugin;
-    const { likeBaseUrl } = serviceConfig;
-    const { themePath } = endpoints;
+    const { endpoints } = this.plugin;
+    const { themePath, likeBaseUrl } = endpoints;
     BaseActionGroup.requireConfig({ likeBaseUrl, themePath }, 'Kuler');
     return `${likeBaseUrl}${themePath}/${themeId}/like`;
   }

--- a/express/code/scripts/color-shared/modal/createGradientPickerRebuildContent.js
+++ b/express/code/scripts/color-shared/modal/createGradientPickerRebuildContent.js
@@ -154,10 +154,11 @@ export function createGradientPickerRebuildContent(gradient, opts = {}) {
     likeTooltip = tooltipController;
   }).catch(() => {});
   likeBtn.addEventListener('click', () => {
+    const previousLiked = liked;
     liked = !liked;
     updateLikeState();
     likeTooltip?.setContent(liked ? 'Remove from favorites' : 'Add to favorites');
-    opts.onLikeToggle?.({ id: gradient?.id, liked })?.catch?.((err) => {
+    opts.onLikeToggle?.({ id: gradient?.id, liked: previousLiked })?.catch?.((err) => {
       window.lana?.log(`[GradientPicker] Like toggle error: ${err?.message}`, {
         tags: 'color-modal,like',
         severity: 'warning',

--- a/express/code/scripts/color-shared/modal/createPaletteModalContent.js
+++ b/express/code/scripts/color-shared/modal/createPaletteModalContent.js
@@ -215,21 +215,29 @@ function createPaletteMetaSection(palette = {}, options = {}) {
   const likeBtn = createTag('button', { type: 'button', class: 'like-icon', 'aria-label': 'Add to favorites' });
   const likeTheme = createTag('sp-theme', { system: 'spectrum-two', color: 'light', scale: 'medium' });
   let liked = options.liked ?? palette?.liked ?? false;
-  likeTheme.appendChild(createTag(liked ? 'sp-icon-heart-filled' : 'sp-icon-heart', { size: 'm', 'aria-hidden': 'true' }));
-  likeBtn.setAttribute('aria-label', liked ? 'Remove from favorites' : 'Add to favorites');
-  likeBtn.classList.toggle('is-liked', liked);
+  const updateLikeState = () => {
+    likeTheme.replaceChildren();
+    likeTheme.appendChild(createTag(liked ? 'sp-icon-heart-filled' : 'sp-icon-heart', { size: 'm', 'aria-hidden': 'true' }));
+    likeBtn.setAttribute('aria-label', liked ? 'Remove from favorites' : 'Add to favorites');
+    likeBtn.classList.toggle('is-liked', liked);
+  };
+  updateLikeState();
   likeBtn.appendChild(likeTheme);
   let likeTooltip = null;
   createExpressTooltip({ targetEl: likeBtn, content: liked ? 'Remove from favorites' : 'Add to favorites', placement: 'bottom' })
     .then((t) => { likeTooltip = t; })
     .catch(() => {});
   likeBtn.addEventListener('click', () => {
+    const previousLiked = liked;
     liked = !liked;
-    likeTheme.replaceChildren();
-    likeTheme.appendChild(createTag(liked ? 'sp-icon-heart-filled' : 'sp-icon-heart', { size: 'm', 'aria-hidden': 'true' }));
-    likeBtn.setAttribute('aria-label', liked ? 'Remove from favorites' : 'Add to favorites');
-    likeBtn.classList.toggle('is-liked', liked);
+    updateLikeState();
     likeTooltip?.setContent(liked ? 'Remove from favorites' : 'Add to favorites');
+    options.onLikeToggle?.({ id: palette?.id, liked: previousLiked })?.catch?.((error) => {
+      window.lana?.log(`[PaletteModal] Like toggle error: ${error?.message}`, {
+        tags: 'color-modal,like',
+        severity: 'warning',
+      });
+    });
   });
   const likesText = createTag('p', { class: 'modal-likes-count' });
   likesText.textContent = String(likesCount);


### PR DESCRIPTION
## Summary

Integrates toggle like functionality and like status in color palette modal on color-explore page.

---

## Jira Ticket

Resolves: [MWPW-185800](https://jira.corp.adobe.com/browse/MWPW-185800)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/yeiber/color/phase-one/palettes?martech=off&q=Vaporwave |
| **After**   | https://color-palette-like--da-express-milo--adobecom.aem.page/drafts/yeiber/color/phase-one/palettes?martech=off&q=Vaporwave?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
