### PR TITLE
[Color] [NO-JIRA] Add URL-based sharing to color palette toolbar

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -27,6 +27,8 @@ const TOOLBAR_I18N_MAP = {
   paletteName: 'color-toolbar-palette-name',
   paletteNamePlaceholder: 'color-toolbar-palette-placeholder',
   ctaText: 'color-toolbar-cta',
+  urlCopiedToClipboard: 'color-toolbar-url-copied-to-clipboard',
+  shareFailed: 'color-toolbar-share-failed',
 };
 
 const DRAWER_I18N_MAP = {

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -27,6 +27,7 @@ const TOOLBAR_I18N_MAP = {
   paletteName: 'color-toolbar-palette-name',
   paletteNamePlaceholder: 'color-toolbar-palette-placeholder',
   ctaText: 'color-toolbar-cta',
+  shareText: 'color-toolbar-share-text',
   urlCopiedToClipboard: 'color-toolbar-url-copied-to-clipboard',
   shareFailed: 'color-toolbar-share-failed',
 };

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -27,7 +27,6 @@ const TOOLBAR_I18N_MAP = {
   paletteName: 'color-toolbar-palette-name',
   paletteNamePlaceholder: 'color-toolbar-palette-placeholder',
   ctaText: 'color-toolbar-cta',
-  shareText: 'color-toolbar-share-text',
   urlCopiedToClipboard: 'color-toolbar-url-copied-to-clipboard',
   shareFailed: 'color-toolbar-share-failed',
 };

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -34,6 +34,7 @@ const TOOLBAR_DEFAULTS = {
   paletteName: 'Palette name',
   paletteNamePlaceholder: 'My Color Theme',
   ctaText: 'Create with my color palette',
+  shareText: 'Check out this color palette on Adobe.com',
   urlCopiedToClipboard: 'URL copied to clipboard',
   shareFailed: 'Unable to share. Please try again.',
 };
@@ -49,7 +50,7 @@ async function handleShare({ name, colors }, t) {
   const shareUrl = url.toString();
 
   try {
-    await navigator.share({ title: name, url: shareUrl });
+    await navigator.share({ title: name, text: t.shareText, url: shareUrl });
     announceToScreenReader(t.sharedSuccessfully);
     showExpressToast({ message: t.sharedSuccessfully, variant: 'positive' });
     return;

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -1,6 +1,7 @@
 import { announceToScreenReader } from '../spectrum/index.js';
 import { isMobileViewport, buildPaletteEditUrl, createColorPaletteParamApi } from '../utils/utilities.js';
 import { showExpressToast } from '../spectrum/components/express-toast.js';
+import { createExpressTooltip } from '../spectrum/components/express-tooltip.js';
 import { createIconButton } from '../utils/icons.js';
 import { createEventBus } from '../utils/createEventBus.js';
 import { createTag, getLibs } from '../../utils.js';
@@ -158,11 +159,11 @@ async function handleSave(
 /* ── Tooltip Helper ──────────────────────────────────────────── */
 
 function attachTooltip(actionBtn, text) {
-  const tooltip = document.createElement('sp-tooltip');
-  tooltip.setAttribute('self-managed', '');
-  tooltip.setAttribute('placement', 'top');
-  tooltip.textContent = text;
-  actionBtn.appendChild(tooltip);
+  createExpressTooltip({
+    targetEl: actionBtn,
+    content: text,
+    placement: 'top',
+  }).catch(() => {});
 }
 
 /* ── DOM Builders ────────────────────────────────────────────── */

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -49,7 +49,7 @@ async function handleShare({ name, colors }, t) {
   const shareUrl = url.toString();
 
   try {
-    await navigator.share({ title: name, text: t.shareText, url: shareUrl });
+    await navigator.share({ title: name, url: shareUrl });
     announceToScreenReader(t.sharedSuccessfully);
     showExpressToast({ message: t.sharedSuccessfully, variant: 'positive' });
     return;

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -15,7 +15,6 @@ function interpolate(tpl, vars) {
 }
 
 const TOOLBAR_DEFAULTS = {
-  shareText: 'Check out this {{type}}: {{name}}\nColors: {{colors}}',
   sharedSuccessfully: 'Shared successfully',
   copiedToClipboard: 'Copied to clipboard',
   downloadStarted: 'Download started',

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -1,5 +1,6 @@
 import { announceToScreenReader } from '../spectrum/index.js';
-import { isMobileViewport, buildPaletteEditUrl } from '../utils/utilities.js';
+import { isMobileViewport, buildPaletteEditUrl, createColorPaletteParamApi } from '../utils/utilities.js';
+import { showExpressToast } from '../spectrum/components/express-toast.js';
 import { createIconButton } from '../utils/icons.js';
 import { createEventBus } from '../utils/createEventBus.js';
 import { createTag, getLibs } from '../../utils.js';
@@ -33,27 +34,40 @@ const TOOLBAR_DEFAULTS = {
   paletteName: 'Palette name',
   paletteNamePlaceholder: 'My Color Theme',
   ctaText: 'Create with my color palette',
+  urlCopiedToClipboard: 'URL copied to clipboard',
+  shareFailed: 'Unable to share. Please try again.',
 };
 
 let toolbarInstanceCounter = 0;
 
 /* ── Default Handlers ────────────────────────────────────────── */
 
-async function handleShare({ name, colors, type }, t) {
-  const text = interpolate(t.shareText, { type, name, colors: colors.join(', ') });
+async function handleShare({ name, colors }, t) {
+  const url = new URL(window.location.href);
+  const { setOnUrl } = createColorPaletteParamApi();
+  setOnUrl(url, colors, { name });
+  const shareUrl = url.toString();
+
   try {
-    await navigator.share({ title: name, text });
+    await navigator.share({ title: name, url: shareUrl });
     announceToScreenReader(t.sharedSuccessfully);
-  } catch {
-    try {
-      await navigator.clipboard.writeText(text);
-      announceToScreenReader(t.copiedToClipboard);
-    } catch (err) {
-      window.lana?.log(`Share/clipboard failed: ${err.message}`, {
-        tags: 'color-floating-toolbar,share',
-        severity: 'error',
-      });
-    }
+    showExpressToast({ message: t.sharedSuccessfully, variant: 'positive' });
+    return;
+  } catch (err) {
+    if (err?.name === 'AbortError') return;
+  }
+
+  try {
+    await navigator.clipboard.writeText(shareUrl);
+    announceToScreenReader(t.urlCopiedToClipboard);
+    showExpressToast({ message: t.urlCopiedToClipboard, variant: 'positive' });
+  } catch (err) {
+    window.lana?.log(`Share/clipboard failed: ${err.message}`, {
+      tags: 'color-floating-toolbar,share',
+      severity: 'error',
+    });
+    announceToScreenReader(t.shareFailed);
+    showExpressToast({ message: t.shareFailed, variant: 'negative' });
   }
 }
 

--- a/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
@@ -267,6 +267,67 @@ describe('createToolbar', () => {
       expect(cb.firstCall.args[0]).to.have.property('palette');
     });
 
+    it('share passes a URL with color-palette params to navigator.share', async () => {
+      const shareStub = sinon.stub(navigator, 'share').resolves();
+      const toolbar = createToolbar(defaultOptions());
+      document.body.appendChild(toolbar.element);
+
+      const shareBtn = toolbar.element.querySelector('sp-action-button[label="Share this color palette"]');
+      shareBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(shareStub.calledOnce).to.be.true;
+      const shareArg = shareStub.firstCall.args[0];
+      expect(shareArg).to.have.property('url');
+      expect(shareArg.url).to.include('color-palette=');
+      expect(shareArg).to.have.property('title', MOCK_PALETTE.name);
+    });
+
+    it('share falls back to clipboard when navigator.share is unavailable', async () => {
+      sinon.stub(navigator, 'share').rejects(new TypeError('share not supported'));
+      const clipboardStub = sinon.stub(navigator.clipboard, 'writeText').resolves();
+      const toolbar = createToolbar(defaultOptions());
+      document.body.appendChild(toolbar.element);
+
+      const shareBtn = toolbar.element.querySelector('sp-action-button[label="Share this color palette"]');
+      shareBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(clipboardStub.calledOnce).to.be.true;
+      expect(clipboardStub.firstCall.args[0]).to.include('color-palette=');
+    });
+
+    it('share does nothing when user cancels native share dialog (AbortError)', async () => {
+      const abortErr = new DOMException('Share canceled', 'AbortError');
+      sinon.stub(navigator, 'share').rejects(abortErr);
+      const clipboardStub = sinon.stub(navigator.clipboard, 'writeText').resolves();
+      const toolbar = createToolbar(defaultOptions());
+      document.body.appendChild(toolbar.element);
+
+      const shareBtn = toolbar.element.querySelector('sp-action-button[label="Share this color palette"]');
+      shareBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(clipboardStub.called).to.be.false;
+    });
+
+    it('share logs error when both share and clipboard fail', async () => {
+      sinon.stub(navigator, 'share').rejects(new TypeError('share not supported'));
+      sinon.stub(navigator.clipboard, 'writeText').rejects(new Error('clipboard denied'));
+      const lanaStub = sinon.stub();
+      window.lana = { log: lanaStub };
+      const toolbar = createToolbar(defaultOptions());
+      document.body.appendChild(toolbar.element);
+
+      const shareBtn = toolbar.element.querySelector('sp-action-button[label="Share this color palette"]');
+      shareBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(lanaStub.calledOnce).to.be.true;
+      expect(lanaStub.firstCall.args[0]).to.include('Share/clipboard failed');
+      delete window.lana;
+    });
+
     it('on("download", cb) fires when Download button clicked', async () => {
       const toolbar = createToolbar(defaultOptions());
       document.body.appendChild(toolbar.element);


### PR DESCRIPTION
## Summary

  Replaces the text-based sharing in the color toolbar with URL-based sharing. The share button now generates a URL containing color-palette query parameters and shares it
  via the Web Share API, falling back to clipboard copy. Toast notifications and screen reader announcements provide user feedback for success/failure states.

  ---

  ## Jira Ticket

  Resolves: NO-JIRA

  ---

  ## Test URLs

  | Env | URL |
  |-------------|-----|
  | **Before**  | https://main--express-color--adobecom.aem.page/drafts/dhananjay/color-contrast-analyzer |
  | **After**   | https://share-colors--express-color--adobecom.aem.page/drafts/dhananjay/color-contrast-analyzer?martech=off |

  ---

  ## Verification Steps

  - Open the **After** URL and interact with the color palette toolbar.
  - Click the **Share** button — on supported devices, the native share dialog should appear with a URL containing `color-palette=` params.
  - On desktop (or if share is dismissed), verify the URL is copied to the clipboard and a toast notification appears.
  - Cancel the native share dialog and confirm no clipboard write or error occurs (AbortError is silently handled).
  - Simulate both share and clipboard failure — verify an error toast appears and `lana.log` is called.

  ---

  ## Potential Regressions

  - https://share-colors--express-color--adobecom.aem.page/drafts/dhananjay/color-contrast-analyzer?martech=off

  ---

  ## Additional Notes

  - Added two new i18n keys: `color-toolbar-url-copied-to-clipboard` and `color-toolbar-share-failed`.
  - Four new unit tests cover: share with URL params, clipboard fallback, AbortError handling, and double-failure error logging.