### PR TITLE
Google yolo

### DIFF
--- a/express/code/libs/features/google-login.js
+++ b/express/code/libs/features/google-login.js
@@ -1,0 +1,58 @@
+const GOOGLE_SCRIPT = 'https://accounts.google.com/gsi/client';
+const GOOGLE_ID = '530526366930-l874a90ipfkn26naa71r010u8epp39jt.apps.googleusercontent.com';
+const PLACEHOLDER = 'feds-googleLogin';
+const WRAPPER = 'feds-profile';
+
+const onToken = async (getMetadata, data, getConfig) => {
+  let destination;
+  const config = getConfig();
+  const acceptedTouList = getMetadata('google-login-accepted-tou-list')?.trim();
+  try {
+    destination = new URL(typeof config.googleLoginURLCallback === 'function' ? await config.googleLoginURLCallback()
+      : getMetadata('google-login-redirect'))?.href;
+  } catch {
+    // Do nothing
+  }
+
+  await window.adobeIMS.socialHeadlessSignIn({
+    provider_id: 'google',
+    idp_token: data?.credential,
+    client_id: window.adobeid?.client_id,
+    scope: window.adobeid?.scope,
+    accepted_tou_list: acceptedTouList || '',
+  }).then(() => {
+    if (window.DISABLE_PAGE_RELOAD === true) return;
+    // Existing account
+    if (destination) {
+      window.location.assign(destination);
+    } else {
+      window.location.reload();
+    }
+  }).catch(() => {
+    // New account
+    window.adobeIMS.signInWithSocialProvider('google', { redirect_uri: destination || window.location.href });
+  });
+};
+
+export default async function initGoogleLogin(loadIms, getMetadata, loadScript, getConfig) {
+  try {
+    await loadIms();
+  } catch {
+    return;
+  }
+  if (window.adobeIMS?.isSignedInUser()) return;
+
+  await loadScript(GOOGLE_SCRIPT);
+  const placeholder = document.createElement('div');
+  placeholder.id = PLACEHOLDER;
+  document.querySelector(`.${WRAPPER}`)?.append(placeholder);
+
+  window.google?.accounts?.id?.initialize({
+    client_id: GOOGLE_ID,
+    callback: (data) => onToken(getMetadata, data, getConfig),
+    prompt_parent_id: PLACEHOLDER,
+    cancel_on_tap_outside: false,
+    auto_select: getMetadata('google-yolo-zero-tap')?.toLowerCase() === 'on',
+  });
+  window.google?.accounts?.id?.prompt();
+}

--- a/express/code/libs/features/google-login.js
+++ b/express/code/libs/features/google-login.js
@@ -38,7 +38,8 @@ export default async function initGoogleLogin(loadIms, getMetadata, loadScript, 
   console.log('[local] initGoogleLogin called');
   try {
     await loadIms();
-  } catch {
+  } catch (error) {
+    console.error('[local] error loading IMS', error);
     return;
   }
   if (window.adobeIMS?.isSignedInUser()) return;

--- a/express/code/libs/features/google-login.js
+++ b/express/code/libs/features/google-login.js
@@ -3,13 +3,11 @@ const GOOGLE_ID = '530526366930-l874a90ipfkn26naa71r010u8epp39jt.apps.googleuser
 const PLACEHOLDER = 'feds-googleLogin';
 const WRAPPER = 'feds-profile';
 
-const onToken = async (getMetadata, data, getConfig) => {
+const onToken = async (getMetadata, data) => {
   let destination;
-  const config = getConfig();
   const acceptedTouList = getMetadata('google-login-accepted-tou-list')?.trim();
   try {
-    destination = new URL(typeof config.googleLoginURLCallback === 'function' ? await config.googleLoginURLCallback()
-      : getMetadata('google-login-redirect'))?.href;
+    destination = new URL(getMetadata('google-login-redirect'))?.href;
   } catch {
     // Do nothing
   }
@@ -34,7 +32,7 @@ const onToken = async (getMetadata, data, getConfig) => {
   });
 };
 
-export default async function initGoogleLogin(loadIms, getMetadata, loadScript, getConfig) {
+export default async function initGoogleLogin(loadIms, getMetadata, loadScript) {
   console.log('[local] initGoogleLogin called');
   try {
     await loadIms();
@@ -51,7 +49,7 @@ export default async function initGoogleLogin(loadIms, getMetadata, loadScript, 
 
   window.google?.accounts?.id?.initialize({
     client_id: GOOGLE_ID,
-    callback: (data) => onToken(getMetadata, data, getConfig),
+    callback: (data) => onToken(getMetadata, data),
     prompt_parent_id: PLACEHOLDER,
     cancel_on_tap_outside: false,
     auto_select: getMetadata('google-yolo-zero-tap')?.toLowerCase() === 'on',

--- a/express/code/libs/features/google-login.js
+++ b/express/code/libs/features/google-login.js
@@ -35,6 +35,7 @@ const onToken = async (getMetadata, data, getConfig) => {
 };
 
 export default async function initGoogleLogin(loadIms, getMetadata, loadScript, getConfig) {
+  console.log('[local] initGoogleLogin called');
   try {
     await loadIms();
   } catch {

--- a/express/code/libs/features/google-login.js
+++ b/express/code/libs/features/google-login.js
@@ -3,13 +3,13 @@ const GOOGLE_ID = '530526366930-l874a90ipfkn26naa71r010u8epp39jt.apps.googleuser
 const PLACEHOLDER = 'feds-googleLogin';
 const WRAPPER = 'feds-profile';
 
-const onToken = async (getMetadata, data) => {
-  let destination;
+const onToken = async (getMetadata, getConfig, data) => {
   const acceptedTouList = getMetadata('google-login-accepted-tou-list')?.trim();
+  let destination;
   try {
-    destination = new URL(getMetadata('google-login-redirect'))?.href;
+    destination = new URL(getMetadata('google-login-redirect'))?.href || await getConfig()?.googleLoginURLCallback?.()  ;
   } catch {
-    // Do nothing
+    window.lana?.log('[local] error parsing google-login-redirect', getMetadata('google-login-redirect'), { tags: 'google-login', severity: 'error' });
   }
 
   await window.adobeIMS.socialHeadlessSignIn({
@@ -32,12 +32,10 @@ const onToken = async (getMetadata, data) => {
   });
 };
 
-export default async function initGoogleLogin(loadIms, getMetadata, loadScript) {
-  console.log('[local] initGoogleLogin called');
+export default async function initGoogleLogin(loadIms, getMetadata, loadScript, getConfig) {
   try {
     await loadIms();
-  } catch (error) {
-    console.error('[local] error loading IMS', error);
+  } catch {
     return;
   }
   if (window.adobeIMS?.isSignedInUser()) return;
@@ -49,7 +47,7 @@ export default async function initGoogleLogin(loadIms, getMetadata, loadScript) 
 
   window.google?.accounts?.id?.initialize({
     client_id: GOOGLE_ID,
-    callback: (data) => onToken(getMetadata, data),
+    callback: (data) => onToken(getMetadata, getConfig, data),
     prompt_parent_id: PLACEHOLDER,
     cancel_on_tap_outside: false,
     auto_select: getMetadata('google-yolo-zero-tap')?.toLowerCase() === 'on',

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -71,8 +71,8 @@ async function loadGoogleLogin() {
   const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
   if (googleLogin === 'mobile' && desktopViewport) return;
   if (googleLogin === 'desktop' && !desktopViewport) return;
-  console.log('[google-login] redirect:', getConfig().googleLoginURLCallback());
-  console.log('[google-login] redirect:', getMetadata('google-login-redirect'));
+  // console.log('[google-login] redirect:', getConfig().googleLoginURLCallback());
+  // console.log('[google-login] redirect:', getMetadata('google-login-redirect'));
   const { default: initGoogleLogin } = await import('../libs/features/google-login.js');
   initGoogleLogin(loadIms, getMetadata, loadScript);
 };

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -3,7 +3,7 @@ import BlockMediator from './block-mediator.min.js';
 
 let createTag; let getMetadata;
 let getConfig; let loadStyle;
-let loadIMS; let loadScript;
+let loadIms; let loadScript;
 
 export function getDestination() {
   const pepDestinationMeta = getMetadata('pep-destination');
@@ -73,7 +73,7 @@ async function loadGoogleLogin() {
   if (googleLogin === 'desktop' && !desktopViewport) return;
 
   const { default: initGoogleLogin } = await import('../libs/features/google-login.js');
-  initGoogleLogin(loadIMS, getMetadata, loadScript, getConfig);
+  initGoogleLogin(loadIms, getMetadata, loadScript, getConfig);
 };
 
 /**
@@ -82,7 +82,7 @@ async function loadGoogleLogin() {
 export default async function loadDelayed() {
   try {
     await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
-      ({ createTag, getMetadata, getConfig, loadStyle, loadIMS, loadScript } = utils);
+      ({ createTag, getMetadata, getConfig, loadStyle, loadScript, loadIms } = utils);
     });
     addJapaneseSectionHeaderSizing();
     turnContentLinksIntoButtons();

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -3,6 +3,8 @@ import BlockMediator from './block-mediator.min.js';
 
 let createTag; let getMetadata;
 let getConfig; let loadStyle;
+let loadIMS; let loadScript;
+
 export function getDestination() {
   const pepDestinationMeta = getMetadata('pep-destination');
   return pepDestinationMeta || BlockMediator.get('primaryCtaUrl')
@@ -63,20 +65,33 @@ async function addJapaneseSectionHeaderSizing() {
   }
 }
 
+async function loadGoogleLogin() {
+  const googleLogin = getMetadata('google-login')?.toLowerCase();
+  if (window.adobeIMS?.isSignedInUser() || !['mobile', 'desktop', 'on'].includes(googleLogin)) return;
+  const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
+  if (googleLogin === 'mobile' && desktopViewport) return;
+  if (googleLogin === 'desktop' && !desktopViewport) return;
+
+  const { default: initGoogleLogin } = await import('../libs/features/google-login.js');
+  initGoogleLogin(loadIMS, getMetadata, loadScript, getConfig);
+};
+
 /**
  * Executes everything that happens a lot later, without impacting the user experience.
  */
 export default async function loadDelayed() {
   try {
     await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
-      ({ createTag, getMetadata, getConfig, loadStyle } = utils);
+      ({ createTag, getMetadata, getConfig, loadStyle, loadIMS, loadScript } = utils);
     });
     addJapaneseSectionHeaderSizing();
     turnContentLinksIntoButtons();
     preloadSUSILight();
+    loadGoogleLogin();
     return null;
   } catch (error) {
     window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { tags: 'express-delayed', severity: 'error' });
     return null;
   }
 }
+

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -71,9 +71,10 @@ async function loadGoogleLogin() {
   const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
   if (googleLogin === 'mobile' && desktopViewport) return;
   if (googleLogin === 'desktop' && !desktopViewport) return;
-
+  console.log('[google-login] redirect:', getConfig().googleLoginURLCallback());
+  console.log('[google-login] redirect:', getMetadata('google-login-redirect'));
   const { default: initGoogleLogin } = await import('../libs/features/google-login.js');
-  initGoogleLogin(loadIms, getMetadata, loadScript, getConfig);
+  initGoogleLogin(loadIms, getMetadata, loadScript);
 };
 
 /**

--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -71,10 +71,8 @@ async function loadGoogleLogin() {
   const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
   if (googleLogin === 'mobile' && desktopViewport) return;
   if (googleLogin === 'desktop' && !desktopViewport) return;
-  // console.log('[google-login] redirect:', getConfig().googleLoginURLCallback());
-  // console.log('[google-login] redirect:', getMetadata('google-login-redirect'));
   const { default: initGoogleLogin } = await import('../libs/features/google-login.js');
-  initGoogleLogin(loadIms, getMetadata, loadScript);
+  initGoogleLogin(loadIms, getMetadata, loadScript, getConfig);
 };
 
 /**

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -16,7 +16,6 @@ import {
   decorateArea,
   getMetadata,
   preDecorateSections,
-  getRedirectUri,
   getIconElementDeprecated,
 } from './utils.js';
 
@@ -97,7 +96,6 @@ const CONFIG = {
     'eb0dcb78-3e56-4b10-89f9-51831f2cc37f': 'express-pep',
   },
   links: 'on',
-  googleLoginURLCallback: getRedirectUri,
   autoBlocks: [
     { axfaas: '/tools/axfaas' },
   ],

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -16,6 +16,7 @@ import {
   decorateArea,
   getMetadata,
   preDecorateSections,
+  getRedirectUri,
   getIconElementDeprecated,
 } from './utils.js';
 
@@ -96,6 +97,7 @@ const CONFIG = {
     'eb0dcb78-3e56-4b10-89f9-51831f2cc37f': 'express-pep',
   },
   links: 'on',
+  googleLoginURLCallback: getRedirectUri,
   autoBlocks: [
     { axfaas: '/tools/axfaas' },
   ],

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -361,10 +361,6 @@ async function loadPage() {
   const adobeHomeRedirect = createTag('meta', { name: 'adobe-home-redirect', content: 'on' });
   document.head.append(adobeHomeRedirect);
 
-  const googleLoginRedirect = createTag('meta', { name: 'google-login', content: 'desktop' });
-  document.head.append(googleLoginRedirect);
-  // end TODO remove metadata after we go live
-
   const config = setConfig({ ...CONFIG, miloLibs });
 
   if (getMetadata('template-search-page') === 'Y') {
@@ -416,6 +412,9 @@ async function loadPage() {
   });
 
   await loadArea();
+
+  // Set after loadArea so milo's delayed doesn't pick it up — express-delayed owns google login
+  document.head.append(createTag('meta', { name: 'google-login', content: 'desktop' }));
 
   const { fixIcons } = await import('./utils.js');
   document.querySelectorAll('.section>.text').forEach((block) => fixIcons(block));


### PR DESCRIPTION
## Summary

This PR adds Express-owned **Google One Tap (YOLO) auto sign-in** so it can be driven from the Express codebase instead of only Milo. Initialization runs from `express-delayed.js` after IMS is available: it loads the Google GSI client, mounts the prompt under the federated profile placeholder, and signs the user in via `adobeIMS.socialHeadlessSignIn` (with fallback to `signInWithSocialProvider` for new accounts).

**Author controls (page metadata):**

- **`google-login`**: `on` | `desktop` | `mobile` to enable One Tap and restrict by viewport (anything else leaves it off).
- **`google-yolo-zero-tap`**: set to `on` for `auto_select` (silent / second-visit style behavior when Google allows it).
- **`google-login-redirect`**: optional absolute URL to send users after a successful existing-account sign-in; otherwise the page reloads (or SUSI redirect flow for new accounts).
- **`google-login-accepted-tou-list`**: optional; passed through as `accepted_tou_list` for progressive / TOU behavior (aligned with Identity expectations).

**Milo coordination:** a default `google-login` meta is appended **after** `loadArea()` in `scripts.js` so Milo’s delayed path does not treat the page as YOLO-enabled before Express takes ownership—reducing duplicate One Tap behavior (authors can still override via document metadata).

---

## Jira Ticket

Resolves: [MWPW-188779](https://jira.corp.adobe.com/browse/MWPW-188779)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://google-yolo--da-express-milo--adobecom.aem.page/express/?martech=off |

**Draft demo (metadata / flow):** https://google-yolo--da-express-milo--adobecom.aem.page/drafts/echen/blog-yolo

---

## Verification Steps

1. Open the **After** URL (and the draft URL) while **signed out** of Adobe; ensure **Google One Tap is allowed** in the browser (and you have an active Google session if testing auto behavior).
2. Confirm the One Tap UI appears when page metadata enables it (`google-login` = `on` / `desktop` / `mobile` as appropriate for your viewport).
3. Complete sign-in: **existing Google-linked Adobe account** should respect **`google-login-redirect`** when set, or reload when not; **new user** flow should continue via social sign-in as implemented.
4. On a page **without** `google-login` enabled (or with an unsupported value), confirm One Tap from **this** Express path does not run (only Milo may still run on some pages until fully decoupled).
5. **Before vs after:** on `main`, Express does not own this flow; on this branch, Express initializes One Tap from delayed scripts with the metadata behavior above. Expect possible **brief double prompt** while both Milo and Express One Tap exist—widget may flash as each stack runs (as noted on the ticket).

---

## Potential Regressions

- https://google-yolo--da-express-milo--adobecom.aem.live/express/?martech=off
- Pages that relied on **only** Milo for One Tap: behavior may change where Express now appends default `google-login` meta (`desktop`) after `loadArea`.
- **IMS / Identity** flows: wrong or missing `google-login-accepted-tou-list` could affect progressive-account / TOU expectations—validate with Identity for production metadata.
- **Viewport gating**: `desktop` vs `mobile` must be verified on real breakpoints (code uses `min-width: 900px`).

---

## Additional Notes

- Progressive account creation (defer DOB / full account) is **already enabled** per team comment on MWPW-188779 (separate from this PR’s scope).
- Related prior Milo work / `accepted_tou_list` discussion: [milo#5401](https://github.com/adobecom/milo/pull/5401).
- Linked reference implementation / requirements: [MWPW-180897](https://jira.corp.adobe.com/browse/MWPW-180897), progressive diligence: [MWPW-186062](https://jira.corp.adobe.com/browse/MWPW-186062).
