### PR TITLE
MWPW-192327 Fix Edit Color on Mobile Android

### DIFF
--- a/express/code/libs/color-components/components/color-swatch-rail/index.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/index.js
@@ -848,7 +848,7 @@ export class ColorSwatchRail extends LitElement {
     const idx = col.getAttribute('data-swatch-index');
     if (idx === null || idx === '') return;
     if ((this.lockedByIndex || new Set()).has(Number(idx))) return;
-    if (e.target.closest('.icon-button--copy, .icon-button--edit-tint, .icon-button--trash, .icon-button--add, .icon-button--lock, .base-color-badge, .color-blindness-badge, .tint-band-btn')) return;
+    if (e.target.closest('.icon-button--copy, .icon-button--edit-tint, .icon-button--trash, .icon-button--add, .icon-button--lock, .base-color-badge, .color-blindness-badge, .tint-band-btn, .hex-code')) return;
     e.preventDefault();
     this._touchDragFromIndex = Number(idx);
     col.classList.add('swatch-column--dragging');


### PR DESCRIPTION
## Summary

Fixes issue where the Edit Color overlay wasn't opening on mobile on the color wheel page for android or android simulated devices

---

## Jira Ticket

Resolves: [MWPW-192327](https://jira.corp.adobe.com/browse/MWPW-192327)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-edit-color--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- In Chrome, open dev tools and click on the device toolbar.
- Select a mobile or tablet device size.
- Scroll down to the palette strips and click on the hexcode.
- This should open the mobile Edit Color overlay.

(You can also test via browserstack with android mobile/tablet devices)
---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
