### PR TITLE
[No Jira] Reintroduce changes reverted in merge conflict resolution

### DIFF
--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -569,6 +569,7 @@ export function createStripContainerRenderer(options) {
       adapter,
       popover,
       mobile,
+      resizeObserver,
       outsideHandler,
       escapeHandler,
       scrollHandler,
@@ -577,6 +578,7 @@ export function createStripContainerRenderer(options) {
     if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
     if (scrollHandler) window.removeEventListener('scroll', scrollHandler, true);
+    resizeObserver?.disconnect?.();
     if (mobile) {
       try {
         adapter.hide?.();
@@ -687,11 +689,23 @@ export function createStripContainerRenderer(options) {
       adapter,
       popover,
       mobile: false,
+      resizeObserver: observer,
       outsideHandler,
       escapeHandler,
       scrollHandler,
       railElement,
     };
+
+    requestAnimationFrame(async () => {
+      try {
+        await customElements.whenDefined('color-edit');
+        await editorElement.updateComplete;
+        if (activeColorEditor?.adapter !== adapter) return;
+        await adapter.show?.();
+      } catch (e) {
+        window.lana?.log(`[color-editor] desktop show failed: ${e.message}`, { tags: 'color-edit' });
+      }
+    });
   }
 
   function attachRailEditor(railElement) {

--- a/test/scripts/color-shared/renderers/createStripContainerRenderer.test.js
+++ b/test/scripts/color-shared/renderers/createStripContainerRenderer.test.js
@@ -1,0 +1,113 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+import { createStripContainerRenderer } from '../../../../express/code/scripts/color-shared/renderers/createStripContainerRenderer.js';
+
+function waitForFrame() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(resolve);
+  });
+}
+
+async function waitForCondition(predicate, attempts = 30) {
+  for (let index = 0; index < attempts; index += 1) {
+    if (predicate()) return true;
+    await waitForFrame();
+  }
+
+  return false;
+}
+
+describe('createStripContainerRenderer', () => {
+  let renderer;
+  let originalResizeObserver;
+
+  beforeEach(() => {
+    originalResizeObserver = window.ResizeObserver;
+    sinon.stub(window, 'matchMedia').callsFake((query) => ({
+      matches: false,
+      media: query,
+      addEventListener() {},
+      removeEventListener() {},
+    }));
+  });
+
+  afterEach(() => {
+    renderer?.destroy();
+    renderer = null;
+    sinon.restore();
+    document.body.innerHTML = '';
+    if (originalResizeObserver) {
+      window.ResizeObserver = originalResizeObserver;
+    } else {
+      delete window.ResizeObserver;
+    }
+  });
+
+  it('opens the desktop color editor after render and cleans up its ResizeObserver', async () => {
+    const disconnectSpy = sinon.spy();
+    window.ResizeObserver = class {
+      constructor(callback) {
+        this.callback = callback;
+        this.connected = false;
+      }
+
+      observe() {
+        this.connected = true;
+        this.callback([{ contentRect: { height: 240 } }]);
+      }
+
+      disconnect() {
+        this.connected = false;
+        disconnectSpy();
+      }
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    renderer = createStripContainerRenderer({
+      container,
+      data: [{
+        id: 'palette-1',
+        name: 'Palette 1',
+        colors: ['#112233', '#445566', '#778899'],
+      }],
+      config: {
+        stripContainerOrientations: ['horizontal'],
+      },
+    });
+
+    renderer.render(container);
+
+    const rail = container.querySelector('color-swatch-rail');
+    expect(rail).to.exist;
+
+    rail.dispatchEvent(new CustomEvent('color-swatch-rail-edit', {
+      detail: {
+        index: 1,
+        anchorRect: {
+          left: 16,
+          right: 56,
+          top: 24,
+          bottom: 48,
+        },
+      },
+      bubbles: true,
+      composed: true,
+    }));
+
+    const opened = await waitForCondition(() => {
+      const editor = document.body.querySelector('.swatches-color-edit-popover color-edit');
+      return editor?.open === true;
+    }, 40);
+
+    expect(opened).to.be.true;
+    expect(document.body.querySelector('.swatches-color-edit-popover')).to.exist;
+
+    renderer.destroy();
+
+    expect(disconnectSpy.called).to.be.true;
+    expect(document.body.querySelector('.swatches-color-edit-popover')).to.be.null;
+  });
+});


### PR DESCRIPTION
## Summary
Merge of https://github.com/adobecom/da-express-milo/pull/293/ reverted the changes introduced for fixing tab navigation in color edit in PR: github.com/adobecom/da-express-milo/pull/301

---

## Jira Ticket

Resolves: No Jira

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://color--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://color-edit-conflict-fix--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
