### PR TITLE
MWPW-192214 added aria label to CTA

### DIFF
--- a/express/code/blocks/banner-bg/banner-bg.js
+++ b/express/code/blocks/banner-bg/banner-bg.js
@@ -125,6 +125,11 @@ function styleButtons(block, variantClass) {
     }
 
     button.className = buttonClasses.join(' ');
+
+    if (!button.getAttribute('aria-label')) {
+      const label = button.title || button.textContent?.trim();
+      if (label) button.setAttribute('aria-label', label);
+    }
   });
 }
 

--- a/test/blocks/banner-bg/banner-bg.test.js
+++ b/test/blocks/banner-bg/banner-bg.test.js
@@ -11,6 +11,7 @@ const basic = await readFile({ path: './mocks/basic.html' });
 const lightBg = await readFile({ path: './mocks/light-bg.html' });
 const multiButton = await readFile({ path: './mocks/multi-button.html' });
 const withLogo = await readFile({ path: './mocks/with-logo.html' });
+const coolDarkBg = await readFile({ path: './mocks/cool-dark-bg.html' });
 
 describe('Banner Background', () => {
   before(() => {
@@ -135,6 +136,15 @@ describe('Banner Background', () => {
     expect(button.classList.contains('accent')).to.be.true;
     expect(button.classList.contains('dark')).to.be.true;
     expect(button.classList.contains('bg-banner-button')).to.be.false;
+  });
+
+  it('cool-dark-bg CTA button has aria-label', async () => {
+    document.body.innerHTML = coolDarkBg;
+    const banner = document.querySelector('.banner-bg');
+    await decorate(banner);
+
+    const button = banner.querySelector('a.button');
+    expect(button.getAttribute('aria-label')).to.equal('Get Started for Free');
   });
 
   it('Multi-button styling includes reverse class', async () => {

--- a/test/blocks/banner-bg/mocks/cool-dark-bg.html
+++ b/test/blocks/banner-bg/mocks/cool-dark-bg.html
@@ -1,0 +1,16 @@
+<div>
+  <div class="banner-bg cool-dark-bg">
+    <div>
+      <div>
+        <h2 id="bring-your-colors-to-life-in-adobe-express">Bring your colors to life in Adobe Express.</h2>
+        <p><a href="https://adobesparkpost.app.link/GJrBPFUWBBb">Get Started for Free</a></p>
+      </div>
+    </div>
+  </div>
+  <div class="section-metadata">
+    <div>
+      <div>inject-logo</div>
+      <div>yes</div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Adds aria-label to CTA in cool banner variant

---

## Jira Ticket

Resolves: [MWPW-192214](https://jira.corp.adobe.com/browse/MWPW-192214)
and MWPW-192211 (duplicate issue) 

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/explore |
| **After**   | https://explore-banner-aria--express-color--adobecom.aem.page/explore?martech=off |

---

## Verification Steps

- Visit after
- Inspect CTA in cool banner
- See aria-label 

---
