### PR TITLE
MWPW-192079 Fix image upload on color wheel

### DIFF
--- a/express/code/blocks/color-wheel/createImageExtractComponent.js
+++ b/express/code/blocks/color-wheel/createImageExtractComponent.js
@@ -347,7 +347,7 @@ export default function createImageExtractComponent(options = {}) {
     if (oldImg && imgLoadHandler) oldImg.removeEventListener('load', imgLoadHandler);
     if (markers) markers.destroy();
 
-    const createImageMarkers = await import('../color-extract/helpers/imageMarkers.js');
+    const { default: createImageMarkers } = await import('../color-extract/helpers/imageMarkers.js');
     markers = createImageMarkers(bgWrapper, canvas, controller, {
       onMoodOverride,
     });


### PR DESCRIPTION
## Summary

Fixes issue with image upload on color wheel page where no markers are showing on image

---

## Jira Ticket

Resolves: [MWPW-192079](https://jira.corp.adobe.com/browse/MWPW-192079)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-upload-error--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- In Image tab, upload an image.
- Should see markers on image and colors in palette

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
