### PR TITLE
Bug fixes from Color Design QA Log.xlsx

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -54,6 +54,7 @@
 }
 
 .color-extract {
+  --ax-color-tool-presentation-max-width: 1440px;
   --color-extract-max-width: 1440px;
   --color-extract-gap: 32px;
   --color-extract-radius: 16px;
@@ -570,8 +571,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   padding: 16px;
   border: 1px solid rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(28px);
-  /* Fixed 634px from Figma spec — image scales to fit, never drives sizing */
-  height: 634px;
+  height: 490px;
 }
 
 .color-extract .color-extract-edit-bg picture,
@@ -604,7 +604,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   width: 100%;
   height: 100%;
   display: block;
-  border-radius: 8px;
+  border-radius: 0;
   object-fit: contain;
   left: 0;
   transform: none;
@@ -674,7 +674,8 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 
 .color-extract .color-extract-mood-dropdown {
   position: relative;
-  width: 330px;
+  width: fit-content;
+  max-width: 330px;
 }
 
 .color-extract .color-extract-mood-trigger {
@@ -957,8 +958,8 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 }
 
 .color-extract .color-extract-gradient-editor-col .gradient-editor-handles {
-  left: 12px;
-  right: 12px;
+  left: 8px;
+  right: 8px;
 }
 
 
@@ -1054,6 +1055,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   .section:has(.color-extract-marquee-wrapper) {
     align-items: flex-start;
     min-height: unset;
+    padding-inline: 16px;
   }
 
   .color-extract .color-extract-landing {
@@ -1082,6 +1084,11 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 
   .color-extract .color-extract-toolbar-divider {
     display: none;
+  }
+
+  .color-extract .color-extract-mood-dropdown {
+    width: 100%;
+    max-width: none;
   }
 
 }

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -769,6 +769,8 @@ function renderColorVariant(block, rows, config) {
 
   const floatingToolbar = createFloatingToolbarMount(controller, VARIANTS.PALETTE);
 
+  const popstateAc = new AbortController();
+
   function goToLanding() {
     block.classList.remove('has-image', 'is-loading');
     if (markerResizeObserver) markerResizeObserver.disconnect();
@@ -781,6 +783,7 @@ function renderColorVariant(block, rows, config) {
     history.clear();
     currentCanvas = null;
     currentSrc = null;
+    popstateAc.abort();
     block.querySelectorAll('.color-extract-suggestion.is-selected').forEach((el) => {
       el.classList.remove('is-selected');
       el.setAttribute('aria-pressed', 'false');
@@ -930,7 +933,7 @@ function renderColorVariant(block, rows, config) {
     if (block.classList.contains('has-image') && e.state?.colorExtract !== 'results') {
       goToLanding();
     }
-  });
+  }, { signal: popstateAc.signal });
 }
 
 /* ---------- Gradient edit stage ---------- */
@@ -1187,6 +1190,7 @@ async function renderGradientVariant(block, rows, config) {
   }
 
   const floatingToolbar = createFloatingToolbarMount(swatchController, VARIANTS.GRADIENT);
+  const popstateAc = new AbortController();
 
   function goToLanding() {
     block.classList.remove('has-image', 'is-loading');
@@ -1200,6 +1204,7 @@ async function renderGradientVariant(block, rows, config) {
     history.clear();
     currentCanvas = null;
     currentSrc = null;
+    popstateAc.abort();
     gradientEditor.setGradient(initialGradient);
     block.querySelectorAll('.color-extract-suggestion.is-selected').forEach((el) => {
       el.classList.remove('is-selected');
@@ -1362,7 +1367,7 @@ async function renderGradientVariant(block, rows, config) {
     if (block.classList.contains('has-image') && e.state?.colorExtract !== 'results') {
       goToLanding();
     }
-  });
+  }, { signal: popstateAc.signal });
 }
 
 export default async function decorate(block) {

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -71,7 +71,7 @@ function createExtractController(maxColors = 5, callbacks = {}) {
       return newIndex;
     },
     removeSwatch(index) {
-      if (index < 0 || index >= state.swatches.length || state.swatches.length <= 1) return;
+      if (index < 0 || index >= state.swatches.length || state.swatches.length <= 2) return;
       state.swatches = state.swatches.filter((_, i) => i !== index);
       if (state.baseColorIndex >= state.swatches.length) {
         state.baseColorIndex = state.swatches.length - 1;
@@ -441,11 +441,22 @@ function createFloatingToolbarMount(controller, variant) {
   const container = createTag('div', { class: 'color-extract-floating-toolbar-mount' });
   let toolbarHandle = null;
   let mounted = false;
+  let mqlHandler = null;
+
+  const desktopMql = window.matchMedia('(min-width: 1200px)');
+  const getToolbarVariant = () => (desktopMql.matches ? 'sticky-on-scroll' : 'sticky');
 
   function sync() {
     if (!toolbarHandle) return;
     const state = controller.getState();
     toolbarHandle.toolbar?.updateSwatches(state.swatches.map((s) => s.hex));
+  }
+
+  function destroy() {
+    if (mqlHandler) desktopMql.removeEventListener('change', mqlHandler);
+    toolbarHandle?.destroy?.();
+    toolbarHandle = null;
+    mounted = false;
   }
 
   async function mount() {
@@ -467,13 +478,18 @@ function createFloatingToolbarMount(controller, variant) {
 
       toolbarHandle = await initFloatingToolbar(container, {
         type: variant === VARIANTS.GRADIENT ? 'gradient' : 'palette',
-        variant: 'sticky-on-scroll',
+        variant: getToolbarVariant(),
         standaloneAppearance: 'raised',
         palette,
         showEdit: true,
         showPaletteName: true,
-        editPaletteName: false,
+        editPaletteName: true,
       });
+
+      mqlHandler = () => {
+        toolbarHandle?.setVariant?.(getToolbarVariant());
+      };
+      desktopMql.addEventListener('change', mqlHandler);
 
       controller.subscribe(() => sync());
     } catch (err) {
@@ -482,7 +498,7 @@ function createFloatingToolbarMount(controller, variant) {
     }
   }
 
-  return { element: container, mount };
+  return { element: container, mount, destroy };
 }
 
 /* ---------- Landing ---------- */
@@ -531,6 +547,11 @@ function buildLoadingOverlay() {
 function attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay) {
   const ac = new AbortController();
   const { signal } = ac;
+  let dragCounter = 0;
+  const clearDrag = () => {
+    dragCounter = 0;
+    block.classList.remove('is-dragging');
+  };
   const isBlockInViewport = () => {
     const rect = block.getBoundingClientRect();
     return rect.bottom > 0 && rect.top < window.innerHeight;
@@ -538,28 +559,38 @@ function attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay) 
   window.addEventListener('dragenter', (e) => {
     if (isBlockInViewport() && isFileDrag(e)) {
       preventDefaults(e);
+      dragCounter += 1;
       block.classList.add('is-dragging');
     }
   }, { signal });
   window.addEventListener('dragover', (e) => {
     if (isBlockInViewport() && isFileDrag(e)) {
       preventDefaults(e);
-      block.classList.add('is-dragging');
     }
   }, { signal });
   window.addEventListener('dragleave', (e) => {
     preventDefaults(e);
-    if (!e.relatedTarget && !document.elementFromPoint(e.clientX, e.clientY)) block.classList.remove('is-dragging');
+    if (isFileDrag(e)) {
+      dragCounter -= 1;
+      if (dragCounter <= 0) clearDrag();
+    }
   }, { signal });
   window.addEventListener('dragend', (e) => {
     preventDefaults(e);
-    block.classList.remove('is-dragging');
+    clearDrag();
   }, { signal });
   window.addEventListener('drop', (e) => {
-    if (!isBlockInViewport() || !isFileDrag(e)) return;
+    if (!isBlockInViewport() || !isFileDrag(e)) {
+      clearDrag();
+      return;
+    }
     preventDefaults(e);
     dropzone.handleFile(e.dataTransfer.files[0]);
-    setTimeout(() => block.classList.remove('is-dragging'), 200);
+    setTimeout(clearDrag, 200);
+  }, { signal });
+  window.addEventListener('blur', clearDrag, { signal });
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) clearDrag();
   }, { signal });
   // Sync is-dragging and is-loading from block to body-level overlays
   const syncObserver = new MutationObserver(() => {
@@ -738,7 +769,26 @@ function renderColorVariant(block, rows, config) {
 
   const floatingToolbar = createFloatingToolbarMount(controller, VARIANTS.PALETTE);
 
+  function goToLanding() {
+    block.classList.remove('has-image', 'is-loading');
+    if (markerResizeObserver) markerResizeObserver.disconnect();
+    if (resizeHandler) window.removeEventListener('resize', resizeHandler);
+    if (markers) {
+      markers.destroy();
+      markers = null;
+    }
+    floatingToolbar.destroy();
+    history.clear();
+    currentCanvas = null;
+    currentSrc = null;
+    block.querySelectorAll('.color-extract-suggestion.is-selected').forEach((el) => {
+      el.classList.remove('is-selected');
+      el.setAttribute('aria-pressed', 'false');
+    });
+  }
+
   async function onImageReady(image, src) {
+    window.history.pushState({ colorExtract: 'results' }, '');
     currentSrc = src;
     edit.setBackground(src);
     history.clear();
@@ -765,8 +815,8 @@ function renderColorVariant(block, rows, config) {
 
     historySnapshot();
 
-    const pctX = 0.5;
-    const pctY = 0.5;
+    const pctX = 0.1 + Math.random() * 0.8;
+    const pctY = 0.1 + Math.random() * 0.8;
     const cx = Math.round(pctX * currentCanvas.width);
     const cy = Math.round(pctY * currentCanvas.height);
     const ctx = currentCanvas.getContext('2d');
@@ -814,7 +864,9 @@ function renderColorVariant(block, rows, config) {
     ]) => {
       const railAdapter = createSwatchRailAdapter(controller, {
         orientation: 'stacked',
-        swatchFeatures: ['copy', 'colorPicker', 'hexCode', 'trash'],
+        swatchFeatures: {
+          copy: true, hexCode: true, trash: true, minSwatches: 2, editColorDisabled: true,
+        },
       });
       railAdapter.element.classList.add('color-extract-swatch-rail');
       edit.railSlot.replaceWith(railAdapter.element);
@@ -873,6 +925,12 @@ function renderColorVariant(block, rows, config) {
   if (resolvedConfig.enableImageUpload) {
     attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay);
   }
+
+  window.addEventListener('popstate', (e) => {
+    if (block.classList.contains('has-image') && e.state?.colorExtract !== 'results') {
+      goToLanding();
+    }
+  });
 }
 
 /* ---------- Gradient edit stage ---------- */
@@ -976,7 +1034,7 @@ async function renderGradientVariant(block, rows, config) {
 
   gradientEditor = createGradientEditor(initialGradient, {
     layout: 'static',
-    size: 'l',
+    size: 'responsive',
     draggable: true,
     copyable: false,
     ariaLabel: 'Extracted gradient editor',
@@ -1130,7 +1188,27 @@ async function renderGradientVariant(block, rows, config) {
 
   const floatingToolbar = createFloatingToolbarMount(swatchController, VARIANTS.GRADIENT);
 
+  function goToLanding() {
+    block.classList.remove('has-image', 'is-loading');
+    if (markerResizeObserver) markerResizeObserver.disconnect();
+    if (resizeHandler) window.removeEventListener('resize', resizeHandler);
+    if (markers) {
+      markers.destroy();
+      markers = null;
+    }
+    floatingToolbar.destroy();
+    history.clear();
+    currentCanvas = null;
+    currentSrc = null;
+    gradientEditor.setGradient(initialGradient);
+    block.querySelectorAll('.color-extract-suggestion.is-selected').forEach((el) => {
+      el.classList.remove('is-selected');
+      el.setAttribute('aria-pressed', 'false');
+    });
+  }
+
   async function onImageReady(image, src) {
+    window.history.pushState({ colorExtract: 'results' }, '');
     currentSrc = src;
     edit.setBackground(src);
     history.clear();
@@ -1156,8 +1234,8 @@ async function renderGradientVariant(block, rows, config) {
 
     historySnapshot();
 
-    const pctX = 0.5;
-    const pctY = 0.5;
+    const pctX = 0.1 + Math.random() * 0.8;
+    const pctY = 0.1 + Math.random() * 0.8;
     const cx = Math.round(pctX * currentCanvas.width);
     const cy = Math.round(pctY * currentCanvas.height);
     const ctx = currentCanvas.getContext('2d');
@@ -1165,12 +1243,13 @@ async function renderGradientVariant(block, rows, config) {
     const { rgbToHex } = await import('../../libs/color-components/utils/ColorConversions.js');
     const hex = rgbToHex({ red: r, green: g, blue: b });
 
-    // Add a new color stop to the gradient editor
+    // Add a new color stop and redistribute all stops evenly
     const grad = gradientEditor.getGradient();
-    const newPosition = grad.colorStops.length > 0
-      ? (grad.colorStops[grad.colorStops.length - 1].position + 1) / 2
-      : 0.5;
-    grad.colorStops.push({ color: hex, position: newPosition });
+    grad.colorStops.push({ color: hex, position: 1 });
+    const total = grad.colorStops.length;
+    grad.colorStops.forEach((stop, i) => {
+      stop.position = total > 1 ? i / (total - 1) : 0.5;
+    });
     gradientEditor.setGradient(grad);
 
     // Add new swatch to the swatch controller (updates the swatch rail)
@@ -1215,7 +1294,9 @@ async function renderGradientVariant(block, rows, config) {
     ]) => {
       const railAdapter = createSwatchRailAdapter(swatchController, {
         orientation: 'stacked',
-        swatchFeatures: ['copy', 'hexCode', 'trash'],
+        swatchFeatures: {
+          copy: true, hexCode: true, trash: true, minSwatches: 2, editColorDisabled: true,
+        },
       });
       railAdapter.element.classList.add('color-extract-swatch-rail', 'color-extract-swatch-rail--gradient');
       edit.railSlot.replaceWith(railAdapter.element);
@@ -1276,6 +1357,12 @@ async function renderGradientVariant(block, rows, config) {
   if (resolvedConfig.enableImageUpload) {
     attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay);
   }
+
+  window.addEventListener('popstate', (e) => {
+    if (block.classList.contains('has-image') && e.state?.colorExtract !== 'results') {
+      goToLanding();
+    }
+  });
 }
 
 export default async function decorate(block) {

--- a/express/code/scripts/color-shared/components/gradients/gradient-editor.css
+++ b/express/code/scripts/color-shared/components/gradients/gradient-editor.css
@@ -189,8 +189,6 @@
 .gradient-editor-handles {
   position: absolute;
   inset: 0;
-  left: var(--border-width-2);
-  right: var(--border-width-2);
   pointer-events: none;
 }
 

--- a/express/code/scripts/color-shared/components/gradients/gradient-editor.js
+++ b/express/code/scripts/color-shared/components/gradients/gradient-editor.js
@@ -180,6 +180,7 @@ export function createGradientEditor(initialGradient, options = {}) {
   let barEl = null;
   let handlesWrap = null;
   let barRect = null;
+  let cachedStopSize = null;
   const eventListeners = {};
   const midHalf = 5;
   let selectedStopId = null;
@@ -464,8 +465,10 @@ export function createGradientEditor(initialGradient, options = {}) {
 
   function getHandleOverflow() {
     if (!barRect) barRect = barEl.getBoundingClientRect();
-    const stopSize = parseFloat(getComputedStyle(barEl).getPropertyValue('--gradient-stop-size')) || 22;
-    return barRect.width > 0 ? (stopSize / 2) / barRect.width : 0;
+    if (cachedStopSize === null) {
+      cachedStopSize = parseFloat(getComputedStyle(barEl).getPropertyValue('--gradient-stop-size')) || 22;
+    }
+    return barRect.width > 0 ? (cachedStopSize / 2) / barRect.width : 0;
   }
 
   function positionFromEvent(e) {

--- a/express/code/scripts/color-shared/components/gradients/gradient-editor.js
+++ b/express/code/scripts/color-shared/components/gradients/gradient-editor.js
@@ -462,13 +462,20 @@ export function createGradientEditor(initialGradient, options = {}) {
     updateMockHandlesOrder();
   }
 
+  function getHandleOverflow() {
+    if (!barRect) barRect = barEl.getBoundingClientRect();
+    const stopSize = parseFloat(getComputedStyle(barEl).getPropertyValue('--gradient-stop-size')) || 22;
+    return barRect.width > 0 ? (stopSize / 2) / barRect.width : 0;
+  }
+
   function positionFromEvent(e) {
     const clientX = e.touches?.[0]?.clientX ?? e.clientX;
     if (!barRect) barRect = barEl.getBoundingClientRect();
     const { width } = barRect;
     if (!width) return 0.5;
     const x = (clientX - barRect.left) / width;
-    return Math.max(0, Math.min(1, x));
+    const overflow = getHandleOverflow();
+    return Math.max(-overflow, Math.min(1 + overflow, x));
   }
 
   function startDragStop(e, stop) {
@@ -487,7 +494,8 @@ export function createGradientEditor(initialGradient, options = {}) {
       ev.preventDefault();
       barRect = barEl.getBoundingClientRect();
       const pos = positionFromEvent(ev);
-      stop.position = Math.max(0, Math.min(1, pos));
+      const overflow = getHandleOverflow();
+      stop.position = Math.max(-overflow, Math.min(1 + overflow, pos));
       data.colorStops.sort((a, b) => a.position - b.position);
       midpoints.length = 0;
       for (let i = 0; i < data.colorStops.length - 1; i += 1) {

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -349,6 +349,24 @@ export async function initFloatingToolbar(container, options = {}) {
     reserveSpace,
   });
 
+  /* Hide toolbar when the page footer scrolls into view (mirrors floating-cta pattern) */
+  let footerIo = null;
+  const footer = document.querySelector('footer');
+  if (footer && typeof IntersectionObserver !== 'undefined') {
+    footerIo = new IntersectionObserver((entries) => {
+      const isVisible = entries[0].isIntersecting || entries[0].intersectionRatio > 0;
+      wrapper.classList.toggle('ax-toolbar-footer-hidden', isVisible);
+      if (isVisible) {
+        wrapper.setAttribute('aria-hidden', 'true');
+        wrapper.setAttribute('inert', '');
+      } else {
+        wrapper.removeAttribute('aria-hidden');
+        wrapper.removeAttribute('inert');
+      }
+    }, { rootMargin: '32px', threshold: 0 });
+    footerIo.observe(footer);
+  }
+
   return {
     toolbar,
     palette: finalPalette,
@@ -358,6 +376,7 @@ export async function initFloatingToolbar(container, options = {}) {
     setVariant,
     destroy() {
       clearStickyBehavior(wrapper, stickyReserveContainer, stickyIo);
+      if (footerIo) footerIo.disconnect();
       toolbar.destroy();
       wrapper.remove();
     },

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -114,6 +114,47 @@ async function handleDownload(palette, t) {
   }
 }
 
+/* Renders gradient to canvas for download. Uses even stop distribution since the
+   toolbar palette only carries a flat colors array — stop positions from the
+   gradient editor are not propagated to the toolbar. */
+async function handleGradientDownload(palette, t) {
+  try {
+    const { name = 'gradient', colors = [], angle = 90 } = palette;
+    const canvas = document.createElement('canvas');
+    canvas.width = 1920;
+    canvas.height = 1080;
+    const ctx = canvas.getContext('2d');
+    const rad = (angle - 90) * (Math.PI / 180);
+    const cx = canvas.width / 2;
+    const cy = canvas.height / 2;
+    const len = Math.hypot(canvas.width, canvas.height) / 2;
+    const grad = ctx.createLinearGradient(
+      cx - Math.cos(rad) * len,
+      cy - Math.sin(rad) * len,
+      cx + Math.cos(rad) * len,
+      cy + Math.sin(rad) * len,
+    );
+    colors.forEach((hex, i) => {
+      grad.addColorStop(colors.length > 1 ? i / (colors.length - 1) : 0.5, hex);
+    });
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const blob = await new Promise((resolve) => { canvas.toBlob(resolve, 'image/jpeg', 0.95); });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${name}.jpg`;
+    a.click();
+    URL.revokeObjectURL(url);
+    announceToScreenReader(t.downloadStarted);
+  } catch (err) {
+    window.lana?.log(`Gradient download failed: ${err.message}`, {
+      tags: 'color-floating-toolbar,download',
+      severity: 'error',
+    });
+  }
+}
+
 let activeDrawer = null;
 
 async function handleSave(
@@ -413,6 +454,8 @@ export function createToolbar(options) {
     effectiveShowEdit,
     async () => {
       const currentPalette = getPaletteWithName();
+      emit('edit', { palette: currentPalette });
+      if (window.isTestEnv) return;
       if (editPaletteLink) {
         window.location.href = editPaletteLink;
       } else {
@@ -435,7 +478,11 @@ export function createToolbar(options) {
     },
     onDownload: async () => {
       const currentPalette = getPaletteWithName();
-      await handleDownload(currentPalette, t);
+      if (type === 'gradient') {
+        await handleGradientDownload(currentPalette, t);
+      } else {
+        await handleDownload(currentPalette, t);
+      }
       emit('download', { palette: currentPalette });
     },
     onSave: async () => {

--- a/express/code/scripts/color-shared/toolbar/toolbar.css
+++ b/express/code/scripts/color-shared/toolbar/toolbar.css
@@ -263,6 +263,7 @@
 
   position: fixed;
   inline-size: calc(100% - var(--ax-toolbar-inline-margin) * 2);
+  max-inline-size: var(--ax-toolbar-presentation-max-width);
   inset-block-end: var(--ax-toolbar-floating-bottom-offset);
   inset-inline-start: 0;
   inset-inline-end: 0;
@@ -273,6 +274,15 @@
 
 .ax-toolbar-sticky-wrapper.ax-toolbar-exiting {
   animation: ax-toolbar-slide-out 0.2s ease-in both;
+}
+
+/* Hide toolbar when footer is in view — slides off-screen like floating-cta */
+.color-floating-toolbar-container.ax-toolbar-footer-hidden,
+.ax-toolbar-sticky-wrapper.ax-toolbar-footer-hidden {
+  transform: translateY(110%);
+  pointer-events: none;
+  transition: transform 0.3s ease-in;
+  animation: none;
 }
 
 @keyframes ax-toolbar-slide-in {

--- a/test/blocks/color-extract/color-extract.test.js
+++ b/test/blocks/color-extract/color-extract.test.js
@@ -13,6 +13,7 @@ const imports = await Promise.all([
 const { default: decorate } = imports[1];
 
 const basic = await readFile({ path: './mocks/basic.html' });
+const gradient = await readFile({ path: './mocks/gradient.html' });
 
 describe('Color Extract', () => {
   before(() => {
@@ -70,6 +71,60 @@ describe('Color Extract', () => {
     await decorate(block);
     const suggestions = block.querySelectorAll('.color-extract-suggestion');
     // mock HTML has 2 suggestion images
+    expect(suggestions.length).to.equal(2);
+  });
+});
+
+describe('Color Extract — gradient variant', () => {
+  before(() => {
+    window.isTestEnv = true;
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = gradient;
+  });
+
+  it('decorates without throwing', async () => {
+    const block = document.querySelector('.color-extract');
+    let error;
+    try {
+      await decorate(block);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).to.be.undefined;
+  });
+
+  it('builds suggestion images from row 0', async () => {
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    expect(block.querySelector('.color-extract-suggestions')).to.exist;
+  });
+
+  it('builds the gradient edit stage', async () => {
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    expect(block.querySelector('.color-extract-edit-stage--gradient')).to.exist;
+  });
+
+  it('builds the landing stage', async () => {
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    expect(block.querySelector('.color-extract-landing')).to.exist;
+  });
+
+  it('places dropzone inside the landing content', async () => {
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    const landing = block.querySelector('.color-extract-landing-content');
+    expect(landing.querySelector('.image-upload-dropzone-container')).to.exist;
+  });
+
+  it('suggestion list contains the expected number of images', async () => {
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    const suggestions = block.querySelectorAll('.color-extract-suggestion');
+    // gradient mock HTML has 2 suggestion images
     expect(suggestions.length).to.equal(2);
   });
 });

--- a/test/blocks/color-extract/mocks/gradient.html
+++ b/test/blocks/color-extract/mocks/gradient.html
@@ -1,0 +1,20 @@
+<div class="color-extract gradient">
+  <div>
+    <div>Don't have an image? Try one of ours:</div>
+    <div>
+      <p><picture><img loading="lazy" alt="Sample gradient 1" src="./mock-img-1.png" width="163" height="163"></picture></p>
+      <p><picture><img loading="lazy" alt="Sample gradient 2" src="./mock-img-2.png" width="163" height="163"></picture></p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h1>Edit Your Color Palette</h1>
+      <p>Adjust the mood, name your palette, and refine your colors by moving the handles on the image.</p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <img loading="lazy" alt="" src="./mock-edit-preview.png" width="2880" height="1600">
+    </div>
+  </div>
+</div>

--- a/test/scripts/color-shared/toolbar/createFloatingToolbar.test.js
+++ b/test/scripts/color-shared/toolbar/createFloatingToolbar.test.js
@@ -197,4 +197,72 @@ describe('initFloatingToolbar', () => {
       expect(io).to.exist;
     });
   });
+
+  describe('footer visibility observer', () => {
+    let OriginalIntersectionObserver;
+    let observers;
+    let footer;
+
+    beforeEach(() => {
+      footer = document.createElement('footer');
+      document.body.appendChild(footer);
+
+      OriginalIntersectionObserver = window.IntersectionObserver;
+      observers = [];
+      window.IntersectionObserver = function MockIO(cb, opts) {
+        const instance = {
+          observe: sinon.stub(),
+          disconnect: sinon.stub(),
+          opts,
+          trigger(entry) { cb([entry]); },
+        };
+        observers.push(instance);
+        return instance;
+      };
+    });
+
+    afterEach(() => {
+      window.IntersectionObserver = OriginalIntersectionObserver;
+    });
+
+    it('creates a footer IntersectionObserver with rootMargin "32px"', async () => {
+      await callInit(container, { palette: MOCK_PALETTE });
+      const footerIo = observers.find((o) => o.opts?.rootMargin === '32px');
+      expect(footerIo).to.exist;
+      expect(footerIo.observe.calledOnce).to.be.true;
+    });
+
+    it('adds aria-hidden and inert and ax-toolbar-footer-hidden when footer enters view', async () => {
+      await callInit(container, { palette: MOCK_PALETTE });
+      const wrapper = container.querySelector('.color-floating-toolbar-container');
+      const footerIo = observers.find((o) => o.opts?.rootMargin === '32px');
+
+      footerIo.trigger({ isIntersecting: true, intersectionRatio: 1 });
+
+      expect(wrapper.classList.contains('ax-toolbar-footer-hidden')).to.be.true;
+      expect(wrapper.getAttribute('aria-hidden')).to.equal('true');
+      expect(wrapper.hasAttribute('inert')).to.be.true;
+    });
+
+    it('removes aria-hidden and inert and ax-toolbar-footer-hidden when footer leaves view', async () => {
+      await callInit(container, { palette: MOCK_PALETTE });
+      const wrapper = container.querySelector('.color-floating-toolbar-container');
+      const footerIo = observers.find((o) => o.opts?.rootMargin === '32px');
+
+      footerIo.trigger({ isIntersecting: true, intersectionRatio: 1 });
+      footerIo.trigger({ isIntersecting: false, intersectionRatio: 0 });
+
+      expect(wrapper.classList.contains('ax-toolbar-footer-hidden')).to.be.false;
+      expect(wrapper.hasAttribute('aria-hidden')).to.be.false;
+      expect(wrapper.hasAttribute('inert')).to.be.false;
+    });
+
+    it('destroy() disconnects the footer observer', async () => {
+      const result = await callInit(container, { palette: MOCK_PALETTE });
+      const footerIo = observers.find((o) => o.opts?.rootMargin === '32px');
+
+      result.destroy();
+      expect(footerIo.disconnect.calledOnce).to.be.true;
+    });
+  });
 });

--- a/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
@@ -343,6 +343,38 @@ describe('createToolbar', () => {
       expect(cb.firstCall.args[0]).to.have.property('palette');
     });
 
+    it('on("download", cb) fires when Download button clicked with gradient type', async () => {
+      const fakeGrad = { addColorStop: sinon.stub() };
+      const fakeCtx = {
+        createLinearGradient: sinon.stub().returns(fakeGrad),
+        fillRect: sinon.stub(),
+        fillStyle: '',
+      };
+      sinon.stub(HTMLCanvasElement.prototype, 'getContext').returns(fakeCtx);
+      sinon.stub(HTMLCanvasElement.prototype, 'toBlob').callsFake((cb) => {
+        cb(new Blob(['img'], { type: 'image/jpeg' }));
+      });
+      sinon.stub(URL, 'createObjectURL').returns('blob:fake');
+      sinon.stub(URL, 'revokeObjectURL');
+      sinon.stub(HTMLAnchorElement.prototype, 'click');
+
+      const toolbar = createToolbar(defaultOptions({
+        type: 'gradient',
+        palette: MOCK_GRADIENT,
+      }));
+      document.body.appendChild(toolbar.element);
+
+      const cb = sinon.stub();
+      toolbar.on('download', cb);
+
+      const downloadBtn = toolbar.element.querySelector('sp-action-button[label="Download this color palette"]');
+      downloadBtn.click();
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(cb.calledOnce).to.be.true;
+      expect(cb.firstCall.args[0]).to.have.property('palette');
+    });
+
     it('on("save", cb) fires when CC Library button clicked', async () => {
       const mockCtx = createMockGetLibraryContext([], null);
       const toolbar = createToolbar(defaultOptions({ getLibraryContext: mockCtx }));
@@ -461,6 +493,30 @@ describe('createToolbar', () => {
 
       expect(cb.calledOnce).to.be.true;
       expect(cb.firstCall.args[0].name).to.equal('Renamed Palette');
+    });
+  });
+
+  describe('setVariant', () => {
+    it('setVariant("sticky") adds ax-toolbar-sticky class and sets sticky to true', () => {
+      const toolbar = createToolbar(defaultOptions({ variant: 'standalone' }));
+      document.body.appendChild(toolbar.element);
+
+      toolbar.setVariant('sticky');
+
+      const tb = toolbar.element.querySelector('.ax-toolbar');
+      expect(tb.classList.contains('ax-toolbar-sticky')).to.be.true;
+      expect(toolbar.sticky).to.be.true;
+    });
+
+    it('setVariant("standalone") removes ax-toolbar-sticky class and sets sticky to false', () => {
+      const toolbar = createToolbar(defaultOptions({ variant: 'sticky' }));
+      document.body.appendChild(toolbar.element);
+
+      toolbar.setVariant('standalone');
+
+      const tb = toolbar.element.querySelector('.ax-toolbar');
+      expect(tb.classList.contains('ax-toolbar-sticky')).to.be.false;
+      expect(toolbar.sticky).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Summary

This resolves issues from https://adobe-my.sharepoint.com/:x:/r/personal/salg_adobe_com/Documents/Color%20Design%20QA%20Log.xlsx?d=we0bc09d4e1aa47cebbaf48ccdd9e6a3b&csf=1&web=1&e=bS2OdL under the extract sheet. 

---

## Jira Ticket

[No Jira]

| Bug | Summary | How |
|---|---|---|
| Drag overlay stuck | `dragCounter` pattern + `blur`/`visibilitychange` listeners | `color-extract.js` |
| Image border-radius | `border-radius: 0` on `img` | `color-extract.css` |
| Mood dropdown width | `fit-content` / `max-width: 330px`; full-width override on mobile | `color-extract.css` |
| Toolbar hides at footer | `IntersectionObserver` on `footer` + slide-out CSS | `createFloatingToolbar.js`, `toolbar.css` |
| Toolbar max-width | `--ax-color-tool-presentation-max-width: 1440px` + `max-inline-size` | `color-extract.css`, `toolbar.css` |
| Min 2 colors | `<= 2` guard + `minSwatches: 2` on both variants | `color-extract.js` |
| No color picker on hex click | Removed `colorPicker` from swatch features object | `color-extract.js` |
| Random color placement | `0.1 + Math.random() * 0.8` (both color and gradient variants) | `color-extract.js` |
| Mobile upload padding | `padding-inline: 16px` on section | `color-extract.css` |
| Toolbar floating on mobile/tablet | `matchMedia` → `sticky` on mobile, `sticky-on-scroll` on desktop | `color-extract.js` |
| Editable palette name | `editPaletteName: true` | `color-extract.js` |
| Gradient full width | `size: 'responsive'` | `color-extract.js` |
| Gradient handles past edges | `positionFromEvent` allows overflow by half a stop handle | `gradient-editor.js` |
| Gradient stop redistribution | Evenly redistributes all stops on add | `color-extract.js` |
| Gradient download | Client-side canvas render → JPEG download | `createToolbarComponent.js` |
| Colors over toolbar on mobile | Implicitly fixed — toolbar is now `sticky` (in-flow) on mobile, not floating over content | `color-extract.js` |
| Edit color dialogue disabled on color strips | Passed proper options | `color-extract.js` |
| Browser back button goes back to landing after results | Added history action, reset states | `color-extract.js` |

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/drafts/bradjohn/extract |
| **After**   | https://extract-bugfixes--express-color--adobecom.aem.page/drafts/bradjohn/extract?martech=off |

---

## Verification Steps
Bug 1 — Drag overlay dismisses when releasing outside window

  1. Open the extract upload page
  2. Drag a file from your desktop into the browser window — overlay appears
  3. Without releasing, move the cursor back outside the browser window and release
  4. Overlay should disappear within ~200ms
  5. Also test: drag a file in, switch tabs (Cmd+Tab), come back — overlay should be gone

  Bug 2 — Floating toolbar hides near footer

  1. Upload an image on the extract page (or gradient page)
  2. Scroll down slowly toward the footer
  3. The floating bottom toolbar should fade out as the footer enters the viewport
  4. Scroll back up — toolbar reappears
  5. Verify keyboard focus isn't trapped on the hidden toolbar (it gets inert)

  Bug 3 — Floating toolbar max-width matches grid

  1. On a wide monitor (>1440px), upload an image
  2. The floating toolbar should not span wider than the content grid (1440px)
  3. Compare toolbar width to the results grid above — they should align

  Bug 4 — Minimum 2 colors in palette

  1. Upload an image, get the palette results
  2. Delete colors one by one using the trash icon
  3. Should not be able to go below 2 colors — clicking trash at 2 does nothing
  4. Test on both palette and gradient variants

  Bug 5 — No color picker on hex click (Extract)

  1. Upload an image on the palette extract page
  2. Click on any hex code in the swatch rail
  3. Should copy hex to clipboard — should NOT open a color picker modal
  4. "Edit color" tooltip should not appear on hover
  5. Gradient variant should also not have color picker (was already the case)

  Bug 6 — Mobile upload page padding

  1. Open extract upload page on a 375px viewport (or phone)
  2. Content should have 16px padding on left and right sides
  3. No content should touch the screen edges

  Bug 8 — Toolbar always floating on tablet/mobile

  1. Open extract results page on a tablet viewport (<1200px)
  2. The toolbar should be fixed at the bottom immediately — no scrolling needed
  3. Resize to desktop (>1200px) — toolbar should become scroll-triggered (only appears when you scroll past it)
  4. Resize back to mobile — toolbar returns to always-floating

  Bug 9 — Editable palette name

  1. Upload an image, wait for floating toolbar to appear
  2. Click on the palette name field in the toolbar
  3. Should be editable — type a custom name
  4. Name should persist as you interact with other toolbar features

  Bug 11 — Gradient control full width

  1. Open the gradient extract page, upload an image
  2. The gradient bar should fill the full width of its column
  3. Check on tablet and desktop — no extra padding/gap on the right

  Bug 12 — Gradient handles extend past edges

  1. On the gradient results page, look at the first and last color stops
  2. The handles at 0% and 100% should extend slightly outside the gradient bar (9px offset)
  3. Compare with the Figma (node-id=6198-370556)

  Bug 16 — Random color placement on "Add color"

  1. Upload an image, click "Add color" (eyedropper) multiple times
  2. Each new marker should appear at a different random position on the image
  3. Colors should vary (not all the same center pixel)
  4. Test on both palette and gradient variants

  Bug 17 — Gradient stops redistribute evenly

  1. On gradient results page, click "Add color" 3-4 times
  2. After each addition, all stops should spread out evenly across the bar
  3. No stops should stack/overlap on the right side

  Bug 18 — Mood dropdown width

  1. On desktop/tablet results page, check the mood dropdown
  2. Should be fit-content width, capped at 330px — not filling the full toolbar
  3. On mobile (<600px), it should fill the available width

  Bug 19 — Image border-radius from container

  1. Upload an image on the extract page
  2. The image in the results view should NOT have rounded corners on the <img> itself
  3. The container (<picture>) clips with its own border-radius + overflow hidden

  Bug 20 — Gradient download

  1. On gradient results page, click the download button
  2. Should download a .jpg file showing the actual gradient (not individual color swatches)
  3. Gradient direction should match the angle (default 90° = left-to-right)

  New Feature: History back button

  1. Upload image, or use pre-selected to view results
  2. Hit back button

---