### PR TITLE
MWPW-192017 Fix color-headline flash

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -95,7 +95,6 @@ export default async function decorate(block) {
       },
     });
 
-    adoptHeadline(block, layoutInstance);
     await layoutInstance.actionMenuReady;
 
     const { sidebar, canvas, topbar } = layoutInstance.slots;
@@ -251,6 +250,7 @@ export default async function decorate(block) {
     };
     document.addEventListener(HISTORY_EVENT, historyHandler);
 
+    adoptHeadline(block, layoutInstance);
     block.classList.add('ax-shell-host');
     block.dataset.blockStatus = 'loaded';
     trackColorBlockLoad('color-blindness');

--- a/express/code/blocks/color-contrast-checker/color-contrast-checker.js
+++ b/express/code/blocks/color-contrast-checker/color-contrast-checker.js
@@ -174,7 +174,6 @@ export default async function decorate(block) {
       },
     });
 
-    adoptHeadline(block, layoutInstance);
     await layoutInstance.actionMenuReady;
 
     layoutInstance.actionMenu?.pushState?.(initialPalette.colors);
@@ -202,6 +201,7 @@ export default async function decorate(block) {
       destroy: destroyInstance,
     });
 
+    adoptHeadline(block, layoutInstance);
     block.dataset.shellState = 'ready';
     block.dataset.blockStatus = 'loaded';
     trackColorBlockLoad('color-contrast-checker');

--- a/express/code/blocks/color-headline/color-headline.css
+++ b/express/code/blocks/color-headline/color-headline.css
@@ -73,7 +73,7 @@ body:has(.color-extract.has-image) .color-headline.extract {
 .color-headline.tools:not([data-adopted="true"]) {
   max-width: var(--block-wd-max-width);
   padding: var(--action-menu-buffer) var(--spacing-300) 0;
-  box-sizing: border-box;
+  margin-inline: auto;
 }
 
 .color-headline.tools .express-logo {

--- a/express/code/blocks/color-headline/color-headline.css
+++ b/express/code/blocks/color-headline/color-headline.css
@@ -62,21 +62,18 @@ body:has(.color-extract.has-image) .color-headline.extract {
   line-height: 1.3;
 }
 
-@media (max-width: 1199px) {
-  .color-headline.extract h1 {
-    font-size: 32px;
-  }
-
-  .color-headline.extract p {
-    font-size: 16px;
-    line-height: 1.4;
-  }
-}
-
 .color-headline.tools {
+  --action-menu-buffer: 81px;
+
   display: flex;
   flex-direction: column;
   gap: var(--spacing-200);
+}
+
+.color-headline.tools:not([data-adopted="true"]) {
+  max-width: var(--block-wd-max-width);
+  padding: var(--action-menu-buffer) var(--spacing-300) 0;
+  box-sizing: border-box;
 }
 
 .color-headline.tools .express-logo {
@@ -107,4 +104,45 @@ body:has(.color-extract.has-image) .color-headline.extract {
   line-height: 1.3;
   color: var(--color-dark-gray);
   margin: 0;
+}
+
+@media (min-width: 600px) {
+  .color-headline.tools {
+    --action-menu-buffer: 97px;
+  }
+
+  .color-headline.tools:not([data-adopted="true"]) {
+    padding-inline: var(--spacing-500);
+  }
+}
+
+@media (min-width: 888px) {
+  .color-headline.tools:not([data-adopted="true"]) > div {
+    width: calc(50% - 8px);
+  }
+}
+
+@media (min-width: 1200px) {
+  .color-headline.tools {
+    --action-menu-buffer: var(--spacing-600);
+  }
+
+  .color-headline.tools:not([data-adopted="true"]) {
+    padding-inline: var(--spacing-600);
+  }
+
+  .color-headline.tools:not([data-adopted="true"]) > div {
+    width: calc(33.33% - 12px);
+  }
+}
+
+@media (max-width: 1199px) {
+  .color-headline.extract h1 {
+    font-size: 32px;
+  }
+
+  .color-headline.extract p {
+    font-size: 16px;
+    line-height: 1.4;
+  }
 }

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -401,10 +401,6 @@ color-wheel-express {
 /* Large Tablet */
 
 @media (min-width: 888px) {
-  .color-wheel .ax-shell-slot--topbar {
-    padding-block-end: var(--spacing-100);
-  }
-
   .color-wheel .ax-shell-slot--sidebar {
     padding-block-end: 0;
   }

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -556,3 +556,9 @@ color-wheel-express {
     display: flex;
   }
 }
+
+@media (min-width: 1440px) {
+  .color-wheel .ax-color-tool-layout {
+    box-sizing: content-box;
+  }
+}

--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -651,7 +651,6 @@ export default async function decorate(block) {
     block.className = 'color-wheel';
     const section = createTag('section');
     block.appendChild(section);
-    if (headline) section.appendChild(headline);
 
     try {
       const [strings, { getResolvedPalette, getResolvedPaletteName }] = await Promise.all([
@@ -753,7 +752,6 @@ export default async function decorate(block) {
         },
       });
 
-      adoptHeadline(section, layoutInstance);
       await layoutInstance.actionMenuReady;
 
       const actionMenuApi = layoutInstance.actionMenu;
@@ -950,6 +948,8 @@ export default async function decorate(block) {
         }
       });
 
+      if (headline) section.appendChild(headline);
+      adoptHeadline(section, layoutInstance);
       block.classList.add('ax-shell-host');
       block.dataset.shellState = 'ready';
       trackColorBlockLoad('color-wheel');


### PR DESCRIPTION
## Summary

Fixes the flash of content from the color headline block for the tools variant

---

## Jira Ticket

Resolves: [MWPW-192017](https://jira.corp.adobe.com/browse/MWPW-192017)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/drafts/methomas/color-wheel |
| **After**   | https://methomas-headline-flash--express-color--adobecom.aem.page/drafts/methomas/color-wheel |
| **Before**  | https://stage--express-color--adobecom.aem.page/drafts/dhananjay/contrast-checker |
| **After**   | https://methomas-headline-flash--express-color--adobecom.aem.page/drafts/dhananjay/contrast-checker |
| **Before**  | https://stage--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |
| **After**   | https://methomas-headline-flash--da-express-milo--adobecom.aem.page/drafts/vineesha/default-colors |

---

## Verification Steps

- On desktop, there should no longer be a flash of headline content outside the container before the color block loads. Content should not appear to move.

---

## Potential Regressions

N/A

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
