### PR TITLE
[MWPW-186751] Color blindness bug fixes

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -209,6 +209,7 @@ export default async function decorate(block) {
           : { baseColor: false },
       },
       onColorChangeEnd: () => pushCurrentPalette(),
+      onEditOpen: (index) => controller.setActiveSwatchIndex(index),
     });
     stripRenderer.render(stripWrapper);
     syncRailConflicts();

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -1013,16 +1013,14 @@ export const style = css`
   button.hex-code {
     background: none;
     border: none;
-    padding: 7px 12px;
+    padding-block: 7px;
+    padding-inline: 0;
     font: inherit;
     text-align: center;
-    width: 90px;
+    width: 75px;
     flex-shrink: 0;
     height: 32px;
     border-radius: var(--Corner-radius-corner-radius-100);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
   .swatch-column[data-contrast="dark"] button.hex-code:hover {
     background-color: rgba(255, 255, 255, 0.12);
@@ -1045,7 +1043,6 @@ export const style = css`
     outline-offset: 2px;
   }
   .hex-code--editable {
-    padding: 7px 12px;
     cursor: pointer;
   }
   .hex-code--copyable {

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -478,6 +478,7 @@ export const style = css`
   .swatch-rail[data-orientation="horizontal"] .hex-code {
     flex-shrink: 0;
     min-width: 0;
+    width: auto;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -1015,9 +1016,13 @@ export const style = css`
     padding: 7px 12px;
     font: inherit;
     text-align: center;
-    min-width: 75px;
+    width: 90px;
+    flex-shrink: 0;
     height: 32px;
     border-radius: var(--Corner-radius-corner-radius-100);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .swatch-column[data-contrast="dark"] button.hex-code:hover {
     background-color: rgba(255, 255, 255, 0.12);

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -236,16 +236,23 @@ class BaseColor extends LitElement {
     const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
 
     if (!this._hasOriginal) {
-      this._originalHue = hsb.hue;
-      this._originalSaturation = hsb.saturation;
       this._originalBrightness = hsb.brightness;
+      if (hsb.brightness > 0) {
+        this._originalHue = hsb.hue;
+        this._originalSaturation = hsb.saturation;
+      } else {
+        this._originalHue = this._hue;
+        this._originalSaturation = this._saturation;
+      }
       this._hasOriginal = true;
     }
 
     if (this.color.toUpperCase() === this._hex.toUpperCase()) return;
-    this._hue = hsb.hue;
-    this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    if (hsb.brightness > 0) {
+      this._hue = hsb.hue;
+      this._saturation = hsb.saturation;
+    }
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
   }
@@ -436,7 +443,7 @@ class BaseColor extends LitElement {
     if (!area) return;
 
     this._saturation = area.x * 100;
-    this._brightness = area.y * 100;
+    this._brightness = Math.max(1, area.y * 100);
     this._hexError = false;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -67,6 +67,7 @@ class BaseColor extends LitElement {
     this._originalHue = 0;
     this._originalSaturation = 0;
     this._originalBrightness = 0;
+    this._pickerInputEnabled = false;
   }
 
   get _rgb() {
@@ -123,7 +124,7 @@ class BaseColor extends LitElement {
     super.connectedCallback();
     loadButton();
     this._menuLoadPromise = loadMenu();
-    loadColorArea();
+    this._colorAreaReady = loadColorArea();
     loadColorSlider();
     loadTextfield();
     this._closeMenuOnOutsideClick = (e) => {
@@ -150,11 +151,29 @@ class BaseColor extends LitElement {
     super.disconnectedCallback();
   }
 
-  updated(changed) {
+  willUpdate(changed) {
     if (changed.has('color') || !this._hasOriginal) {
       this._syncFromColor();
     }
+  }
+
+  updated() {
     this._updateOriginalDots();
+    if (!this._colorAreaInitSynced) {
+      this._colorAreaInitSynced = true;
+      this._syncColorAreaAfterInit();
+    }
+  }
+
+  async _syncColorAreaAfterInit() {
+    await this._colorAreaReady;
+    const area = this.renderRoot.querySelector('sp-color-area');
+    if (!area) return;
+    await area.updateComplete;
+    if (this._pickerInputEnabled) return;
+    area.x = this._saturation / 100;
+    area.y = this._brightness / 100;
+    area.hue = this._hue;
   }
 
   _ensureDotStyles(shadowRoot) {
@@ -235,24 +254,27 @@ class BaseColor extends LitElement {
     if (!rgb) return;
     const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
 
-    if (!this._hasOriginal) {
-      this._originalBrightness = hsb.brightness;
-      if (hsb.brightness > 0) {
-        this._originalHue = hsb.hue;
-        this._originalSaturation = hsb.saturation;
-      } else {
+    if (this.color.toUpperCase() === this._hex.toUpperCase()) {
+      if (!this._hasOriginal) {
         this._originalHue = this._hue;
         this._originalSaturation = this._saturation;
+        this._originalBrightness = this._brightness;
+        this._hasOriginal = true;
       }
+      return;
+    }
+
+    this._hue = hsb.hue;
+    this._saturation = hsb.saturation;
+    this._brightness = hsb.brightness;
+
+    if (!this._hasOriginal) {
+      this._originalHue = hsb.hue;
+      this._originalSaturation = hsb.saturation;
+      this._originalBrightness = hsb.brightness;
       this._hasOriginal = true;
     }
 
-    if (this.color.toUpperCase() === this._hex.toUpperCase()) return;
-    this._brightness = hsb.brightness;
-    if (hsb.brightness > 0) {
-      this._hue = hsb.hue;
-      this._saturation = hsb.saturation;
-    }
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
   }
@@ -427,6 +449,11 @@ class BaseColor extends LitElement {
 
   _onPointerDown(e) {
     this._lastPointerType = e.pointerType;
+    this._pickerInputEnabled = true;
+  }
+
+  _onPickerKeyDown() {
+    this._pickerInputEnabled = true;
   }
 
   _blurOnTouch(target) {
@@ -439,11 +466,12 @@ class BaseColor extends LitElement {
   // --- Color area (Saturation/Brightness) ---
 
   _onColorAreaInput(e) {
+    if (!this._pickerInputEnabled) return;
     const area = e.target;
     if (!area) return;
 
     this._saturation = area.x * 100;
-    this._brightness = Math.max(1, area.y * 100);
+    this._brightness = area.y * 100;
     this._hexError = false;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
@@ -459,6 +487,7 @@ class BaseColor extends LitElement {
   // --- Hue slider ---
 
   _onHueInput(e) {
+    if (!this._pickerInputEnabled) return;
     const slider = e.target;
     if (slider.value == null) return;
 
@@ -937,6 +966,7 @@ class BaseColor extends LitElement {
             .y=${this._brightness / 100}
             .hue=${this._hue}
             @pointerdown=${this._onPointerDown}
+            @keydown=${this._onPickerKeyDown}
             @input=${this._onColorAreaInput}
             @change=${this._onColorAreaChange}
           ></sp-color-area>
@@ -945,6 +975,7 @@ class BaseColor extends LitElement {
             gradient="hue"
             color=${currentColor}
             @pointerdown=${this._onPointerDown}
+            @keydown=${this._onPickerKeyDown}
             @input=${this._onHueInput}
             @change=${this._onHueInput}
           ></sp-color-slider>

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -166,7 +166,11 @@ class BaseColor extends LitElement {
   }
 
   async _syncColorAreaAfterInit() {
-    await this._colorAreaReady;
+    try {
+      await this._colorAreaReady;
+    } catch {
+      return;
+    }
     const area = this.renderRoot.querySelector('sp-color-area');
     if (!area) return;
     await area.updateComplete;

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -14,6 +14,11 @@ import '../color-channel-slider/index.js';
 
 const COLOR_MODES = ['HEX', 'RGB', 'HSB', 'Lab'];
 
+/** Snap hue slider to original when within this many degrees (wraps at 0/360). */
+const ORIGINAL_COLOR_HUE_SNAP_DEG = 10;
+/** Snap color area to original S/B when both axes are within this many percent points. */
+const ORIGINAL_COLOR_AREA_SNAP_PCT = 4;
+
 class BaseColor extends LitElement {
   static get styles() {
     return [style];
@@ -469,13 +474,32 @@ class BaseColor extends LitElement {
 
   // --- Color area (Saturation/Brightness) ---
 
+  _snapColorAreaToOriginal(area, saturation, brightness) {
+    if (!this._hasOriginal) return { saturation, brightness };
+    const ds = Math.abs(saturation - this._originalSaturation);
+    const db = Math.abs(brightness - this._originalBrightness);
+    if (ds > ORIGINAL_COLOR_AREA_SNAP_PCT || db > ORIGINAL_COLOR_AREA_SNAP_PCT) {
+      return { saturation, brightness };
+    }
+    const s = this._originalSaturation;
+    const b = this._originalBrightness;
+    if (area) {
+      area.x = s / 100;
+      area.y = b / 100;
+    }
+    return { saturation: s, brightness: b };
+  }
+
   _onColorAreaInput(e) {
     if (!this._pickerInputEnabled) return;
     const area = e.target;
     if (!area) return;
 
-    this._saturation = area.x * 100;
-    this._brightness = area.y * 100;
+    const rawS = area.x * 100;
+    const rawB = area.y * 100;
+    const snapped = this._snapColorAreaToOriginal(area, rawS, rawB);
+    this._saturation = snapped.saturation;
+    this._brightness = snapped.brightness;
     this._hexError = false;
     this._colorUpdatedFromPicker = true;
     this._labCache = null;
@@ -499,7 +523,10 @@ class BaseColor extends LitElement {
     if (this._hasOriginal) {
       const diff = Math.abs(hue - this._originalHue);
       const wrappedDiff = Math.min(diff, 360 - diff);
-      if (wrappedDiff <= 5) hue = this._originalHue;
+      if (wrappedDiff <= ORIGINAL_COLOR_HUE_SNAP_DEG) {
+        hue = this._originalHue;
+        slider.value = hue;
+      }
     }
 
     this._hue = hue;

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -61,7 +61,6 @@ class ColorEdit extends LitElement {
     loadSwatch();
     this._menuLoadPromise = loadMenu();
     loadTextfield();
-    this._syncFromPalette();
     this._closeMenuOnOutsideClick = (e) => {
       if (this._modeMenuOpen && !e.composedPath().includes(this.shadowRoot.querySelector('.ce-mode-wrap'))) {
         this._modeMenuOpen = false;
@@ -92,7 +91,7 @@ class ColorEdit extends LitElement {
     super.disconnectedCallback();
   }
 
-  updated(changed) {
+  willUpdate(changed) {
     if (changed.has('palette') || changed.has('selectedIndex')) {
       this._syncFromPalette();
     }
@@ -104,11 +103,9 @@ class ColorEdit extends LitElement {
     const rgb = hexToRGB(hex);
     if (!rgb) return;
     const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
+    this._hue = hsb.hue;
+    this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
-    if (hsb.brightness > 0) {
-      this._hue = hsb.hue;
-      this._saturation = hsb.saturation;
-    }
   }
 
   _emitColorChange() {
@@ -457,11 +454,9 @@ class ColorEdit extends LitElement {
       const rgb = hexToRGB(`#${hex}`);
       if (!rgb) return;
       const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
+      this._hue = hsb.hue;
+      this._saturation = hsb.saturation;
       this._brightness = hsb.brightness;
-      if (hsb.brightness > 0) {
-        this._hue = hsb.hue;
-        this._saturation = hsb.saturation;
-      }
       if (this.palette?.length) {
         const newPalette = [...this.palette];
         newPalette[this.selectedIndex] = this._hex;

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -104,9 +104,11 @@ class ColorEdit extends LitElement {
     const rgb = hexToRGB(hex);
     if (!rgb) return;
     const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
-    this._hue = hsb.hue;
-    this._saturation = hsb.saturation;
     this._brightness = hsb.brightness;
+    if (hsb.brightness > 0) {
+      this._hue = hsb.hue;
+      this._saturation = hsb.saturation;
+    }
   }
 
   _emitColorChange() {
@@ -455,9 +457,11 @@ class ColorEdit extends LitElement {
       const rgb = hexToRGB(`#${hex}`);
       if (!rgb) return;
       const hsb = rgbToHSB(rgb.red / 255, rgb.green / 255, rgb.blue / 255);
-      this._hue = hsb.hue;
-      this._saturation = hsb.saturation;
       this._brightness = hsb.brightness;
+      if (hsb.brightness > 0) {
+        this._hue = hsb.hue;
+        this._saturation = hsb.saturation;
+      }
       if (this.palette?.length) {
         const newPalette = [...this.palette];
         newPalette[this.selectedIndex] = this._hex;

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -527,7 +527,7 @@ export function createStripContainerRenderer(options) {
     : null;
 
   const colorBlindness = config?.colorBlindness === true;
-  const { onColorChangeEnd } = options;
+  const { onColorChangeEnd, onEditOpen } = options;
   const mobileQuery = typeof options.mobileBreakpointQuery === 'string'
     ? options.mobileBreakpointQuery
     : MOBILE_BREAKPOINT_QUERY;
@@ -600,6 +600,7 @@ export function createStripContainerRenderer(options) {
     anchorRectFromDetail = null,
   ) {
     closeActiveColorEditor();
+    onEditOpen?.(selectedIndex);
 
     const state = controller?.getState?.() || {};
     const palette = (state.swatches || []).map((swatch) => swatch?.hex).filter(Boolean);

--- a/express/code/scripts/color-shared/spectrum/components/express-tooltip.js
+++ b/express/code/scripts/color-shared/spectrum/components/express-tooltip.js
@@ -67,6 +67,13 @@ export async function createExpressTooltip(config) {
 
   theme.appendChild(tooltip);
 
+  Object.assign(theme.style, {
+    position: 'absolute',
+    width: '0',
+    height: '0',
+    overflow: 'hidden',
+  });
+
   const ariaLink = disableAria ? null : ariaDescribedBy(targetEl, tooltip);
 
   const controller = new AbortController();


### PR DESCRIPTION
## Summary

- **Fixed color-area picker syncing wrong values on initial load** — color-area now waits for its component to be ready before setting x/y/hue, preventing stale or incorrect initial state.
- **Preserved original color state correctly** — moved sync logic from `updated` to `willUpdate` lifecycle and ensured original HSB values are captured before any overwrite when the incoming color matches the current hex.
- **Guarded picker inputs until user interaction** — added a `_pickerInputEnabled` flag so `color-area` and `hue-slider` input events are ignored until the user explicitly interacts (pointer or keyboard), avoiding unwanted color resets during initialization.
- **Fixed hex-code button overflowing on swatch rail** — set a fixed `width: 90px` with `flex-shrink: 0` and added text truncation so the button no longer resizes with long hex values.
- **Synced active swatch index when opening color editor** — added an `onEditOpen` callback to the strip container renderer so the color-blindness block updates its active swatch when the editor opens, keeping the color-wheel marker in sync with the selected strip color.
- Tooltip sp-theme wrappers appended to document.body were block-level elements in normal document flow, rendering as white space below the footer — fixed by styling them with position: absolute; width: 0; height: 0; overflow: hidden so they don't affect layout while the popover-based tooltip content still renders correctly in the top layer.

---

## Jira Ticket

Resolves: [MWPW-186751](https://jira.corp.adobe.com/browse/MWPW-186751)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-accessibility |
| **After**   | https://color-blindness-bug-fixes--express-color--adobecom.aem.page/create/color-accessibility?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://color-blindness-bug-fixes--express-color--adobecom.aem.page/create/color-contrast-analyzer?martech=off
- https://color-blindness-bug-fixes--express-color--adobecom.aem.page/create/color-wheel?martech=off 

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
