### PR TITLE
[Color] MWPW-192335: Fix toolbar on mobile

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -347,6 +347,10 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 
 /* ---- Typography ---- */
 
+.color-extract .color-extract-edit-copy .icon.icon-adobe-express-logo {
+  padding: 0;
+}
+
 .color-extract .color-extract-edit-copy h1 {
   font-size: 45px;
   line-height: 1.04;
@@ -1063,7 +1067,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   }
 
   .color-extract.has-image .color-extract-inner {
-    padding: 32px 16px 56px;
+    padding: var(--spacing-500) 0 56px;
     gap: 24px;
   }
 
@@ -1086,9 +1090,27 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
     display: none;
   }
 
+  /* Flatten toolbar-left so mood and actions join the toolbar's flex directly */
+  .color-extract .color-extract-toolbar-left {
+    display: contents;
+  }
+
+  /* Mood: full width, stack label above trigger */
+  .color-extract .color-extract-mood {
+    width: 100%;
+    height: auto;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
   .color-extract .color-extract-mood-dropdown {
     width: 100%;
     max-width: none;
+  }
+
+  .color-extract .color-extract-mood-trigger {
+    width: 100%;
   }
 
 }


### PR DESCRIPTION
## Summary

Ensures the icons don't overlap on results view of extract component

<img width="382" height="144" alt="image" src="https://github.com/user-attachments/assets/257aaa02-96c3-43fb-8e37-16bfd291c8e2" />

Also: 

- Removes duplicate padding on mobile
- Ensures the Express logo is visible on results view 


---

## Jira Ticket

Resolves: [MWPW-192335](https://jira.corp.adobe.com/browse/MWPW-192335)
[MWPW-192338](https://jira.corp.adobe.com/browse/MWPW-192338)
---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/drafts/bradjohn/extract |
| **After**   | https://MWPW-192335-color-tools-overlap--express-color--adobecom.aem.page/drafts/bradjohn/extract?martech=off |

---

## Verification Steps

- Visit URL on mobile 
- Select a preview image to get to results
- Observe toolbar is accessible and icons not overlapped like stage
