### PR TITLE
MWPW-187451 Color Wheel Design QA Batch 2

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -552,9 +552,3 @@ color-wheel-express {
     display: flex;
   }
 }
-
-@media (min-width: 1440px) {
-  .color-wheel .ax-color-tool-layout {
-    box-sizing: content-box;
-  }
-}

--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -864,7 +864,7 @@ export default async function decorate(block) {
       stripRenderer = createStripContainerRenderer({
         container: stripHost,
         data: [swatchRailController],
-        mobileBreakpointQuery: '(max-width: 1199px)',
+        mobileBreakpointQuery: '(max-width: 599px)',
         config: {
           stripContainerOrientations: ['vertical-responsive'],
           swatchFeatures: {

--- a/express/code/libs/color-components/components/color-swatch-rail/index.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/index.js
@@ -495,7 +495,6 @@ export class ColorSwatchRail extends LitElement {
   }
 
   _handleTrash(index) {
-    if ((this.lockedByIndex || new Set()).has(index)) return;
     const minSwatches = this._features.minSwatches ?? 0;
     if ((this.swatches?.length ?? 0) <= minSwatches) return;
     const e = new CustomEvent('color-swatch-rail-delete', { bubbles: true, composed: true, detail: { index } });
@@ -508,7 +507,12 @@ export class ColorSwatchRail extends LitElement {
         else if (index < currentTintIndex) nextTintIndex = currentTintIndex - 1;
         else if (index === currentTintIndex) nextTintIndex = Math.min(currentTintIndex, swatches.length - 1);
       }
-      this.controller.setState({ swatches, tintIndex: nextTintIndex });
+      const nextLocked = new Set();
+      for (const i of (this.lockedByIndex || [])) {
+        if (i === index) continue;
+        nextLocked.add(i > index ? i - 1 : i);
+      }
+      this.controller.setState({ swatches, tintIndex: nextTintIndex, lockedByIndex: nextLocked });
       showExpressToast({ message: 'Color removed', variant: 'neutral', timeout: 2000, anchor: this.closest('.strip-container') || undefined });
     }
   }
@@ -654,7 +658,6 @@ export class ColorSwatchRail extends LitElement {
   _handleTintBandSelect(index, band, event) {
     event?.stopPropagation?.();
     if (!band?.hex || !this.controller?.setState) return;
-    if ((this.lockedByIndex || new Set()).has(index)) return;
     const swatches = [...this.swatches];
     if (!swatches[index]) return;
     const nextHex = this._normalizeHex(band.hex);
@@ -681,7 +684,6 @@ export class ColorSwatchRail extends LitElement {
   }
 
   _handleTintSelect(index, anchorEl = null) {
-    if ((this.lockedByIndex || new Set()).has(index)) return;
     const hex = this.swatches[index]?.hex;
     const rect = anchorEl?.getBoundingClientRect?.();
     const anchorRect = rect
@@ -749,7 +751,6 @@ export class ColorSwatchRail extends LitElement {
   }
 
   _onNativePickerChange(index, e) {
-    if ((this.lockedByIndex || new Set()).has(index)) return;
     this._markNativePickerOpen();
     const hex = e.target?.value;
     if (hex && this.controller?.setState) {
@@ -781,7 +782,6 @@ export class ColorSwatchRail extends LitElement {
 
   _handleDragStart(index, e) {
     if (!this._features.drag) return;
-    if ((this.lockedByIndex || new Set()).has(index)) return;
     if (e.target.closest('.icon-button--copy, .icon-button--edit-tint, .icon-button--trash, .icon-button--add, .icon-button--lock, .base-color-badge, .color-blindness-badge, .tint-band-btn')) return;
     this._dragFromIndex = index;
     e.dataTransfer.effectAllowed = 'move';
@@ -847,7 +847,6 @@ export class ColorSwatchRail extends LitElement {
     if (!col || col.closest('.swatch-column--empty')) return;
     const idx = col.getAttribute('data-swatch-index');
     if (idx === null || idx === '') return;
-    if ((this.lockedByIndex || new Set()).has(Number(idx))) return;
     if (e.target.closest('.icon-button--copy, .icon-button--edit-tint, .icon-button--trash, .icon-button--add, .icon-button--lock, .base-color-badge, .color-blindness-badge, .tint-band-btn')) return;
     e.preventDefault();
     this._touchDragFromIndex = Number(idx);
@@ -1336,7 +1335,7 @@ export class ColorSwatchRail extends LitElement {
         isBase && 'base-color',
         tintMode && 'swatch-column--tint-mode',
         isTintSelected && 'swatch-column--tint-selected',
-        f.drag && !isLocked && 'swatch-column--draggable',
+        f.drag && 'swatch-column--draggable',
         superLight && 'swatch-column--super-light',
         f.rightActionsHoverOnly && 'swatch-column--right-actions-hover-only',
         opts.cornerClass || ''

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -564,7 +564,6 @@ export const style = css`
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 6px;
     flex-shrink: 0;
   }
 

--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -35,6 +35,7 @@ export const style = css`
         inset: 0;
         z-index: 100;
         background: var(--Alias-overlay-curtain);
+        backdrop-filter: blur(10px);
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.2s ease;

--- a/express/code/scripts/color-shared/shell/README.md
+++ b/express/code/scripts/color-shared/shell/README.md
@@ -176,9 +176,7 @@ The layout exposes CSS variables for common customizations. Override these on yo
 | `--ax-bg-*` | varies | Background color for each slot |
 | `--ax-padding-*-mobile` | `var(--spacing-m)` | Padding for slots on mobile |
 | `--ax-padding-*-desktop` | varies | Padding for slots on desktop |
-| `--ax-z-topbar` | `20` | Z-index for sticky topbar |
 | `--ax-z-footer` | `10` | Z-index for sticky footer |
-| `--ax-sticky-topbar-top` | `0` | Top position for sticky topbar |
 | `--ax-sticky-footer-bottom` | `0` | Bottom position for sticky footer |
 | `--ax-footer-margin-top` | `var(--spacing-300)` | Top margin for footer slot |
 | `--ax-focus-outline-*` | varies | Focus indicator styling |

--- a/express/code/scripts/color-shared/shell/layouts/styles/color-tool-layout.css
+++ b/express/code/scripts/color-shared/shell/layouts/styles/color-tool-layout.css
@@ -44,11 +44,9 @@
   --ax-padding-canvas-desktop: 0;
 
   /* Z-index layers */
-  --ax-z-topbar: 20;
   --ax-z-footer: 10;
 
   /* Sticky positions */
-  --ax-sticky-topbar-top: 0;
   --ax-sticky-footer-bottom: 0;
 
   /* Canvas Styling */
@@ -103,9 +101,6 @@
 .ax-shell-slot--topbar {
   grid-area: var(--ax-area-topbar);
   background-color: var(--ax-bg-topbar);
-  position: sticky;
-  top: var(--ax-sticky-topbar-top);
-  z-index: var(--ax-z-topbar);
 }
 
 .ax-shell-slot--sidebar {
@@ -170,12 +165,6 @@
   .ax-shell-slot {
     order: unset;
     grid-area: auto;
-  }
-
-  .ax-shell-slot--topbar {
-    position: relative;
-    top: unset;
-    z-index: unset;
   }
 
   .ax-shell-slot--sidebar {

--- a/test/scripts/color-shared/components/color-swatch-rail.test.js
+++ b/test/scripts/color-shared/components/color-swatch-rail.test.js
@@ -67,7 +67,7 @@ describe('color-swatch-rail tint bands', () => {
     });
   });
 
-  it('does not apply tint band when swatch is locked', () => {
+  it('applies tint band even when swatch is locked', () => {
     const rail = createRail();
     rail.swatches = [{ hex: '#1900AB' }];
     rail.lockedByIndex = new Set([0]);
@@ -81,7 +81,7 @@ describe('color-swatch-rail tint bands', () => {
 
     const selectedBand = rail._buildTintBands('#1900AB')[1];
     rail._handleTintBandSelect(0, selectedBand);
-    expect(setStateCalled).to.equal(false);
+    expect(setStateCalled).to.equal(true);
   });
 
   it('returns null when no tint swatch is currently selected', () => {


### PR DESCRIPTION
## Summary

Addresses these design qa items:

- Spacing between Color strip action buttons should be 0px
- (Mobile only) Missing background blur when I open the Edit color sheet. 
- The desired experience for editing a color in tablet should be for the Color Edit overlay to open without the palette colors. 
- I should still be able to drag a locked color strip in order to reorder it in my palette. Currently doesn't seem to work! 
- I should be able to edit the tint of a locked color (seems to be disabled if color is locked)
- When you delete a locked swatch, the next swatch over gets locked when it shouldn't.
- At some screen size 1440-1520px, the layout is pushing outside the window
- Action menu is sticky on mobile / small tablet when it shouldn't be. Covers the local nav. 

---

## Jira Ticket

Resolves: [MWPW-187451](https://jira.corp.adobe.com/browse/MWPW-187451)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-design-qa2--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- See description

---

## Potential Regressions

- https://methomas-design-qa2--express-color--adobecom.aem.page/create/color-accessibility
- https://methomas-design-qa2--express-color--adobecom.aem.page/create/color-contrast-analyzer

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
