### PR TITLE
Comparison table v2 anchors

### DIFF
--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -474,6 +474,17 @@ function createAriaLiveRegion(comparisonBlock) {
   return ariaLiveRegion;
 }
 
+function applyTabAnchorToButtons(comparisonBlock) {
+  const closestTab = comparisonBlock.closest('[role="tabpanel"]');
+  if (!closestTab) return;
+  try {
+    const tabId = parseInt(closestTab.id.split('-').pop(), 10);
+    comparisonBlock.setAttribute('id', `pricing-table-${tabId}`);
+  } catch (e) {
+    window.lana?.log(`Comparison Table V2 Tab Anchor Error: ${e?.message || e?.detail || e}`, { tags: 'comparison-table-v2', severity: 'error' });
+  }
+}
+
 /**
  * Process button styling for fill buttons
  * @param {Array} contentSections - The content sections array
@@ -766,6 +777,7 @@ export default async function decorate(comparisonBlock) {
     const ariaLiveRegion = createAriaLiveRegion(comparisonBlock);
 
     processButtonStyling(contentSections);
+    applyTabAnchorToButtons(comparisonBlock);
 
     const { stickyHeaderEl, colTitles } = createStickyHeader(contentSections[0], comparisonBlock);
     comparisonBlock.appendChild(stickyHeaderEl);

--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.js
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.js
@@ -477,12 +477,9 @@ function createAriaLiveRegion(comparisonBlock) {
 function applyTabAnchorToButtons(comparisonBlock) {
   const closestTab = comparisonBlock.closest('[role="tabpanel"]');
   if (!closestTab) return;
-  try {
-    const tabId = parseInt(closestTab.id.split('-').pop(), 10);
-    comparisonBlock.setAttribute('id', `pricing-table-${tabId}`);
-  } catch (e) {
-    window.lana?.log(`Comparison Table V2 Tab Anchor Error: ${e?.message || e?.detail || e}`, { tags: 'comparison-table-v2', severity: 'error' });
-  }
+  const tabId = parseInt(closestTab.id.split('-').pop(), 10);
+  if (Number.isNaN(tabId)) return;
+  comparisonBlock.setAttribute('id', `pricing-table-${tabId}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

When a **comparison-table-v2** block is rendered inside a **tab panel** (`[role="tabpanel"]`), decoration now assigns the block element a stable `id` derived from the tab panel’s numeric suffix (`pricing-table-{n}`). That lets pricing (and similar) pages use **in-page anchors** so links scroll to the comparison table that matches the active tab context, instead of every instance sharing ambiguous markup. Invalid or non-numeric tab suffixes are ignored without throwing; the earlier try/catch + Lana path was replaced with an explicit `Number.isNaN` guard.

---

## Jira Ticket

Resolves: [DOTCOM-183085](https://jira.corp.adobe.com/browse/DOTCOM-183085)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/pricing |
| **After** | https://comparison-table-v2-anchors--da-express-milo--adobecom.aem.page/express/pricing?martech=off |

---

## Verification Steps

1. Open the pricing page (preview URL above or local).
2. In DevTools, find a **comparison-table-v2** block that lives inside a tabs/tab-panel layout.
3. **Before:** the block typically has no predictable `id`, so deep links cannot target the table for a given tab.
4. **After:** the block should have `id="pricing-table-{n}"` where `{n}` matches the tab panel’s numeric id suffix (e.g. last segment of the tabpanel `id` after `-`).
5. Confirm that navigating to `#pricing-table-{n}` (when that tab’s content is the one shown or after switching tabs as your UX allows) scrolls to or targets the intended table instance. **Note that the second and third panels have incorrect comparison links authored, so test the first and fourth cards only**
6. Smoke-check a comparison table **not** inside a tab panel: no `id` should be applied and the block should behave as before.

---

## Potential Regressions

- https://comparison-table-v2-anchors--da-express-milo--adobecom.aem.live/express/pricing?martech=off  
- Other pages using **comparison-table-v2** inside tab panels: confirm no duplicate `id` values on the same document and no id collisions with other fragments.

---

## Additional Notes

- **Scope:** Only `express/code/blocks/comparison-table-v2/comparison-table-v2.js` is changed on this branch; logic is gated on `closest('[role="tabpanel"]')` and a valid parsed integer suffix.
- If product expects **query** `?tab=` on CTA links rather than **hash** `#pricing-table-n`, that would be a separate content or follow-up code change—the current implementation sets DOM `id` for anchor targets, not `href` query params.