### PR TITLE
[MWPW-192106] Color Explore Bug Fixes

### DIFF
--- a/express/code/blocks/color-explore/color-explore.css
+++ b/express/code/blocks/color-explore/color-explore.css
@@ -298,6 +298,8 @@
   outline: var(--border-width-2) solid var(--color-blue-800);
   outline-offset: var(--border-width-2);
   border-radius: var(--Corner-radius-corner-radius-100);
+  position: relative;
+  z-index: 2;
 }
 
 .color-explore .filters-desktop .filter-dropdown sp-theme {
@@ -349,6 +351,8 @@
   outline: var(--border-width-2) solid var(--color-blue-800);
   outline-offset: var(--border-width-2);
   border-radius: 8px;
+  position: relative;
+  z-index: 2;
 }
 
 .color-explore .filters-mobile__panel {

--- a/express/code/blocks/color-explore/color-explore.css
+++ b/express/code/blocks/color-explore/color-explore.css
@@ -23,6 +23,18 @@
   max-width: var(--block-wd-content-max-width);
 }
 
+.color-explore sp-theme {
+  display: block;
+}
+
+.color-explore > .ax-color-loading {
+  width: 100%;
+  max-width: var(--block-wd-content-max-width);
+  margin: 0 auto;
+  box-sizing: border-box;
+  padding: 0 var(--spacing-300) var(--spacing-600);
+}
+
 .color-explore-container {
   width: 100%;
   max-width: var(--block-wd-content-max-width);

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -15,6 +15,11 @@ import { loadIconsRail } from '../../scripts/color-shared/spectrum/load-spectrum
 
 const VARIANTS = { STRIPS: 'strips', GRADIENTS: 'gradients' };
 const VARIANT_CLASSES = { GRADIENTS: 'gradients', PALETTES: 'palettes' };
+const THEME_URL_PARAM = 'theme';
+const THEME_URL_QUERY_VALUE = {
+  [VARIANTS.GRADIENTS]: 'color-gradients',
+  [VARIANTS.STRIPS]: 'color-palettes',
+};
 const DEFAULTS = {
   variant: VARIANTS.STRIPS,
   initialLoad: 24,
@@ -83,6 +88,23 @@ function getVariantFromBlock(block) {
   if (block.classList.contains(VARIANT_CLASSES.GRADIENTS)) return VARIANTS.GRADIENTS;
   if (block.classList.contains(VARIANT_CLASSES.PALETTES)) return VARIANTS.STRIPS;
   return null;
+}
+
+function getVariantFromThemeUrlParam() {
+  if (typeof window === 'undefined') return null;
+  const t = new URLSearchParams(window.location.search).get(THEME_URL_PARAM);
+  if (t === THEME_URL_QUERY_VALUE[VARIANTS.GRADIENTS]) return VARIANTS.GRADIENTS;
+  if (t === THEME_URL_QUERY_VALUE[VARIANTS.STRIPS]) return VARIANTS.STRIPS;
+  return null;
+}
+
+function syncColorExploreThemeUrl(variant) {
+  if (typeof window === 'undefined') return;
+  const value = THEME_URL_QUERY_VALUE[variant];
+  if (!value) return;
+  const url = new URL(window.location.href);
+  url.searchParams.set(THEME_URL_PARAM, value);
+  window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
 }
 
 function isSwatchesMode(config) {
@@ -229,7 +251,7 @@ export default async function decorate(block) {
     const variantFromClass = getVariantFromBlock(block);
     const rows = [...block.children];
     const config = parseBlockConfig(rows, DEFAULTS);
-    if (variantFromClass) config.variant = variantFromClass;
+    config.variant = getVariantFromThemeUrlParam() ?? variantFromClass ?? config.variant;
 
     block.dataset.blockStatus = 'loading';
     block.replaceChildren();
@@ -301,6 +323,7 @@ export default async function decorate(block) {
       let filterInteractionSuppressUntil = 0;
       let isSearchActive = false;
       let currentColumnCount = getGridColumnCount();
+      let hasCompletedInitialModeMount = false;
 
       const setModeClasses = (variant) => {
         block.classList.remove(VARIANT_CLASSES.GRADIENTS, VARIANT_CLASSES.PALETTES);
@@ -392,6 +415,7 @@ export default async function decorate(block) {
           activeMode = VARIANTS.GRADIENTS;
           activeDataService = gradientsDataService;
           setModeClasses(VARIANTS.GRADIENTS);
+          if (hasCompletedInitialModeMount) syncColorExploreThemeUrl(VARIANTS.GRADIENTS);
           block.dispatchEvent(new CustomEvent('color-explore:mode-change', { detail: { mode: VARIANTS.GRADIENTS }, bubbles: true }));
 
           let gradientFilterHandler = null;
@@ -526,6 +550,7 @@ export default async function decorate(block) {
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
           }
 
+          if (!hasCompletedInitialModeMount) hasCompletedInitialModeMount = true;
           publishInstances();
         } finally {
           isMounting = false;
@@ -540,6 +565,7 @@ export default async function decorate(block) {
           activeMode = VARIANTS.STRIPS;
           activeDataService = palettesDataService;
           setModeClasses(VARIANTS.STRIPS);
+          if (hasCompletedInitialModeMount) syncColorExploreThemeUrl(VARIANTS.STRIPS);
           block.dispatchEvent(new CustomEvent('color-explore:mode-change', { detail: { mode: VARIANTS.STRIPS }, bubbles: true }));
 
           let stripsFilterHandler = null;
@@ -687,6 +713,7 @@ export default async function decorate(block) {
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
           }
 
+          if (!hasCompletedInitialModeMount) hasCompletedInitialModeMount = true;
           publishInstances();
         } finally {
           isMounting = false;

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -399,7 +399,13 @@ export default async function decorate(block) {
             (filters) => gradientFilterHandler?.(filters),
           );
 
-          allData = await activeDataService.fetchData();
+          const urlQuery = new URLSearchParams(window.location.search).get('q');
+          if (urlQuery) {
+            allData = await activeDataService.search(urlQuery);
+            isSearchActive = true;
+          } else {
+            allData = await activeDataService.fetchData();
+          }
           visibleCount = alignToFullRow(
             Math.min(config.initialLoad, allData.length),
             allData.length,
@@ -498,9 +504,10 @@ export default async function decorate(block) {
           };
           document.addEventListener('floating-search:submit', floatingSearchHandler);
 
-          const urlQuery = new URLSearchParams(window.location.search).get('q');
-          if (urlQuery) {
-            await floatingSearchHandler({ detail: { query: urlQuery } });
+          if (urlQuery && allData.length === 0) {
+            document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
+          } else if (urlQuery) {
+            document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
           }
 
           publishInstances();
@@ -526,7 +533,13 @@ export default async function decorate(block) {
             (filters) => stripsFilterHandler?.(filters),
           );
 
-          allData = await activeDataService.fetchData();
+          const urlQuery = new URLSearchParams(window.location.search).get('q');
+          if (urlQuery) {
+            allData = await activeDataService.search(urlQuery);
+            isSearchActive = true;
+          } else {
+            allData = await activeDataService.fetchData();
+          }
           const alignedCount = Math.min(config.initialLoad, allData.length);
           visibleCount = alignToFullRow(alignedCount, allData.length);
 
@@ -637,9 +650,10 @@ export default async function decorate(block) {
           };
           document.addEventListener('floating-search:submit', floatingSearchHandler);
 
-          const urlQuery = new URLSearchParams(window.location.search).get('q');
-          if (urlQuery) {
-            await floatingSearchHandler({ detail: { query: urlQuery } });
+          if (urlQuery && allData.length === 0) {
+            document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
+          } else if (urlQuery) {
+            document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
           }
 
           publishInstances();
@@ -661,10 +675,17 @@ export default async function decorate(block) {
       });
 
       (async () => {
-      const allData = await dataService.fetchData();
+      const urlQuery = new URLSearchParams(window.location.search).get('q');
+      let isSearchActive = false;
+      let allData;
+      if (urlQuery) {
+        allData = await dataService.search(urlQuery);
+        isSearchActive = true;
+      } else {
+        allData = await dataService.fetchData();
+      }
       const alignedCount = Math.min(config.initialLoad, allData.length);
       let visibleCount = alignToFullRow(alignedCount, allData.length);
-      let isSearchActive = false;
 
       let renderer;
       if (isSwatchesMode(config)) {
@@ -780,9 +801,10 @@ export default async function decorate(block) {
       };
       document.addEventListener('floating-search:submit', floatingHandler);
 
-      const urlQuery = new URLSearchParams(window.location.search).get('q');
-      if (urlQuery) {
-        await floatingHandler({ detail: { query: urlQuery } });
+      if (urlQuery && allData.length === 0) {
+        document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
+      } else if (urlQuery) {
+        document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
       }
 
       block.addEventListener('block-unload', () => {

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -401,8 +401,13 @@ export default async function decorate(block) {
 
           const urlQuery = new URLSearchParams(window.location.search).get('q');
           if (urlQuery) {
-            allData = await activeDataService.search(urlQuery);
-            isSearchActive = true;
+            const searchResults = await activeDataService.search(urlQuery);
+            if (searchResults.length > 0) {
+              allData = searchResults;
+              isSearchActive = true;
+            } else {
+              allData = await activeDataService.fetchData();
+            }
           } else {
             allData = await activeDataService.fetchData();
           }
@@ -486,9 +491,23 @@ export default async function decorate(block) {
 
           floatingSearchHandler = async (e) => {
             const { query } = e.detail;
-            isSearchActive = !!query;
             block.classList.add(CSS_CLASSES.LOADING);
-            allData = await activeDataService.search(query);
+            if (!query) {
+              isSearchActive = false;
+              allData = await activeDataService.fetchData();
+              document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+            } else {
+              const searchResults = await activeDataService.search(query);
+              if (searchResults.length === 0) {
+                isSearchActive = false;
+                allData = await activeDataService.fetchData();
+                document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
+              } else {
+                isSearchActive = true;
+                allData = searchResults;
+                document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+              }
+            }
             visibleCount = alignToFullRow(
               Math.min(config.initialLoad, allData.length),
               allData.length,
@@ -496,15 +515,10 @@ export default async function decorate(block) {
             await activeRenderer.update(allData.slice(0, visibleCount));
             updateLoadMoreState();
             block.classList.remove(CSS_CLASSES.LOADING);
-            if (query && allData.length === 0) {
-              document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
-            } else {
-              document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
-            }
           };
           document.addEventListener('floating-search:submit', floatingSearchHandler);
 
-          if (urlQuery && allData.length === 0) {
+          if (urlQuery && !isSearchActive) {
             document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
           } else if (urlQuery) {
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
@@ -535,8 +549,13 @@ export default async function decorate(block) {
 
           const urlQuery = new URLSearchParams(window.location.search).get('q');
           if (urlQuery) {
-            allData = await activeDataService.search(urlQuery);
-            isSearchActive = true;
+            const searchResults = await activeDataService.search(urlQuery);
+            if (searchResults.length > 0) {
+              allData = searchResults;
+              isSearchActive = true;
+            } else {
+              allData = await activeDataService.fetchData();
+            }
           } else {
             allData = await activeDataService.fetchData();
           }
@@ -632,9 +651,23 @@ export default async function decorate(block) {
 
           floatingSearchHandler = async (e) => {
             const { query } = e.detail;
-            isSearchActive = !!query;
             block.classList.add(CSS_CLASSES.LOADING);
-            allData = await activeDataService.search(query);
+            if (!query) {
+              isSearchActive = false;
+              allData = await activeDataService.fetchData();
+              document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+            } else {
+              const searchResults = await activeDataService.search(query);
+              if (searchResults.length === 0) {
+                isSearchActive = false;
+                allData = await activeDataService.fetchData();
+                document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
+              } else {
+                isSearchActive = true;
+                allData = searchResults;
+                document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+              }
+            }
             visibleCount = alignToFullRow(
               Math.min(config.initialLoad, allData.length),
               allData.length,
@@ -642,15 +675,10 @@ export default async function decorate(block) {
             activeRenderer.update(allData.slice(0, visibleCount));
             updateLoadMoreState();
             block.classList.remove(CSS_CLASSES.LOADING);
-            if (query && allData.length === 0) {
-              document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
-            } else {
-              document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
-            }
           };
           document.addEventListener('floating-search:submit', floatingSearchHandler);
 
-          if (urlQuery && allData.length === 0) {
+          if (urlQuery && !isSearchActive) {
             document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
           } else if (urlQuery) {
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
@@ -679,8 +707,13 @@ export default async function decorate(block) {
       let isSearchActive = false;
       let allData;
       if (urlQuery) {
-        allData = await dataService.search(urlQuery);
-        isSearchActive = true;
+        const searchResults = await dataService.search(urlQuery);
+        if (searchResults.length > 0) {
+          allData = searchResults;
+          isSearchActive = true;
+        } else {
+          allData = await dataService.fetchData();
+        }
       } else {
         allData = await dataService.fetchData();
       }
@@ -783,9 +816,23 @@ export default async function decorate(block) {
 
       const floatingHandler = async (e) => {
         const { query } = e.detail;
-        isSearchActive = !!query;
         block.classList.add(CSS_CLASSES.LOADING);
-        allData = await dataService.search(query);
+        if (!query) {
+          isSearchActive = false;
+          allData = await dataService.fetchData();
+          document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+        } else {
+          const searchResults = await dataService.search(query);
+          if (searchResults.length === 0) {
+            isSearchActive = false;
+            allData = await dataService.fetchData();
+            document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
+          } else {
+            isSearchActive = true;
+            allData = searchResults;
+            document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+          }
+        }
         visibleCount = alignToFullRow(
           Math.min(config.initialLoad, allData.length),
           allData.length,
@@ -793,15 +840,10 @@ export default async function decorate(block) {
         renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
         loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
         block.classList.remove(CSS_CLASSES.LOADING);
-        if (query && allData.length === 0) {
-          document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
-        } else {
-          document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
-        }
       };
       document.addEventListener('floating-search:submit', floatingHandler);
 
-      if (urlQuery && allData.length === 0) {
+      if (urlQuery && !isSearchActive) {
         document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
       } else if (urlQuery) {
         document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -231,8 +231,6 @@ export default async function decorate(block) {
     const config = parseBlockConfig(rows, DEFAULTS);
     if (variantFromClass) config.variant = variantFromClass;
 
-    loadStripSharedStyles();
-
     block.dataset.blockStatus = 'loading';
     block.replaceChildren();
     block.className = CSS_CLASSES.BLOCK;
@@ -262,12 +260,16 @@ export default async function decorate(block) {
       header.appendChild(titleEl);
       const section = document.createElement('section');
       section.className = 'explore-main-section';
-      const loadingScreen = createLoadingScreenComponent({ variant: 'gradients', cardCount: 6 });
+      const loadingScreen = createLoadingScreenComponent({
+        variant: isGradients ? 'gradients' : 'strips',
+        cardCount: 6,
+      });
       section.appendChild(loadingScreen.element);
       loadingScreen.show();
       container.replaceChildren(header, section);
     }
     showLoadingSkeleton();
+    await loadStripSharedStyles();
 
     if (config.variant === VARIANTS.GRADIENTS || config.variant === VARIANTS.STRIPS) {
       const gradientsDataService = createSharedColorDataService({
@@ -569,6 +571,7 @@ export default async function decorate(block) {
               ...config,
               variant: VARIANTS.STRIPS,
               renderGridVariant: 'summary',
+              initialActivationSuppressUntil: filterInteractionSuppressUntil,
             },
           });
           await activeRenderer.render?.(container);
@@ -691,9 +694,14 @@ export default async function decorate(block) {
       };
 
       const mountFn = activeMode === VARIANTS.GRADIENTS ? mountGradientsMode : mountStripsMode;
-      mountFn().catch((err) => {
-        window.lana?.log(`[ColorExplore] Mount error: ${err?.message}`, { tags: 'color-explore', severity: 'error' });
-      });
+      mountFn()
+        .then(() => {
+          block.dataset.blockStatus = 'loaded';
+        })
+        .catch((err) => {
+          window.lana?.log(`[ColorExplore] Mount error: ${err?.message}`, { tags: 'color-explore', severity: 'error' });
+          block.dataset.blockStatus = '';
+        });
     } else {
       const dataService = createSharedColorDataService({
         variant: config.variant,
@@ -857,8 +865,10 @@ export default async function decorate(block) {
       block.rendererInstance = renderer;
       block.modalManagerInstance = modalManager;
       block.dataServiceInstance = dataService;
+      block.dataset.blockStatus = 'loaded';
       })().catch((err) => {
         window.lana?.log(`[ColorExplore] Mount error: ${err?.message}`, { tags: 'color-explore', severity: 'error' });
+        block.dataset.blockStatus = '';
       });
     }
 

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -484,7 +484,7 @@ export default async function decorate(block) {
               return;
             }
             block.classList.add(CSS_CLASSES.LOADING);
-            allData = activeDataService.filter(filters);
+            allData = await activeDataService.filter(filters);
             visibleCount = alignToFullRow(
               Math.min(config.initialLoad, allData.length),
               allData.length,
@@ -616,7 +616,7 @@ export default async function decorate(block) {
               return;
             }
             block.classList.add(CSS_CLASSES.LOADING);
-            allData = activeDataService.filter(filters);
+            allData = await activeDataService.filter(filters);
             visibleCount = alignToFullRow(
               Math.min(config.initialLoad, allData.length),
               allData.length,

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -9,6 +9,7 @@ import { createGradientModalContent, ensureGradientModalContentStyles } from '..
 import { createColorDataService as createSharedColorDataService } from '../../scripts/color-shared/services/createColorDataService.js';
 import { buildPaletteEditUrl } from '../../scripts/color-shared/utils/utilities.js';
 import { createFiltersComponent } from '../../scripts/color-shared/components/createFiltersComponent.js';
+import { createLoadingScreenComponent } from '../../scripts/color-shared/components/createLoadingScreenComponent.js';
 import loadMiloStyle from '../../scripts/color-shared/utils/loadMiloStyle.js';
 import { loadIconsRail } from '../../scripts/color-shared/spectrum/load-spectrum.js';
 
@@ -213,6 +214,7 @@ async function createBlockFilterControl(container, variant, onFilterChange) {
   }
 
   return {
+    element: filters.element,
     destroy() {
       filters.reset?.();
       filters.element?.remove?.();
@@ -229,7 +231,7 @@ export default async function decorate(block) {
     const config = parseBlockConfig(rows, DEFAULTS);
     if (variantFromClass) config.variant = variantFromClass;
 
-    await loadStripSharedStyles();
+    loadStripSharedStyles();
 
     block.dataset.blockStatus = 'loading';
     block.replaceChildren();
@@ -249,6 +251,23 @@ export default async function decorate(block) {
     const container = document.createElement('div');
     container.className = CSS_CLASSES.CONTAINER;
     themeHost.appendChild(container);
+
+    const isGradients = config.variant === VARIANTS.GRADIENTS;
+    function showLoadingSkeleton() {
+      const header = document.createElement('div');
+      header.className = 'explore-header';
+      const titleEl = document.createElement(isGradients ? 'h2' : 'span');
+      titleEl.className = isGradients ? 'gradients-title' : 'results-count';
+      titleEl.textContent = '\u00a0';
+      header.appendChild(titleEl);
+      const section = document.createElement('section');
+      section.className = 'explore-main-section';
+      const loadingScreen = createLoadingScreenComponent({ variant: 'gradients', cardCount: 6 });
+      section.appendChild(loadingScreen.element);
+      loadingScreen.show();
+      container.replaceChildren(header, section);
+    }
+    showLoadingSkeleton();
 
     if (config.variant === VARIANTS.GRADIENTS || config.variant === VARIANTS.STRIPS) {
       const gradientsDataService = createSharedColorDataService({
@@ -373,12 +392,14 @@ export default async function decorate(block) {
           setModeClasses(VARIANTS.GRADIENTS);
           block.dispatchEvent(new CustomEvent('color-explore:mode-change', { detail: { mode: VARIANTS.GRADIENTS }, bubbles: true }));
 
-          block.classList.add(CSS_CLASSES.LOADING);
-          try {
-            allData = await activeDataService.fetchData();
-          } finally {
-            block.classList.remove(CSS_CLASSES.LOADING);
-          }
+          let gradientFilterHandler = null;
+          filtersControl = await createBlockFilterControl(
+            container,
+            VARIANTS.GRADIENTS,
+            (filters) => gradientFilterHandler?.(filters),
+          );
+
+          allData = await activeDataService.fetchData();
           visibleCount = alignToFullRow(
             Math.min(config.initialLoad, allData.length),
             allData.length,
@@ -411,28 +432,30 @@ export default async function decorate(block) {
 
           await activeRenderer.render();
 
+          const gradientHeader = container.querySelector('.explore-header, .gradients-header');
+          if (gradientHeader && filtersControl?.element) {
+            gradientHeader.querySelectorAll(':scope > .filters-container').forEach((n) => n.remove());
+            gradientHeader.appendChild(filtersControl.element);
+          }
+
           // Explore contract: filters are always rendered for gradients/palettes.
-          filtersControl = await createBlockFilterControl(
-            container,
-            VARIANTS.GRADIENTS,
-            async (filters) => {
-              filterInteractionSuppressUntil = Date.now() + 350;
-              isSearchActive = false;
-              if (filters?.contentType === 'color-palettes') {
-                await mountStripsMode();
-                return;
-              }
-              block.classList.add(CSS_CLASSES.LOADING);
-              allData = await activeDataService.filter(filters);
-              visibleCount = alignToFullRow(
-                Math.min(config.initialLoad, allData.length),
-                allData.length,
-              );
-              await activeRenderer.update(allData.slice(0, visibleCount));
-              updateLoadMoreState();
-              block.classList.remove(CSS_CLASSES.LOADING);
-            },
-          );
+          gradientFilterHandler = async (filters) => {
+            filterInteractionSuppressUntil = Date.now() + 350;
+            isSearchActive = false;
+            if (filters?.contentType === 'color-palettes') {
+              await mountStripsMode();
+              return;
+            }
+            block.classList.add(CSS_CLASSES.LOADING);
+            allData = activeDataService.filter(filters);
+            visibleCount = alignToFullRow(
+              Math.min(config.initialLoad, allData.length),
+              allData.length,
+            );
+            await activeRenderer.update(allData.slice(0, visibleCount));
+            updateLoadMoreState();
+            block.classList.remove(CSS_CLASSES.LOADING);
+          };
 
           loadMoreControl = await createBlockLoadMoreControl(container, async () => {
             const nextTarget = visibleCount + Math.max(1, Number(config.loadMoreIncrement) || 10);
@@ -496,12 +519,14 @@ export default async function decorate(block) {
           setModeClasses(VARIANTS.STRIPS);
           block.dispatchEvent(new CustomEvent('color-explore:mode-change', { detail: { mode: VARIANTS.STRIPS }, bubbles: true }));
 
-          block.classList.add(CSS_CLASSES.LOADING);
-          try {
-            allData = await activeDataService.fetchData();
-          } finally {
-            block.classList.remove(CSS_CLASSES.LOADING);
-          }
+          let stripsFilterHandler = null;
+          filtersControl = await createBlockFilterControl(
+            container,
+            VARIANTS.STRIPS,
+            (filters) => stripsFilterHandler?.(filters),
+          );
+
+          allData = await activeDataService.fetchData();
           const alignedCount = Math.min(config.initialLoad, allData.length);
           visibleCount = alignToFullRow(alignedCount, allData.length);
 
@@ -516,27 +541,29 @@ export default async function decorate(block) {
           });
           await activeRenderer.render?.(container);
 
-          filtersControl = await createBlockFilterControl(
-            container,
-            VARIANTS.STRIPS,
-            async (filters) => {
-              filterInteractionSuppressUntil = Date.now() + 350;
-              isSearchActive = false;
-              if (filters?.contentType === 'color-gradients') {
-                await mountGradientsMode();
-                return;
-              }
-              block.classList.add(CSS_CLASSES.LOADING);
-              allData = await activeDataService.filter(filters);
-              visibleCount = alignToFullRow(
-                Math.min(config.initialLoad, allData.length),
-                allData.length,
-              );
-              activeRenderer.update(allData.slice(0, visibleCount));
-              updateLoadMoreState();
-              block.classList.remove(CSS_CLASSES.LOADING);
-            },
-          );
+          const stripsHeader = container.querySelector('.explore-header, .gradients-header');
+          if (stripsHeader && filtersControl?.element) {
+            stripsHeader.querySelectorAll(':scope > .filters-container').forEach((n) => n.remove());
+            stripsHeader.appendChild(filtersControl.element);
+          }
+
+          stripsFilterHandler = async (filters) => {
+            filterInteractionSuppressUntil = Date.now() + 350;
+            isSearchActive = false;
+            if (filters?.contentType === 'color-gradients') {
+              await mountGradientsMode();
+              return;
+            }
+            block.classList.add(CSS_CLASSES.LOADING);
+            allData = activeDataService.filter(filters);
+            visibleCount = alignToFullRow(
+              Math.min(config.initialLoad, allData.length),
+              allData.length,
+            );
+            activeRenderer.update(allData.slice(0, visibleCount));
+            updateLoadMoreState();
+            block.classList.remove(CSS_CLASSES.LOADING);
+          };
 
           loadMoreControl = await createBlockLoadMoreControl(container, async () => {
             const nextTarget = visibleCount + Math.max(1, Number(config.loadMoreIncrement) || 10);
@@ -621,11 +648,10 @@ export default async function decorate(block) {
         }
       };
 
-      if (activeMode === VARIANTS.GRADIENTS) {
-        await mountGradientsMode();
-      } else {
-        await mountStripsMode();
-      }
+      const mountFn = activeMode === VARIANTS.GRADIENTS ? mountGradientsMode : mountStripsMode;
+      mountFn().catch((err) => {
+        window.lana?.log(`[ColorExplore] Mount error: ${err?.message}`, { tags: 'color-explore', severity: 'error' });
+      });
     } else {
       const dataService = createSharedColorDataService({
         variant: config.variant,
@@ -634,12 +660,11 @@ export default async function decorate(block) {
         apiEndpoint: config.apiEndpoint,
       });
 
-      block.classList.add(CSS_CLASSES.LOADING);
-      let allData = await dataService.fetchData();
+      (async () => {
+      const allData = await dataService.fetchData();
       const alignedCount = Math.min(config.initialLoad, allData.length);
       let visibleCount = alignToFullRow(alignedCount, allData.length);
       let isSearchActive = false;
-      block.classList.remove(CSS_CLASSES.LOADING);
 
       let renderer;
       if (isSwatchesMode(config)) {
@@ -651,7 +676,7 @@ export default async function decorate(block) {
           config,
         });
       }
-      await renderer.render?.(container);
+      if (renderer.render) renderer.render(container);
       const loadMoreControl = !isSwatchesMode(config)
         ? await createBlockLoadMoreControl(container, async () => {
           const nextTarget = visibleCount + Math.max(1, Number(config.loadMoreIncrement) || 10);
@@ -768,9 +793,11 @@ export default async function decorate(block) {
       block.rendererInstance = renderer;
       block.modalManagerInstance = modalManager;
       block.dataServiceInstance = dataService;
+      })().catch((err) => {
+        window.lana?.log(`[ColorExplore] Mount error: ${err?.message}`, { tags: 'color-explore', severity: 'error' });
+      });
     }
 
-    block.dataset.blockStatus = 'loaded';
     trackColorBlockLoad('color-explore');
   } catch (error) {
     window.lana?.log(`[ColorExplore] ❌ Error: ${error}`, { tags: 'color-explore', severity: 'error' });

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -273,7 +273,7 @@ export default async function decorate(block) {
     themeHost.appendChild(container);
 
     const isGradients = config.variant === VARIANTS.GRADIENTS;
-    function showLoadingSkeleton() {
+    const showLoadingSkeleton = () => {
       const header = document.createElement('div');
       header.className = 'explore-header';
       const titleEl = document.createElement(isGradients ? 'h2' : 'span');
@@ -289,7 +289,7 @@ export default async function decorate(block) {
       section.appendChild(loadingScreen.element);
       loadingScreen.show();
       container.replaceChildren(header, section);
-    }
+    };
     showLoadingSkeleton();
     await loadStripSharedStyles();
 
@@ -738,161 +738,161 @@ export default async function decorate(block) {
       });
 
       (async () => {
-      const urlQuery = new URLSearchParams(window.location.search).get('q');
-      let isSearchActive = false;
-      let allData;
-      if (urlQuery) {
-        const searchResults = await dataService.search(urlQuery);
-        if (searchResults.length > 0) {
-          allData = searchResults;
-          isSearchActive = true;
-        } else {
-          allData = await dataService.fetchData();
-        }
-      } else {
-        allData = await dataService.fetchData();
-      }
-      const alignedCount = Math.min(config.initialLoad, allData.length);
-      let visibleCount = alignToFullRow(alignedCount, allData.length);
-
-      let renderer;
-      if (isSwatchesMode(config)) {
-        renderer = createSwatchesRenderer({ container, data: allData, config });
-      } else {
-        renderer = createStripsRenderer({
-          container,
-          data: allData.slice(0, visibleCount),
-          config,
-        });
-      }
-      if (renderer.render) renderer.render(container);
-      const loadMoreControl = !isSwatchesMode(config)
-        ? await createBlockLoadMoreControl(container, async () => {
-          const nextTarget = visibleCount + Math.max(1, Number(config.loadMoreIncrement) || 10);
-          if (nextTarget > allData.length) {
-            const moreData = isSearchActive
-              ? await dataService.searchMore()
-              : await dataService.loadMore();
-            allData = mergeLoadMoreData(allData, moreData);
+        const urlQuery = new URLSearchParams(window.location.search).get('q');
+        let isSearchActive = false;
+        let allData;
+        if (urlQuery) {
+          const searchResults = await dataService.search(urlQuery);
+          if (searchResults.length > 0) {
+            allData = searchResults;
+            isSearchActive = true;
+          } else {
+            allData = await dataService.fetchData();
           }
-          visibleCount = alignToFullRow(Math.min(nextTarget, allData.length), allData.length);
-          renderer.update(allData.slice(0, visibleCount));
-          loadMoreControl.update(Math.max(0, allData.length - visibleCount));
-        }, { iconSize: config.loadMoreIconSize || 'xl' })
-        : null;
-      loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
-
-      let elseCurrentColumnCount = getGridColumnCount();
-      const elseResizeObserver = new ResizeObserver(() => {
-        const newCols = getGridColumnCount();
-        if (newCols === elseCurrentColumnCount || isSwatchesMode(config)) return;
-        elseCurrentColumnCount = newCols;
-        const aligned = alignToFullRow(visibleCount, allData.length);
-        if (aligned !== visibleCount) {
-          visibleCount = aligned;
-          renderer.update(allData.slice(0, visibleCount));
-          loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
-        }
-      });
-      elseResizeObserver.observe(container);
-
-      const modalManager = createModalManager();
-
-      renderer.on(EVENTS.PALETTE_CLICK, async (palette) => {
-        await modalManager.openPaletteSwatchesModal(
-          palette || {},
-          {
-            verticalMaxPerRow: config.swatchVerticalMaxPerRow,
-            onLikeToggle: async ({ id, liked }) => dataService.toggleLike({ id, liked }),
-          },
-        );
-      });
-      renderer.on(EVENTS.PALETTE_EDIT, (palette) => {
-        const colors = palette?.colors || [];
-        const name = palette?.name || '';
-        const editUrl = buildPaletteEditUrl('/create/color-wheel', colors, name);
-        window.location.href = editUrl;
-      });
-      renderer.on(EVENTS.SHARE, async ({ palette }) => {
-        await modalManager.openPaletteSwatchesModal(
-          palette || {},
-          {
-            verticalMaxPerRow: config.swatchVerticalMaxPerRow,
-            onLikeToggle: async ({ id, liked }) => dataService.toggleLike({ id, liked }),
-          },
-        );
-      });
-
-      renderer.on(EVENTS.SEARCH, async ({ query }) => {
-        isSearchActive = !!query;
-        block.classList.add(CSS_CLASSES.LOADING);
-        allData = await dataService.search(query);
-        visibleCount = alignToFullRow(
-          Math.min(config.initialLoad, allData.length),
-          allData.length,
-        );
-        renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
-        loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
-        block.classList.remove(CSS_CLASSES.LOADING);
-      });
-
-      renderer.on(EVENTS.FILTER, async (filters) => {
-        isSearchActive = false;
-        block.classList.add(CSS_CLASSES.LOADING);
-        allData = await dataService.filter(filters);
-        visibleCount = alignToFullRow(
-          Math.min(config.initialLoad, allData.length),
-          allData.length,
-        );
-        renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
-        loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
-        block.classList.remove(CSS_CLASSES.LOADING);
-      });
-
-      const floatingHandler = async (e) => {
-        const { query } = e.detail;
-        block.classList.add(CSS_CLASSES.LOADING);
-        if (!query) {
-          isSearchActive = false;
-          allData = await dataService.fetchData();
-          document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
         } else {
-          const searchResults = await dataService.search(query);
-          if (searchResults.length === 0) {
+          allData = await dataService.fetchData();
+        }
+        const alignedCount = Math.min(config.initialLoad, allData.length);
+        let visibleCount = alignToFullRow(alignedCount, allData.length);
+
+        let renderer;
+        if (isSwatchesMode(config)) {
+          renderer = createSwatchesRenderer({ container, data: allData, config });
+        } else {
+          renderer = createStripsRenderer({
+            container,
+            data: allData.slice(0, visibleCount),
+            config,
+          });
+        }
+        if (renderer.render) renderer.render(container);
+        const loadMoreControl = !isSwatchesMode(config)
+          ? await createBlockLoadMoreControl(container, async () => {
+            const nextTarget = visibleCount + Math.max(1, Number(config.loadMoreIncrement) || 10);
+            if (nextTarget > allData.length) {
+              const moreData = isSearchActive
+                ? await dataService.searchMore()
+                : await dataService.loadMore();
+              allData = mergeLoadMoreData(allData, moreData);
+            }
+            visibleCount = alignToFullRow(Math.min(nextTarget, allData.length), allData.length);
+            renderer.update(allData.slice(0, visibleCount));
+            loadMoreControl.update(Math.max(0, allData.length - visibleCount));
+          }, { iconSize: config.loadMoreIconSize || 'xl' })
+          : null;
+        loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
+
+        let elseCurrentColumnCount = getGridColumnCount();
+        const elseResizeObserver = new ResizeObserver(() => {
+          const newCols = getGridColumnCount();
+          if (newCols === elseCurrentColumnCount || isSwatchesMode(config)) return;
+          elseCurrentColumnCount = newCols;
+          const aligned = alignToFullRow(visibleCount, allData.length);
+          if (aligned !== visibleCount) {
+            visibleCount = aligned;
+            renderer.update(allData.slice(0, visibleCount));
+            loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
+          }
+        });
+        elseResizeObserver.observe(container);
+
+        const modalManager = createModalManager();
+
+        renderer.on(EVENTS.PALETTE_CLICK, async (palette) => {
+          await modalManager.openPaletteSwatchesModal(
+            palette || {},
+            {
+              verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+              onLikeToggle: async ({ id, liked }) => dataService.toggleLike({ id, liked }),
+            },
+          );
+        });
+        renderer.on(EVENTS.PALETTE_EDIT, (palette) => {
+          const colors = palette?.colors || [];
+          const name = palette?.name || '';
+          const editUrl = buildPaletteEditUrl('/create/color-wheel', colors, name);
+          window.location.href = editUrl;
+        });
+        renderer.on(EVENTS.SHARE, async ({ palette }) => {
+          await modalManager.openPaletteSwatchesModal(
+            palette || {},
+            {
+              verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+              onLikeToggle: async ({ id, liked }) => dataService.toggleLike({ id, liked }),
+            },
+          );
+        });
+
+        renderer.on(EVENTS.SEARCH, async ({ query }) => {
+          isSearchActive = !!query;
+          block.classList.add(CSS_CLASSES.LOADING);
+          allData = await dataService.search(query);
+          visibleCount = alignToFullRow(
+            Math.min(config.initialLoad, allData.length),
+            allData.length,
+          );
+          renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
+          loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
+          block.classList.remove(CSS_CLASSES.LOADING);
+        });
+
+        renderer.on(EVENTS.FILTER, async (filters) => {
+          isSearchActive = false;
+          block.classList.add(CSS_CLASSES.LOADING);
+          allData = await dataService.filter(filters);
+          visibleCount = alignToFullRow(
+            Math.min(config.initialLoad, allData.length),
+            allData.length,
+          );
+          renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
+          loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
+          block.classList.remove(CSS_CLASSES.LOADING);
+        });
+
+        const floatingHandler = async (e) => {
+          const { query } = e.detail;
+          block.classList.add(CSS_CLASSES.LOADING);
+          if (!query) {
             isSearchActive = false;
             allData = await dataService.fetchData();
-            document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
-          } else {
-            isSearchActive = true;
-            allData = searchResults;
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+          } else {
+            const searchResults = await dataService.search(query);
+            if (searchResults.length === 0) {
+              isSearchActive = false;
+              allData = await dataService.fetchData();
+              document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query }, bubbles: true }));
+            } else {
+              isSearchActive = true;
+              allData = searchResults;
+              document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
+            }
           }
+          visibleCount = alignToFullRow(
+            Math.min(config.initialLoad, allData.length),
+            allData.length,
+          );
+          renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
+          loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
+          block.classList.remove(CSS_CLASSES.LOADING);
+        };
+        document.addEventListener('floating-search:submit', floatingHandler);
+
+        if (urlQuery && !isSearchActive) {
+          document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
+        } else if (urlQuery) {
+          document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
         }
-        visibleCount = alignToFullRow(
-          Math.min(config.initialLoad, allData.length),
-          allData.length,
-        );
-        renderer.update(isSwatchesMode(config) ? allData : allData.slice(0, visibleCount));
-        loadMoreControl?.update(Math.max(0, allData.length - visibleCount));
-        block.classList.remove(CSS_CLASSES.LOADING);
-      };
-      document.addEventListener('floating-search:submit', floatingHandler);
 
-      if (urlQuery && !isSearchActive) {
-        document.dispatchEvent(new CustomEvent('color-explore:empty-result', { detail: { query: urlQuery }, bubbles: true }));
-      } else if (urlQuery) {
-        document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
-      }
+        block.addEventListener('block-unload', () => {
+          elseResizeObserver.disconnect();
+          document.removeEventListener('floating-search:submit', floatingHandler);
+        }, { once: true });
 
-      block.addEventListener('block-unload', () => {
-        elseResizeObserver.disconnect();
-        document.removeEventListener('floating-search:submit', floatingHandler);
-      }, { once: true });
-
-      block.rendererInstance = renderer;
-      block.modalManagerInstance = modalManager;
-      block.dataServiceInstance = dataService;
-      block.dataset.blockStatus = 'loaded';
+        block.rendererInstance = renderer;
+        block.modalManagerInstance = modalManager;
+        block.dataServiceInstance = dataService;
+        block.dataset.blockStatus = 'loaded';
       })().catch((err) => {
         window.lana?.log(`[ColorExplore] Mount error: ${err?.message}`, { tags: 'color-explore', severity: 'error' });
         block.dataset.blockStatus = '';

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -18,7 +18,7 @@ const VARIANT_CLASSES = { GRADIENTS: 'gradients', PALETTES: 'palettes' };
 const DEFAULTS = {
   variant: VARIANTS.STRIPS,
   initialLoad: 24,
-  loadMoreIncrement: 10,
+  loadMoreIncrement: 12,
   maxItems: 100,
   enableFilters: true,
   enableSearch: true,

--- a/express/code/blocks/color-explore/renderers/createGradientsRenderer.js
+++ b/express/code/blocks/color-explore/renderers/createGradientsRenderer.js
@@ -4,6 +4,7 @@ import { createGradientStripElements } from '../../../scripts/color-shared/compo
 import { createLoadMoreComponent } from '../../../scripts/color-shared/components/createLoadMoreComponent.js';
 import { loadIconsRail } from '../../../scripts/color-shared/spectrum/load-spectrum.js';
 import { createExpressTooltip } from '../../../scripts/color-shared/spectrum/components/express-tooltip.js';
+import { createLoadingScreenComponent } from '../../../scripts/color-shared/components/createLoadingScreenComponent.js';
 
 const PAGINATION = {
   INITIAL_COUNT: 24,
@@ -708,6 +709,13 @@ export function createGradientsRenderer(options) {
     if (isInitialRender) {
       container.addEventListener('color-explore:filter-interaction', onFilterInteraction);
       container.replaceChildren();
+
+      gradientsSection = createTag('section', { class: 'explore-main-section' });
+      const loadingScreen = createLoadingScreenComponent({ variant: 'strips', cardCount: 6 });
+      gradientsSection.appendChild(loadingScreen.element);
+      loadingScreen.show();
+      container.appendChild(gradientsSection);
+
       await loadIconsRail();
 
       const header = createTag('div', { class: 'explore-header' });
@@ -715,9 +723,9 @@ export function createGradientsRenderer(options) {
       const countLabel = formatCount(allGradients.length);
       title.textContent = `${countLabel} color gradients`;
       header.appendChild(title);
-      container.appendChild(header);
+      container.insertBefore(header, gradientsSection);
 
-      gradientsSection = createTag('section', { class: 'explore-main-section' });
+      gradientsSection.replaceChildren();
 
       const columns = getGridColumns();
       const rows = Math.ceil(allGradients.length / columns);

--- a/express/code/blocks/color-explore/renderers/createGradientsRenderer.js
+++ b/express/code/blocks/color-explore/renderers/createGradientsRenderer.js
@@ -18,10 +18,6 @@ function sanitizeAnalyticsText(value, max = 20) {
   return raw.substring(0, max);
 }
 
-function formatCount(n) {
-  return n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
-}
-
 export function createGradientsRenderer(options) {
   const { container, data = [], config = {} } = options;
 
@@ -65,7 +61,7 @@ export function createGradientsRenderer(options) {
 
   function getAnalyticsHeaderText() {
     const titleText = container?.querySelector('.gradients-title')?.textContent?.trim();
-    const fallback = `${formatCount(allGradients.length)} color gradients`;
+    const fallback = 'Color gradients';
     return sanitizeAnalyticsText(titleText || fallback);
   }
 
@@ -654,8 +650,7 @@ export function createGradientsRenderer(options) {
   function updateTitle() {
     const title = container?.querySelector('.gradients-title');
     if (title) {
-      const countLabel = formatCount(allGradients.length);
-      title.textContent = `${countLabel} color gradients`;
+      title.textContent = 'Color gradients';
     }
   }
 
@@ -720,8 +715,7 @@ export function createGradientsRenderer(options) {
 
       const header = createTag('div', { class: 'explore-header' });
       const title = createTag('h2', { class: 'gradients-title' });
-      const countLabel = formatCount(allGradients.length);
-      title.textContent = `${countLabel} color gradients`;
+      title.textContent = 'Color gradients';
       header.appendChild(title);
       container.insertBefore(header, gradientsSection);
 

--- a/express/code/blocks/color-search-marquee/color-search-marquee.css
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.css
@@ -54,7 +54,6 @@
   max-width: none;
   min-width: 0;
   overflow: hidden;
-  padding-block: 6px;
   margin-block: -6px;
   margin-inline: calc(-1 * var(--spacing-300));
 }
@@ -68,6 +67,7 @@
   -ms-overflow-style: none;
   width: 100%;
   box-sizing: border-box;
+  padding-block: 6px;
 }
 
 .color-search-marquee .tags-container::-webkit-scrollbar {

--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -170,8 +170,6 @@ export function setupStickyBounds(block, searchBar) {
   endObserver.observe(endSentinel);
   window.addEventListener('resize', evaluateStickyGate, { passive: true });
 
-  evaluateStickyGate();
-
   return () => {
     endObserver.disconnect();
     window.removeEventListener('resize', evaluateStickyGate);

--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -159,6 +159,15 @@ export function setupStickyBounds(block, searchBar) {
     setStickyEnabled(!shouldDisableSticky);
   };
 
+  let layoutGateRaf = 0;
+  const scheduleEvaluateStickyGate = () => {
+    if (layoutGateRaf) cancelAnimationFrame(layoutGateRaf);
+    layoutGateRaf = requestAnimationFrame(() => {
+      layoutGateRaf = 0;
+      evaluateStickyGate();
+    });
+  };
+
   const endObserver = new IntersectionObserver(() => {
     evaluateStickyGate();
   }, {
@@ -170,7 +179,12 @@ export function setupStickyBounds(block, searchBar) {
   endObserver.observe(endSentinel);
   window.addEventListener('resize', evaluateStickyGate, { passive: true });
 
+  const exploreLayoutObserver = new ResizeObserver(scheduleEvaluateStickyGate);
+  exploreLayoutObserver.observe(colorExploreBlock);
+
   return () => {
+    if (layoutGateRaf) cancelAnimationFrame(layoutGateRaf);
+    exploreLayoutObserver.disconnect();
     endObserver.disconnect();
     window.removeEventListener('resize', evaluateStickyGate);
     endSentinel.remove();

--- a/express/code/libs/color-components/components/color-palette-icon-button/styles.css.js
+++ b/express/code/libs/color-components/components/color-palette-icon-button/styles.css.js
@@ -44,7 +44,7 @@ export const style = css`
         content: '';
         position: absolute;
         inset: 0;
-        border: var(--color-palette-border-width, 2px) solid var(--color-palette-border-color, #0000001A);
+        border: var(--color-palette-border-width) solid var(--color-palette-border-color);
         border-radius: var(--color-palette-border-radius, 8px);
     }
 

--- a/express/code/libs/color-components/components/color-palette/styles.css.js
+++ b/express/code/libs/color-components/components/color-palette/styles.css.js
@@ -55,7 +55,7 @@ export const style = css`
         content: '';
         position: absolute;
         inset: 0;
-        border: var(--color-palette-border-width, 2px) solid var(--color-palette-border-color, #0000001A);
+        border: var(--color-palette-border-width) solid var(--color-palette-border-color);
         border-radius: var(--color-palette-border-radius, 8px);
     }
 

--- a/express/code/scripts/color-shared/components/createLoadingScreenComponent.js
+++ b/express/code/scripts/color-shared/components/createLoadingScreenComponent.js
@@ -82,8 +82,8 @@ export function createLoadingScreenComponent(options = {}) {
     element: root,
     setVariant,
     setCardCount,
-    async show() {
-      await loadLoadingScreenStyles();
+    show() {
+      loadLoadingScreenStyles();
       root.dataset.loadingVisible = 'true';
       root.setAttribute('aria-hidden', 'true');
       root.style.display = 'block';

--- a/express/code/scripts/color-shared/components/gradients/gradient-strip.css
+++ b/express/code/scripts/color-shared/components/gradients/gradient-strip.css
@@ -31,8 +31,9 @@
   height: var(--Gradient-strip-height-s-m);
   flex-shrink: 0;
   border-radius: var(--Corner-radius-corner-radius-100);
-  border: 0.5px solid var(--color-light-gray, var(--color-gray-100, #e9e9e9));
   box-sizing: border-box;
+  outline: 1px solid rgba(31, 31, 31, 0.2);
+  outline-offset: -1px;
 }
 
 .gradient-strip .gradient-strip-info {

--- a/express/code/scripts/color-shared/renderers/createGradientsRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createGradientsRenderer.js
@@ -253,8 +253,7 @@ export function createGradientsRenderer(options) {
 
     const title = document.createElement('h2');
     title.className = 'gradients-title';
-    const totalGradients = normalizeGradients(getData()).length;
-    title.textContent = `${totalGradients} color gradients`;
+    title.textContent = 'Color gradients';
 
     header.appendChild(title);
 

--- a/express/code/scripts/color-shared/renderers/createStripsRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripsRenderer.js
@@ -11,10 +11,6 @@ const ignoreError = () => {};
 const ANALYTICS_TEXT_LIMIT = 20;
 const FILTER_CLICK_SUPPRESS_MS = 250;
 
-function formatCount(n) {
-  return n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
-}
-
 function sanitizeAnalyticsText(value) {
   const raw = String(value ?? '')
     .replace(/[^a-zA-Z0-9\s]/g, '')
@@ -388,12 +384,9 @@ export function createStripsRenderer(options) {
     await loadIconsRail();
 
     if (config?.renderGridVariant === 'summary') {
-      const data = getData();
-      const count = Array.isArray(data) ? data.length : 0;
-      const countLabel = formatCount(count);
       const headerEl = createTag('div', { class: 'explore-header' });
       resultsCountEl = createTag('span', { class: 'results-count' });
-      resultsCountEl.textContent = `${countLabel} color palettes`;
+      resultsCountEl.textContent = 'Color palettes';
       headerEl.appendChild(resultsCountEl);
 
       const sectionEl = createTag('section', { class: 'explore-main-section' });
@@ -408,12 +401,9 @@ export function createStripsRenderer(options) {
     const searchUI = createSearchUI();
     gridElement = createPalettesGridDefault();
 
-    const data = getData();
-    const count = Array.isArray(data) ? data.length : 0;
-    const countLabel = formatCount(count);
     const resultsHeader = createTag('div', { class: 'results-header' });
     resultsCountEl = createTag('span', { class: 'results-count' });
-    resultsCountEl.textContent = `${countLabel} color palettes`;
+    resultsCountEl.textContent = 'Color palettes';
     resultsHeader.appendChild(resultsCountEl);
 
     container.append(searchUI, resultsHeader, gridElement);
@@ -444,9 +434,7 @@ export function createStripsRenderer(options) {
     gridNavReinit?.();
 
     if (resultsCountEl) {
-      const count = newData.length;
-      const countLabel = formatCount(count);
-      resultsCountEl.textContent = `${countLabel} color palettes`;
+      resultsCountEl.textContent = 'Color palettes';
     }
     applyCardActionAnalytics(gridElement);
     scheduleGridTooltips(gridElement);

--- a/express/code/scripts/color-shared/renderers/createStripsRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripsRenderer.js
@@ -9,6 +9,7 @@ import { loadIconsRail } from '../spectrum/load-spectrum.js';
 
 const ignoreError = () => {};
 const ANALYTICS_TEXT_LIMIT = 20;
+const FILTER_CLICK_SUPPRESS_MS = 250;
 
 function formatCount(n) {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
@@ -185,6 +186,30 @@ export function createStripsRenderer(options) {
   const base = createBaseRenderer(options);
   const { getData, setData, emit, createGrid, config } = base;
 
+  let suppressActivationUntil = Number.isFinite(config?.initialActivationSuppressUntil)
+    ? Number(config.initialActivationSuppressUntil)
+    : 0;
+  let filterInteractionListenerBound = false;
+
+  function isActivationSuppressed() {
+    return Date.now() < suppressActivationUntil;
+  }
+
+  function onFilterInteraction() {
+    suppressActivationUntil = Date.now() + FILTER_CLICK_SUPPRESS_MS;
+  }
+
+  function emitPaletteInteractionGuarded(event, detail) {
+    if (event === 'palette-click' && isActivationSuppressed()) return;
+    emit(event, detail);
+  }
+
+  function bindFilterInteractionSuppressor() {
+    if (!rootContainer || filterInteractionListenerBound) return;
+    rootContainer.addEventListener('color-explore:filter-interaction', onFilterInteraction);
+    filterInteractionListenerBound = true;
+  }
+
   let gridElement = null;
   let searchAdapter = null;
   let resultsCountEl = null;
@@ -265,7 +290,7 @@ export function createStripsRenderer(options) {
     const variant = variantOverride
       || (config?.stripVariant === 'compact' ? PALETTE_VARIANT.COMPACT : PALETTE_VARIANT.SUMMARY);
     const { element } = createPaletteVariant(palette, variant, {
-      emit,
+      emit: emitPaletteInteractionGuarded,
       cardFocusable: config?.cardFocusable !== false,
       registry: {
         pushStrip: (strip) => paletteStrips.push(strip),
@@ -355,6 +380,7 @@ export function createStripsRenderer(options) {
   }
 
   async function render(container) {
+    bindFilterInteractionSuppressor();
     tooltipInitToken += 1;
     clearGridTooltips();
     container.replaceChildren();
@@ -427,6 +453,10 @@ export function createStripsRenderer(options) {
   }
 
   function destroy() {
+    if (rootContainer && filterInteractionListenerBound) {
+      rootContainer.removeEventListener('color-explore:filter-interaction', onFilterInteraction);
+      filterInteractionListenerBound = false;
+    }
     tooltipInitToken += 1;
     clearGridTooltips();
     gridNavDestroy?.();

--- a/express/code/scripts/color-shared/styles/color-card.css
+++ b/express/code/scripts/color-shared/styles/color-card.css
@@ -31,9 +31,9 @@
   width: 100%;
   border-radius: var(--Corner-radius-corner-radius-100);
   --color-palette-margin-bottom: 0;
-  --color-palette-border-width: 0.5px;
-  --color-palette-border-color: var(--color-gray-100);
-  --color-palette-active-border-color: var(--color-gray-100);
+  --color-palette-border-width: 1px;
+  --color-palette-border-color: #1f1f1f33;
+  --color-palette-active-border-color: #1f1f1f33;
   --color-palette-min-height: var(--color-card-palette-min-height);
 }
 

--- a/test/scripts/color-shared/renderers/createStripsRenderer.test.js
+++ b/test/scripts/color-shared/renderers/createStripsRenderer.test.js
@@ -86,14 +86,14 @@ describe('createStripsRenderer — grid', () => {
     const buttons = Array.from(container.querySelectorAll('.color-card-action-btn'));
     expect(buttons).to.have.length(4);
 
-    expect(buttons[0].getAttribute('daa-ll')).to.equal('Edit palette-1--2 color palettes');
-    expect(buttons[0].getAttribute('data-ll')).to.equal('Edit palette-1--2 color palettes');
+    expect(buttons[0].getAttribute('daa-ll')).to.equal('Edit palette-1--Color palettes');
+    expect(buttons[0].getAttribute('data-ll')).to.equal('Edit palette-1--Color palettes');
 
-    expect(buttons[1].getAttribute('daa-ll')).to.equal('Open-2--2 color palettes');
-    expect(buttons[1].getAttribute('data-ll')).to.equal('Open-2--2 color palettes');
+    expect(buttons[1].getAttribute('daa-ll')).to.equal('Open-2--Color palettes');
+    expect(buttons[1].getAttribute('data-ll')).to.equal('Open-2--Color palettes');
 
-    expect(buttons[2].getAttribute('daa-ll')).to.equal('Edit palette-3--2 color palettes');
-    expect(buttons[3].getAttribute('daa-ll')).to.equal('Open-4--2 color palettes');
+    expect(buttons[2].getAttribute('daa-ll')).to.equal('Edit palette-3--Color palettes');
+    expect(buttons[3].getAttribute('daa-ll')).to.equal('Open-4--Color palettes');
   });
 });
 
@@ -187,7 +187,7 @@ describe('createStripsRenderer — summary variant (results count)', () => {
 
     const count = container.querySelector('.results-count');
     expect(count).to.exist;
-    expect(count.textContent).to.include('3');
+    expect(count.textContent).to.equal('Color palettes');
   });
 
   it('update() refreshes results count', async function () {
@@ -198,7 +198,7 @@ describe('createStripsRenderer — summary variant (results count)', () => {
     renderer.update(makeData(7));
 
     const count = container.querySelector('.results-count');
-    expect(count.textContent).to.include('7');
+    expect(count.textContent).to.equal('Color palettes');
   });
 
   it('formats count >= 1000 as xK', async function () {
@@ -209,6 +209,6 @@ describe('createStripsRenderer — summary variant (results count)', () => {
     renderer.update(makeData(1000));
 
     const count = container.querySelector('.results-count');
-    expect(count.textContent).to.include('1.0K');
+    expect(count.textContent).to.equal('Color palettes');
   });
 });


### PR DESCRIPTION
## Summary

- Add support for showing the loading screen for color palettes and color gradients.
- Remove the `fetchData` call when a search query parameter is present.
- Load 12 palettes when loading more palettes.
- Fix clipping of the filter outline on focus.
- Show default fetch results when a search term returns no results.
- Fix sticky search bar behavior on desktop.

---

## Jira Ticket

Resolves: [MWPW-192106](https://jira.corp.adobe.com/browse/MWPW-192106), [MWPW-192287](https://jira.corp.adobe.com/browse/MWPW-192287), [MWPW-192099](https://jira.corp.adobe.com/browse/MWPW-192099), [MWPW-192109](https://jira.corp.adobe.com/browse/MWPW-192109), [MWPW-192122](https://jira.corp.adobe.com/browse/MWPW-192122)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/explore |
| **After**   | https://color-explore-bug-fixes--express-color--adobecom.aem.page/explore?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
