### PR TITLE
[No JIRA] add placeholder keys for i18n for base-color, color-edit and color-blindness page

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -8,6 +8,9 @@ import { getConflictPairs, TYPE_ORDER } from '../../scripts/color-shared/service
 import { announceToScreenReader } from '../../scripts/color-shared/spectrum/utils/a11y.js';
 import { createColorPaletteParamApi } from '../../scripts/color-shared/utils/utilities.js';
 import adoptHeadline from '../../scripts/color-shared/utils/adoptHeadline.js';
+import loadColorBlindnessPlaceholders from '../../scripts/color-shared/i18n/loadColorBlindnessPlaceholders.js';
+import loadBaseColorPlaceholders from '../../scripts/color-shared/i18n/loadBaseColorPlaceholders.js';
+import loadColorEditPlaceholders from '../../scripts/color-shared/i18n/loadColorEditPlaceholders.js';
 import '../../scripts/color-shared/components/color-wheel-express/index.js';
 
 const ACTION_MENU_ID = 'action-menu-color-blindness';
@@ -45,7 +48,14 @@ export default async function decorate(block) {
 
     block.innerHTML = '';
 
-    const section = createTag('section', { 'aria-label': 'Color blindness simulator' });
+    const [cbStrings, baseColorStrings, colorEditStrings] = await Promise.all([
+      loadColorBlindnessPlaceholders(),
+      loadBaseColorPlaceholders(),
+      loadColorEditPlaceholders(),
+    ]);
+    const { shared, block: blockStrings } = cbStrings;
+
+    const section = createTag('section', { 'aria-label': blockStrings.sectionAria });
     block.appendChild(section);
 
     const {
@@ -64,13 +74,13 @@ export default async function decorate(block) {
     };
 
     const navLinks = [
-      { id: 'palette', label: 'Create palette', href: '/create/color-wheel' },
-      { id: 'contrast', label: 'Contrast Checker', href: '/create/color-contrast-analyzer' },
-      { id: 'color-blindness', label: 'Color Blindness Simulator', href: '/create/color-accessibility' },
+      { id: 'palette', label: blockStrings.navCreatePalette, href: '/create/color-wheel' },
+      { id: 'contrast', label: blockStrings.navContrastChecker, href: '/create/color-contrast-analyzer' },
+      { id: 'color-blindness', label: blockStrings.navColorBlindness, href: '/create/color-accessibility' },
     ];
     const controls = [
-      { id: 'undo', label: 'Undo' },
-      { id: 'redo', label: 'Redo' },
+      { id: 'undo', label: blockStrings.controlUndo },
+      { id: 'redo', label: blockStrings.controlRedo },
     ];
 
     layoutInstance = await createColorToolLayout(section, {
@@ -104,11 +114,12 @@ export default async function decorate(block) {
     const actionMenuApi = layoutInstance.actionMenu;
     const conflicts = createColorConflictsAdapter({
       conflictsFound: true,
-      label: 'Potential color blind conflicts',
+      label: shared.summary,
+      strings: shared,
     });
     conflicts.element.setAttribute('tabindex', '0');
     conflicts.element.addEventListener('focus', () => {
-      announceToScreenReader('The conflicts between colors are shown with a caution symbol.');
+      announceToScreenReader(blockStrings.conflictsFocusAnnouncement);
     });
     sidebar.appendChild(conflicts.element);
 
@@ -131,12 +142,12 @@ export default async function decorate(block) {
     };
 
     const wheelEl = createTag('color-wheel-express', {
-      'aria-label': 'Color wheel',
+      'aria-label': blockStrings.wheelAria,
       color: initialPalette.colors[0],
       tabindex: '0',
     });
     wheelEl.addEventListener('focus', () => {
-      announceToScreenReader('Color wheel');
+      announceToScreenReader(blockStrings.wheelFocusAnnouncement);
     });
     wheelEl.showLines = true;
 
@@ -207,6 +218,9 @@ export default async function decorate(block) {
         swatchFeatures: hasValidBaseColor
           ? { baseColor: false, baseColorReadOnly: true }
           : { baseColor: false },
+        colorBlindnessStrings: shared,
+        colorEditStrings,
+        baseColorStrings,
       },
       onColorChangeEnd: () => pushCurrentPalette(),
     });

--- a/express/code/scripts/color-shared/adapters/litComponentAdapters.js
+++ b/express/code/scripts/color-shared/adapters/litComponentAdapters.js
@@ -256,6 +256,8 @@ export function createColorEditAdapter(options = {}, callbacks = {}) {
     colorMode = 'RGB',
     showPalette = true,
     mobile = false,
+    strings,
+    baseColorStrings,
   } = options;
 
   element.palette = palette.slice(0, 10);
@@ -263,6 +265,8 @@ export function createColorEditAdapter(options = {}, callbacks = {}) {
   element.colorMode = colorMode;
   element.showPalette = showPalette;
   element.mobile = mobile;
+  if (strings) element.strings = strings;
+  if (baseColorStrings) element.baseColorStrings = baseColorStrings;
 
   element.addEventListener('color-change', (e) => {
     callbacks.onColorChange?.(e.detail);
@@ -344,11 +348,13 @@ export function createColorConflictsAdapter(options = {}) {
   const element = document.createElement('color-conflicts');
   const {
     conflictsFound = false,
-    label = 'Potential color blind conflicts',
+    label,
+    strings,
   } = options;
 
   element.conflictsFound = conflictsFound;
-  element.label = label;
+  if (strings) element.strings = strings;
+  if (label) element.label = label;
 
   return {
     element,
@@ -371,12 +377,14 @@ export function createBaseColorAdapter(options = {}, callbacks = {}) {
     colorMode = 'HEX',
     showHeader = true,
     showBrightnessControl = true,
+    strings,
   } = options;
 
   element.color = color;
   element.colorMode = colorMode;
   element.showHeader = showHeader;
   element.showBrightnessControl = showBrightnessControl;
+  if (strings) element.strings = strings;
 
   element.addEventListener('color-change', (e) => {
     callbacks.onColorChange?.(e.detail);

--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -10,6 +10,7 @@ import {
   labToRGB,
 } from '../../../../libs/color-components/utils/ColorConversions.js';
 import { loadMenu, loadButton, loadColorArea, loadColorSlider, loadTextfield } from '../../spectrum/load-spectrum.js';
+import { DEFAULT_PLACEHOLDERS as BASE_COLOR_DEFAULTS } from '../../i18n/loadBaseColorPlaceholders.js';
 import '../color-channel-slider/index.js';
 
 const COLOR_MODES = ['HEX', 'RGB', 'HSB', 'Lab'];
@@ -41,6 +42,7 @@ class BaseColor extends LitElement {
       _brightness: { type: Number, state: true },
       _modeMenuOpen: { type: Boolean, state: true },
       _isLocked: { type: Boolean, state: true, reflect: true, attribute: 'locked' },
+      strings: { type: Object },
       _hexError: { type: Boolean, state: true },
       _liveRegionText: { type: String, state: true },
       _colorUpdatedFromPicker: { type: Boolean, state: true },
@@ -53,6 +55,7 @@ class BaseColor extends LitElement {
     this.colorMode = 'HEX';
     this.showHeader = true;
     this.showBrightnessControl = true;
+    this.strings = BASE_COLOR_DEFAULTS;
     this._hue = 0;
     this._saturation = 100;
     this._brightness = 100;
@@ -290,18 +293,19 @@ class BaseColor extends LitElement {
   }
 
   _getColorAnnouncement() {
+    const s = this.strings;
     switch (this.colorMode) {
       case 'RGB': {
         const rgb = this._rgb;
-        return `Red ${Math.round(rgb.red)}, Green ${Math.round(rgb.green)}, Blue ${Math.round(rgb.blue)}`;
+        return `${s.channelRed} ${Math.round(rgb.red)}, ${s.channelGreen} ${Math.round(rgb.green)}, ${s.channelBlue} ${Math.round(rgb.blue)}`;
       }
       case 'HSB': {
         const hsb = this._hsb;
-        return `Hue ${hsb.h} degrees, Saturation ${hsb.s}%, Brightness ${hsb.b}%`;
+        return `${s.channelHue} ${hsb.h} degrees, ${s.channelSaturation} ${hsb.s}%, ${s.channelBrightness} ${hsb.b}%`;
       }
       case 'Lab': {
         const lab = this._lab;
-        return `Lightness ${lab.l}, a ${lab.a}, b ${lab.b}`;
+        return `${s.channelLightness} ${lab.l}, ${s.channelLabA} ${lab.a}, ${s.channelLabB} ${lab.b}`;
       }
       case 'HEX':
       default:
@@ -665,16 +669,17 @@ class BaseColor extends LitElement {
   _renderHeader() {
     if (!this.showHeader) return nothing;
 
+    const s = this.strings;
     return html`
       <div class="bc-header">
         <div class="bc-header-row">
-          <span class="bc-title">Primary color</span>
+          <span class="bc-title">${s.title}</span>
           <div class="bc-mode-wrap">
             <button
               type="button"
               class="bc-mode-trigger"
               @click=${this._toggleModeMenu}
-              aria-label="Color mode, ${this.colorMode}"
+              aria-label="${s.modeLabel}, ${this.colorMode}"
               aria-haspopup="listbox"
               aria-expanded=${this._modeMenuOpen}
               aria-controls=${this._modeMenuOpen ? 'bc-mode-menu' : nothing}
@@ -688,7 +693,7 @@ class BaseColor extends LitElement {
                 role="listbox"
                 selects="single"
                 size="s"
-                label="Color mode"
+                label="${s.modeLabel}"
                 @change=${this._onModeMenuChange}
                 @keydown=${this._onModeMenuKeyDown}
               >
@@ -714,14 +719,14 @@ class BaseColor extends LitElement {
                 maxlength="7"
                 .value=${this._colorValue}
                 ?invalid=${this._hexError}
-                label="Base color"
+                label="${s.fieldLabel}"
                 @input=${this._onColorValueInput}
                 @paste=${this._onHexPaste}
                 @change=${this._onHexCommit}
               ></sp-textfield>
               <span
                 class="bc-lock-icon"
-                aria-label="${this._isLocked ? 'Color locked' : 'Color unlocked'}"
+                aria-label="${this._isLocked ? s.lockedAria : s.unlockedAria}"
               >
                 <img
                   src="/express/code/icons/${this._isLocked ? 'S2_Icon_Lock_20_N.svg' : 'S2_Icon_LockOpen_20_N.svg'}"
@@ -731,7 +736,7 @@ class BaseColor extends LitElement {
                 />
               </span>
             </div>
-            ${this._hexError ? html`<span class="bc-hex-error-text">Please enter a valid 6-character HEX code</span>` : nothing}
+            ${this._hexError ? html`<span class="bc-hex-error-text">${s.hexError}</span>` : nothing}
           </div>
         ` : nothing}
       </div>
@@ -741,10 +746,11 @@ class BaseColor extends LitElement {
   _renderBrightnessSlider() {
     if (!this.showBrightnessControl) return nothing;
     const h = this._hue / 360;
-    const s = this._saturation / 100;
-    const gradient = `linear-gradient(to right, ${hsbToHEX(h, s, 0)}, ${hsbToHEX(h, s, 1)})`;
+    const sat = this._saturation / 100;
+    const gradient = `linear-gradient(to right, ${hsbToHEX(h, sat, 0)}, ${hsbToHEX(h, sat, 1)})`;
     const value = Math.round(this._brightness);
-    const label = html`<img src="/express/code/icons/S2_Icon_BrightnessContrast_20_N.svg" alt="Brightness/Contrast" width="20" height="20" />`;
+    const str = this.strings;
+    const label = html`<img src="/express/code/icons/S2_Icon_BrightnessContrast_20_N.svg" alt="${str.brightnessContrast}" width="20" height="20" />`;
 
     return html`
       <div class="bc-channel-row">
@@ -754,8 +760,8 @@ class BaseColor extends LitElement {
             min="0"
             max="100"
             .value=${value}
-            label="Lightness control handle"
-            valuetext=${`Lightness: ${value}%`}
+            label="${str.channelLightness}"
+            valuetext=${`${str.channelLightness}: ${value}%`}
             gradient=${gradient}
             @input=${(e) => this._onHSBChannelSliderInput(e, 'b')}
             @change=${() => this._emitColorChangeEnd()}
@@ -767,7 +773,7 @@ class BaseColor extends LitElement {
           size="s"
           maxlength="3"
           .value=${String(value)}
-          label="Lightness amount value"
+          label="${str.channelLightness}"
           label-visibility="none"
           @keydown=${(e) => this._onChannelKeyDown(e)}
           @input=${(e) => this._onHSBChannelTextInput(e, 'b')}
@@ -781,18 +787,19 @@ class BaseColor extends LitElement {
     if (this.colorMode === 'HEX') return this._renderBrightnessSlider();
 
     if (this.colorMode === 'RGB') {
+      const s = this.strings;
       const rgb = this._rgb;
       const channels = [
-        { key: 'red', label: 'R', ariaLabel: 'Red', value: Math.round(rgb.red), min: 0, max: 255, unit: '', maxlength: 3 },
-        { key: 'green', label: 'G', ariaLabel: 'Green', value: Math.round(rgb.green), min: 0, max: 255, unit: '', maxlength: 3 },
-        { key: 'blue', label: 'B', ariaLabel: 'Blue', value: Math.round(rgb.blue), min: 0, max: 255, unit: '', maxlength: 3 },
+        { key: 'red', label: 'R', ariaLabel: s.channelRed, value: Math.round(rgb.red), min: 0, max: 255, unit: '', maxlength: 3 },
+        { key: 'green', label: 'G', ariaLabel: s.channelGreen, value: Math.round(rgb.green), min: 0, max: 255, unit: '', maxlength: 3 },
+        { key: 'blue', label: 'B', ariaLabel: s.channelBlue, value: Math.round(rgb.blue), min: 0, max: 255, unit: '', maxlength: 3 },
       ];
 
       if (this.showBrightnessControl) {
         channels.push({
           key: 'brightness',
-          label: html`<img src="/express/code/icons/S2_Icon_BrightnessContrast_20_N.svg" alt="Brightness/Contrast" width="20" height="20" />`,
-          ariaLabel: 'Brightness/Contrast',
+          label: html`<img src="/express/code/icons/S2_Icon_BrightnessContrast_20_N.svg" alt="${s.brightnessContrast}" width="20" height="20" />`,
+          ariaLabel: s.brightnessContrast,
           value: Math.round(this._brightness),
           min: 0,
           max: 100,
@@ -811,7 +818,7 @@ class BaseColor extends LitElement {
                 min=${ch.min}
                 max=${ch.max}
                 .value=${ch.value}
-                label=${ch.isIcon ? 'Lightness control handle' : ch.ariaLabel}
+                label=${ch.isIcon ? s.channelLightness : ch.ariaLabel}
                 valuetext=${`${ch.ariaLabel}: ${ch.value}${ch.unit}`}
                 gradient=${this._getChannelGradient(ch.key)}
                 @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelSliderInput(e, 'b') : this._onRGBChannelSliderInput(e, ch.key)}
@@ -824,7 +831,7 @@ class BaseColor extends LitElement {
               size="s"
               maxlength=${ch.maxlength}
               .value=${String(ch.value)}
-              label=${ch.isIcon ? 'Lightness amount value' : ch.ariaLabel}
+              label=${ch.isIcon ? s.channelLightness : ch.ariaLabel}
               label-visibility="none"
               @keydown=${(e) => this._onChannelKeyDown(e)}
               @input=${(e) => ch.key === 'brightness' ? this._onHSBChannelTextInput(e, 'b') : this._onRGBChannelTextInput(e, ch.key)}
@@ -836,10 +843,11 @@ class BaseColor extends LitElement {
     }
 
     if (this.colorMode === 'HSB') {
+      const s = this.strings;
       const channels = [
-        { key: 'h', label: 'H', ariaLabel: 'Hue', value: Math.round(this._hue), min: 0, max: 360, unit: ' degrees', maxlength: 3 },
-        { key: 's', label: 'S', ariaLabel: 'Saturation', value: Math.round(this._saturation), min: 0, max: 100, unit: '%', maxlength: 3 },
-        { key: 'b', label: 'B', ariaLabel: 'Brightness', value: Math.round(this._brightness), min: 0, max: 100, unit: '%', maxlength: 3 },
+        { key: 'h', label: 'H', ariaLabel: s.channelHue, value: Math.round(this._hue), min: 0, max: 360, unit: ' degrees', maxlength: 3 },
+        { key: 's', label: 'S', ariaLabel: s.channelSaturation, value: Math.round(this._saturation), min: 0, max: 100, unit: '%', maxlength: 3 },
+        { key: 'b', label: 'B', ariaLabel: s.channelBrightness, value: Math.round(this._brightness), min: 0, max: 100, unit: '%', maxlength: 3 },
       ];
 
       return html`
@@ -876,11 +884,12 @@ class BaseColor extends LitElement {
     }
 
     if (this.colorMode === 'Lab') {
+      const s = this.strings;
       const lab = this._lab;
       const channels = [
-        { key: 'l', label: 'L', ariaLabel: 'Lightness', value: Math.round(lab.l), min: 0, max: 100, unit: '', maxlength: 3, allowNegative: false },
-        { key: 'a', label: 'a', ariaLabel: 'a (green-red)', value: Math.round(lab.a), min: -128, max: 127, unit: '', maxlength: 4, allowNegative: true },
-        { key: 'b', label: 'b', ariaLabel: 'b (blue-yellow)', value: Math.round(lab.b), min: -128, max: 127, unit: '', maxlength: 4, allowNegative: true },
+        { key: 'l', label: 'L', ariaLabel: s.channelLightness, value: Math.round(lab.l), min: 0, max: 100, unit: '', maxlength: 3, allowNegative: false },
+        { key: 'a', label: 'a', ariaLabel: s.channelLabA, value: Math.round(lab.a), min: -128, max: 127, unit: '', maxlength: 4, allowNegative: true },
+        { key: 'b', label: 'b', ariaLabel: s.channelLabB, value: Math.round(lab.b), min: -128, max: 127, unit: '', maxlength: 4, allowNegative: true },
       ];
 
       return html`

--- a/express/code/scripts/color-shared/components/color-conflicts/index.js
+++ b/express/code/scripts/color-shared/components/color-conflicts/index.js
@@ -1,6 +1,7 @@
 import { LitElement, html } from '../../../../libs/deps/lit-all.min.js';
 import { style } from './styles.css.js';
 import { loadBadge, loadTooltip } from '../../spectrum/load-spectrum.js';
+import { DEFAULT_SHARED_PLACEHOLDERS as CB_DEFAULTS } from '../../i18n/loadColorBlindnessPlaceholders.js';
 
 const TOOLTIP_CSS_PATH = '/express/code/scripts/color-shared/spectrum/styles/tooltip.css';
 
@@ -15,13 +16,15 @@ class ColorConflicts extends LitElement {
     return {
       conflictsFound: { type: Boolean, attribute: 'conflicts-found' },
       label: { type: String },
+      strings: { type: Object },
     };
   }
 
   constructor() {
     super();
     this.conflictsFound = false;
-    this.label = 'Potential color blind conflicts';
+    this.label = CB_DEFAULTS.summary;
+    this.strings = CB_DEFAULTS;
     this._hasRendered = false;
     this._tooltipOpen = false;
     this._isTouchDevice = false;
@@ -109,23 +112,25 @@ class ColorConflicts extends LitElement {
   }
 
   get _statusText() {
-    return this.conflictsFound ? 'Conflicts found' : 'No conflicts';
+    const s = this.strings;
+    return this.conflictsFound ? s.statusConflictsFound : s.statusNoConflicts;
   }
 
   render() {
-    const tooltipContent = 'The conflicts between colors are shown with a caution symbol.';
+    const s = this.strings;
+    const tooltipContent = s.tooltip;
     const badge = this.conflictsFound
       ? html`
         <sp-badge variant="negative" size="s"
-          aria-label="Color blind conflicts found">
+          aria-label="${s.badgeConflictsAria}">
           <sp-icon-alert-triangle slot="icon"></sp-icon-alert-triangle>
-          Conflicts found
+          ${s.statusConflictsFound}
         </sp-badge>`
       : html`
         <sp-badge variant="positive" size="s"
-          aria-label="No color blind conflicts">
+          aria-label="${s.badgeNoneAria}">
           <sp-icon-checkmark-circle slot="icon"></sp-icon-checkmark-circle>
-          None
+          ${s.statusNone}
         </sp-badge>`;
 
     return html`

--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -8,6 +8,7 @@ import {
 } from '../../../../libs/color-components/utils/ColorConversions.js';
 import { loadSwatch, loadMenu, loadTextfield } from '../../spectrum/load-spectrum.js';
 import { trapFocus, disableBackgroundScroll, restoreBackgroundScroll } from '../../spectrum/utils/a11y.js';
+import { DEFAULT_PLACEHOLDERS as COLOR_EDIT_DEFAULTS } from '../../i18n/loadColorEditPlaceholders.js';
 import '../base-color/index.js';
 
 const COLOR_MODES = ['HEX', 'RGB'];
@@ -23,6 +24,8 @@ class ColorEdit extends LitElement {
       selectedIndex: { type: Number, attribute: 'selected-index' },
       colorMode: { type: String, attribute: 'color-mode' },
       showPalette: { type: Boolean, attribute: 'show-palette' },
+      strings: { type: Object },
+      baseColorStrings: { type: Object, attribute: false },
       mobile: { type: Boolean, reflect: true },
       open: { type: Boolean, reflect: true },
       _hue: { type: Number, state: true },
@@ -39,6 +42,8 @@ class ColorEdit extends LitElement {
     this.selectedIndex = 0;
     this.colorMode = 'HEX';
     this.showPalette = true;
+    this.strings = COLOR_EDIT_DEFAULTS;
+    this.baseColorStrings = null;
     this.mobile = false;
     this.open = false;
     this._hue = 0;
@@ -313,15 +318,16 @@ class ColorEdit extends LitElement {
   }
 
   _renderHeader() {
+    const s = this.strings;
     return html`
       <div class="ce-header">
-        <span class="ce-title">Edit color</span>
+        <span class="ce-title">${s.title}</span>
         <div class="ce-mode-wrap">
           <button
             type="button"
             class="ce-mode-trigger"
             @click=${this._toggleModeMenu}
-            aria-label="Color mode, ${this.colorMode}"
+            aria-label="${s.modeLabel}, ${this.colorMode}"
             aria-haspopup="listbox"
             aria-expanded=${this._modeMenuOpen}
             aria-controls=${this._modeMenuOpen ? 'ce-mode-menu' : nothing}
@@ -336,7 +342,7 @@ class ColorEdit extends LitElement {
                 role="listbox"
                 selects="single"
                 size="s"
-                label="Color mode"
+                label="${s.modeLabel}"
                 @change=${this._onModeMenuChange}
                 @keydown=${this._onModeMenuKeyDown}
               >
@@ -356,13 +362,14 @@ class ColorEdit extends LitElement {
 
   _renderPaletteSwatches() {
     if (!this.showPalette || !this.palette?.length) return nothing;
+    const s = this.strings;
     return html`
       <div class="ce-palette-section">
-        <span class="ce-palette-label">Palette colors</span>
+        <span class="ce-palette-label">${s.paletteColors}</span>
         <sp-theme system="spectrum-two" color="light" scale="medium">
           <div
             role="listbox"
-            aria-label="Color palette colors"
+            aria-label="${s.paletteColors}"
             @keydown=${this._onSwatchGroupKeyDown}
           >
             <sp-swatch-group
@@ -494,15 +501,16 @@ class ColorEdit extends LitElement {
   }
 
   _renderHexInput() {
+    const s = this.strings;
     return html`
       <div class="ce-hex-section">
-        <span class="ce-hex-label">HEX</span>
+        <span class="ce-hex-label">${s.hexLabel}</span>
         <sp-textfield
           class="ce-hex-field"
           size="m"
           maxlength="7"
           .value=${this._hex}
-          label="Color Hex Value"
+          label="${s.hexFieldLabel}"
           label-visibility="none"
           @input=${this._onHexInput}
           @paste=${this._onHexPaste}
@@ -528,6 +536,7 @@ class ColorEdit extends LitElement {
           color-mode=${this.colorMode}
           .showHeader=${false}
           .showBrightnessControl=${isHexMode}
+          .strings=${this.baseColorStrings || nothing}
           @color-change=${this._onBaseColorChange}
         ></base-color>
         <div class="ce-sr-only" role="status" aria-live="polite" aria-atomic="true">${this._liveRegionText}</div>
@@ -544,7 +553,7 @@ class ColorEdit extends LitElement {
               class="ce-sheet ${this.open ? 'open' : ''}"
               role="dialog"
               aria-modal="true"
-              aria-label="Edit color"
+              aria-label="${this.strings.dialogAria}"
               tabindex="-1"
               @keydown=${this._onSheetKeyDown}
             >

--- a/express/code/scripts/color-shared/i18n/loadBaseColorPlaceholders.js
+++ b/express/code/scripts/color-shared/i18n/loadBaseColorPlaceholders.js
@@ -1,0 +1,71 @@
+import { getLibs } from '../../utils.js';
+
+export const DEFAULT_PLACEHOLDERS = Object.freeze({
+  title: 'Base color',
+  modeLabel: 'Color mode',
+  fieldLabel: 'Base color',
+  lockedAria: 'Color locked',
+  unlockedAria: 'Color unlocked',
+  hexError: 'Please enter a valid 6-character HEX code',
+  brightnessContrast: 'Brightness/Contrast',
+  channelRed: 'Red',
+  channelGreen: 'Green',
+  channelBlue: 'Blue',
+  channelHue: 'Hue',
+  channelSaturation: 'Saturation',
+  channelBrightness: 'Brightness',
+  channelLightness: 'Lightness',
+  channelLabA: 'a (green-red)',
+  channelLabB: 'b (blue-yellow)',
+});
+
+const PLACEHOLDER_KEY_MAP = Object.freeze({
+  title: 'base-color-title',
+  modeLabel: 'base-color-mode-label',
+  fieldLabel: 'base-color-field-label',
+  lockedAria: 'base-color-locked',
+  unlockedAria: 'base-color-unlocked',
+  hexError: 'base-color-hex-error',
+  brightnessContrast: 'base-color-brightness-contrast',
+  channelRed: 'base-color-channel-red',
+  channelGreen: 'base-color-channel-green',
+  channelBlue: 'base-color-channel-blue',
+  channelHue: 'base-color-channel-hue',
+  channelSaturation: 'base-color-channel-saturation',
+  channelBrightness: 'base-color-channel-brightness',
+  channelLightness: 'base-color-channel-lightness',
+  channelLabA: 'base-color-channel-lab-a',
+  channelLabB: 'base-color-channel-lab-b',
+});
+
+function isResolvedPlaceholder(value, key) {
+  return value && value !== key.replaceAll('-', ' ');
+}
+
+export function createBaseColorPlaceholders(overrides = {}) {
+  return { ...DEFAULT_PLACEHOLDERS, ...overrides };
+}
+
+export default async function loadBaseColorPlaceholders() {
+  try {
+    const [{ getConfig }, { replaceKeyArray }] = await Promise.all([
+      import(`${getLibs()}/utils/utils.js`),
+      import(`${getLibs()}/features/placeholders.js`),
+    ]);
+
+    const keys = Object.values(PLACEHOLDER_KEY_MAP);
+    const values = await replaceKeyArray(keys, getConfig());
+    const overrides = {};
+
+    Object.entries(PLACEHOLDER_KEY_MAP).forEach(([prop, key], index) => {
+      const value = values[index];
+      if (isResolvedPlaceholder(value, key)) {
+        overrides[prop] = value;
+      }
+    });
+
+    return createBaseColorPlaceholders(overrides);
+  } catch {
+    return createBaseColorPlaceholders();
+  }
+}

--- a/express/code/scripts/color-shared/i18n/loadColorBlindnessPlaceholders.js
+++ b/express/code/scripts/color-shared/i18n/loadColorBlindnessPlaceholders.js
@@ -1,0 +1,112 @@
+import { getLibs } from '../../utils.js';
+
+export const DEFAULT_SHARED_PLACEHOLDERS = Object.freeze({
+  typeTritan: 'Tritanopia',
+  typeProtan: 'Protanopia',
+  typeDeutan: 'Deuteranopia',
+  typeDescTritan: 'Blue-yellow color blindness',
+  typeDescProtan: 'Red-green color blindness',
+  typeDescDeutan: 'Red-green color blindness',
+  tooltip: 'The conflicts between colors are shown with a caution symbol.',
+  summary: 'Potential color blind conflicts',
+  statusNone: 'None',
+  statusNoConflicts: 'No conflicts',
+  statusConflictsFound: 'Conflicts found',
+  mobilePaletteHeader: 'Palette',
+  conflictIconAria: 'Conflict',
+  badgeNoneAria: 'No color blind conflicts',
+  badgeConflictsAria: 'Color blind conflicts found',
+});
+
+export const DEFAULT_BLOCK_PLACEHOLDERS = Object.freeze({
+  sectionAria: 'Color blindness simulator',
+  navCreatePalette: 'Create palette',
+  navContrastChecker: 'Contrast Checker',
+  navColorBlindness: 'Color Blindness Simulator',
+  controlUndo: 'Undo',
+  controlRedo: 'Redo',
+  wheelAria: 'Color wheel',
+  wheelFocusAnnouncement: 'Color wheel',
+  conflictsFocusAnnouncement: 'The conflicts between colors are shown with a caution symbol.',
+  blockError: 'Failed to load Color Blindness.',
+});
+
+const SHARED_KEY_MAP = Object.freeze({
+  typeTritan: 'color-blindness-type-tritan',
+  typeProtan: 'color-blindness-type-protan',
+  typeDeutan: 'color-blindness-type-deutan',
+  typeDescTritan: 'color-blindness-type-desc-tritan',
+  typeDescProtan: 'color-blindness-type-desc-protan',
+  typeDescDeutan: 'color-blindness-type-desc-deutan',
+  tooltip: 'color-blindness-tooltip',
+  summary: 'color-blindness-summary',
+  statusNone: 'color-blindness-status-none',
+  statusNoConflicts: 'color-blindness-status-no-conflicts',
+  statusConflictsFound: 'color-blindness-status-conflicts-found',
+  mobilePaletteHeader: 'color-blindness-mobile-palette-header',
+  conflictIconAria: 'color-blindness-conflict-icon-aria',
+  badgeNoneAria: 'color-blindness-badge-none-aria',
+  badgeConflictsAria: 'color-blindness-badge-conflicts-aria',
+});
+
+const BLOCK_KEY_MAP = Object.freeze({
+  sectionAria: 'color-blindness-section-aria',
+  navCreatePalette: 'color-blindness-nav-create-palette',
+  navContrastChecker: 'color-blindness-nav-contrast-checker',
+  navColorBlindness: 'color-blindness-nav-color-blindness',
+  controlUndo: 'color-blindness-control-undo',
+  controlRedo: 'color-blindness-control-redo',
+  wheelAria: 'color-blindness-wheel-aria',
+  wheelFocusAnnouncement: 'color-blindness-wheel-focus-announcement',
+  conflictsFocusAnnouncement: 'color-blindness-conflicts-focus-announcement',
+  blockError: 'color-blindness-block-error',
+});
+
+function isResolvedPlaceholder(value, key) {
+  return value && value !== key.replaceAll('-', ' ');
+}
+
+function resolveMap(keyMap, values, startIndex) {
+  const overrides = {};
+  Object.entries(keyMap).forEach(([prop, key], index) => {
+    const value = values[startIndex + index];
+    if (isResolvedPlaceholder(value, key)) {
+      overrides[prop] = value;
+    }
+  });
+  return overrides;
+}
+
+export function createColorBlindnessSharedPlaceholders(overrides = {}) {
+  return { ...DEFAULT_SHARED_PLACEHOLDERS, ...overrides };
+}
+
+export function createColorBlindnessBlockPlaceholders(overrides = {}) {
+  return { ...DEFAULT_BLOCK_PLACEHOLDERS, ...overrides };
+}
+
+export default async function loadColorBlindnessPlaceholders() {
+  try {
+    const [{ getConfig }, { replaceKeyArray }] = await Promise.all([
+      import(`${getLibs()}/utils/utils.js`),
+      import(`${getLibs()}/features/placeholders.js`),
+    ]);
+
+    const sharedKeys = Object.values(SHARED_KEY_MAP);
+    const blockKeys = Object.values(BLOCK_KEY_MAP);
+    const values = await replaceKeyArray([...sharedKeys, ...blockKeys], getConfig());
+
+    const sharedOverrides = resolveMap(SHARED_KEY_MAP, values, 0);
+    const blockOverrides = resolveMap(BLOCK_KEY_MAP, values, sharedKeys.length);
+
+    return {
+      shared: createColorBlindnessSharedPlaceholders(sharedOverrides),
+      block: createColorBlindnessBlockPlaceholders(blockOverrides),
+    };
+  } catch {
+    return {
+      shared: createColorBlindnessSharedPlaceholders(),
+      block: createColorBlindnessBlockPlaceholders(),
+    };
+  }
+}

--- a/express/code/scripts/color-shared/i18n/loadColorEditPlaceholders.js
+++ b/express/code/scripts/color-shared/i18n/loadColorEditPlaceholders.js
@@ -1,0 +1,51 @@
+import { getLibs } from '../../utils.js';
+
+export const DEFAULT_PLACEHOLDERS = Object.freeze({
+  title: 'Edit color',
+  dialogAria: 'Edit color',
+  modeLabel: 'Color mode',
+  paletteColors: 'Palette colors',
+  hexLabel: 'HEX',
+  hexFieldLabel: 'HEX color value',
+});
+
+const PLACEHOLDER_KEY_MAP = Object.freeze({
+  title: 'color-edit-title',
+  dialogAria: 'color-edit-dialog-aria',
+  modeLabel: 'color-edit-mode-label',
+  paletteColors: 'color-edit-palette-colors',
+  hexLabel: 'color-edit-hex-label',
+  hexFieldLabel: 'color-edit-hex-field-label',
+});
+
+function isResolvedPlaceholder(value, key) {
+  return value && value !== key.replaceAll('-', ' ');
+}
+
+export function createColorEditPlaceholders(overrides = {}) {
+  return { ...DEFAULT_PLACEHOLDERS, ...overrides };
+}
+
+export default async function loadColorEditPlaceholders() {
+  try {
+    const [{ getConfig }, { replaceKeyArray }] = await Promise.all([
+      import(`${getLibs()}/utils/utils.js`),
+      import(`${getLibs()}/features/placeholders.js`),
+    ]);
+
+    const keys = Object.values(PLACEHOLDER_KEY_MAP);
+    const values = await replaceKeyArray(keys, getConfig());
+    const overrides = {};
+
+    Object.entries(PLACEHOLDER_KEY_MAP).forEach(([prop, key], index) => {
+      const value = values[index];
+      if (isResolvedPlaceholder(value, key)) {
+        overrides[prop] = value;
+      }
+    });
+
+    return createColorEditPlaceholders(overrides);
+  } catch {
+    return createColorEditPlaceholders();
+  }
+}

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -4,9 +4,6 @@ import { createSwatchRailAdapter, createColorEditAdapter } from '../adapters/lit
 import { getContrastTextColor, isSuperLight } from '../../../libs/color-components/utils/ColorConversions.js';
 import {
   TYPE_ORDER,
-  TYPE_LABELS,
-  DEFECT_DEFINITIONS,
-  DEFECT_TOOLTIP_DEFINITIONS,
   getConflictPairs,
   getConflictingIndices,
   simulateHex,
@@ -105,7 +102,11 @@ function refreshColorBlindnessLabelTooltips(root) {
 }
 
 function createColorBlindnessRowsInMatrix(
-  controller, orientation, containerEl, railWrapEl, cbStrings,
+  controller,
+  orientation,
+  containerEl,
+  railWrapEl,
+  cbStrings,
 ) {
   const cb = resolveCBLabels(cbStrings);
   const unsub = controller?.subscribe?.((state) => {
@@ -220,7 +221,7 @@ function createFourRowsColorBlindnessTitlesOnly(controller, containerEl, railWra
   };
 }
 
-function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS, cbStrings) {
+function createMobileCBLayout(controller, cbStrings, maxColumns = MAX_CB_COLUMNS) {
   const cb = resolveCBLabels(cbStrings);
   const container = createTag('div', { class: 'strip-cb-mobile-layout' });
 
@@ -302,7 +303,9 @@ function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS, cbStrings
           role: 'img',
           'aria-label': `${sim.toUpperCase()} ${cb.labels[type]}`,
         });
-        if (conflicting.has(colorIndex)) simCell.appendChild(createConflictIcon(cb.conflictIconAria));
+        if (conflicting.has(colorIndex)) {
+          simCell.appendChild(createConflictIcon(cb.conflictIconAria));
+        }
         row.appendChild(simCell);
       });
 
@@ -323,7 +326,7 @@ function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS, cbStrings
 export function createFourRowsColorBlindnessLayout(adapter, cbStrings) {
   const controller = getAdapterController(adapter);
   // eslint-disable-next-line no-use-before-define
-  const summary = createConflictSummaryBlock(controller, MAX_CB_COLUMNS, cbStrings);
+  const summary = createConflictSummaryBlock(controller, cbStrings);
   const outer = createTag('div', { class: 'strip-with-color-blindness strip-with-color-blindness--four-rows' });
 
   const desktopLayout = createTag('div', { class: 'strip-cb-desktop-layout' });
@@ -337,7 +340,7 @@ export function createFourRowsColorBlindnessLayout(adapter, cbStrings) {
 
   let mobileLayout = null;
   if (controller) {
-    mobileLayout = createMobileCBLayout(controller, MAX_CB_COLUMNS, cbStrings);
+    mobileLayout = createMobileCBLayout(controller, cbStrings);
     outer.appendChild(mobileLayout);
 
     createFourRowsColorBlindnessTitlesOnly(controller, gridContainer, railContainer, cbStrings);
@@ -441,7 +444,7 @@ function createWarningIcon() {
   return el;
 }
 
-function createConflictSummaryBlock(controller, maxColumns = MAX_CB_COLUMNS, cbStrings) {
+function createConflictSummaryBlock(controller, cbStrings, maxColumns = MAX_CB_COLUMNS) {
   const cb = resolveCBLabels(cbStrings);
   const wrap = createTag('div', { class: 'strip-conflict-summary' });
   const label = createTag('span', { class: 'strip-conflict-summary__label' });
@@ -517,10 +520,14 @@ export function createStripWithColorBlindness(adapter, orientation, cbStrings) {
       unsub = u;
     } else {
       unsub = createColorBlindnessRowsInMatrix(
-        controller, orientation, matrixOrRows, railWrap, cbStrings,
+        controller,
+        orientation,
+        matrixOrRows,
+        railWrap,
+        cbStrings,
       );
     }
-    const conflictSummary = createConflictSummaryBlock(controller, MAX_CB_COLUMNS, cbStrings);
+    const conflictSummary = createConflictSummaryBlock(controller, cbStrings);
     conflictSummary.cleanup = conflictSummary.cleanup || (() => {});
     const origDestroy = adapter.destroy;
     adapter.destroy = () => {

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -13,6 +13,20 @@ import {
 } from '../services/createColorBlindnessService.js';
 import { createExpressTooltip } from '../spectrum/components/express-tooltip.js';
 import { announceToScreenReader } from '../spectrum/utils/a11y.js';
+import { DEFAULT_SHARED_PLACEHOLDERS as CB_DEFAULTS } from '../i18n/loadColorBlindnessPlaceholders.js';
+
+function resolveCBLabels(cbStrings) {
+  const s = cbStrings || CB_DEFAULTS;
+  return {
+    labels: { deutan: s.typeDeutan, protan: s.typeProtan, tritan: s.typeTritan },
+    defs: { deutan: s.typeDescDeutan, protan: s.typeDescProtan, tritan: s.typeDescTritan },
+    summary: s.summary,
+    statusNone: s.statusNone,
+    statusConflictsFound: s.statusConflictsFound,
+    conflictIconAria: s.conflictIconAria,
+    mobilePaletteHeader: s.mobilePaletteHeader,
+  };
+}
 
 const COLORS_PER_ROW_TWO_ROWS = 5;
 
@@ -49,14 +63,14 @@ function getAdapterController(adapter) {
   return adapter?.controller || adapter?.rail?.controller || null;
 }
 
-function createConflictIcon() {
+function createConflictIcon(ariaLabel = CB_DEFAULTS.conflictIconAria) {
   return createTag(
     'span',
     {
       class: 'strip-color-blindness-swatch__conflict-icon',
       'aria-hidden': 'true',
       role: 'img',
-      'aria-label': 'Conflict',
+      'aria-label': ariaLabel,
     },
     '<svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 3.1L17.1 16H2.9L10 3.1Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"></path><path d="M10 8.1V11.8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"></path><circle cx="10" cy="14.2" r="0.9" fill="currentColor"></circle></svg>',
   );
@@ -90,7 +104,10 @@ function refreshColorBlindnessLabelTooltips(root) {
   ).catch(() => {});
 }
 
-function createColorBlindnessRowsInMatrix(controller, orientation, containerEl, railWrapEl) {
+function createColorBlindnessRowsInMatrix(
+  controller, orientation, containerEl, railWrapEl, cbStrings,
+) {
+  const cb = resolveCBLabels(cbStrings);
   const unsub = controller?.subscribe?.((state) => {
     const allColors = (state?.swatches || []).map((s) => s?.hex).filter(Boolean);
     if (!allColors.length) return;
@@ -117,11 +134,11 @@ function createColorBlindnessRowsInMatrix(controller, orientation, containerEl, 
         class: `strip-color-blindness-row__title-cell strip-color-blindness-row--${type} ${pairs.length > 0 ? 'fail' : 'pass'}`,
       });
       const label = createTag('span', { class: 'strip-color-blindness-row__label', tabindex: '0' });
-      label.textContent = TYPE_LABELS[type];
-      label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-      label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      label.textContent = cb.labels[type];
+      label.setAttribute('data-tooltip-content', cb.defs[type]);
+      label.setAttribute('aria-label', `${cb.labels[type]}: ${cb.defs[type]}`);
       label.addEventListener('focus', () => {
-        announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+        announceToScreenReader(`${cb.labels[type]}: ${cb.defs[type]}`);
       });
       titleCell.appendChild(label);
       titleCell.style.gridColumn = '1';
@@ -139,9 +156,9 @@ function createColorBlindnessRowsInMatrix(controller, orientation, containerEl, 
           class: `strip-color-blindness-swatch${conflicting.has(i) ? ' conflict' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
           role: 'img',
-          'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,
+          'aria-label': `${sim.toUpperCase()} ${cb.labels[type]}`,
         });
-        if (conflicting.has(i)) swatch.appendChild(createConflictIcon());
+        if (conflicting.has(i)) swatch.appendChild(createConflictIcon(cb.conflictIconAria));
         swatchesWrap.appendChild(swatch);
       });
       containerEl.appendChild(swatchesWrap);
@@ -154,7 +171,8 @@ function createColorBlindnessRowsInMatrix(controller, orientation, containerEl, 
   };
 }
 
-function createFourRowsColorBlindnessTitlesOnly(controller, containerEl, railWrapEl) {
+function createFourRowsColorBlindnessTitlesOnly(controller, containerEl, railWrapEl, cbStrings) {
+  const cb = resolveCBLabels(cbStrings);
   containerEl.style.display = 'grid';
   containerEl.style.gridTemplateColumns = '100px 1fr';
   containerEl.style.gridTemplateRows = '1fr 90px 90px 90px';
@@ -174,11 +192,11 @@ function createFourRowsColorBlindnessTitlesOnly(controller, containerEl, railWra
       class: `strip-four-rows-cb-title strip-four-rows-cb-title--${type}`,
     });
     const label = createTag('span', { class: 'strip-four-rows-cb-title__label', tabindex: '0' });
-    label.textContent = TYPE_LABELS[type];
-    label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-    label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+    label.textContent = cb.labels[type];
+    label.setAttribute('data-tooltip-content', cb.defs[type]);
+    label.setAttribute('aria-label', `${cb.labels[type]}: ${cb.defs[type]}`);
     label.addEventListener('focus', () => {
-      announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      announceToScreenReader(`${cb.labels[type]}: ${cb.defs[type]}`);
     });
     titleCell.style.gridColumn = '1';
     titleCell.style.gridRow = String(gridRow);
@@ -202,24 +220,25 @@ function createFourRowsColorBlindnessTitlesOnly(controller, containerEl, railWra
   };
 }
 
-function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS) {
+function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS, cbStrings) {
+  const cb = resolveCBLabels(cbStrings);
   const container = createTag('div', { class: 'strip-cb-mobile-layout' });
 
   const header = createTag('div', { class: 'strip-cb-mobile-header' });
   const paletteLabel = createTag('span', {
     class: 'strip-cb-mobile-header__label--palette',
   });
-  paletteLabel.textContent = 'Palette';
+  paletteLabel.textContent = cb.mobilePaletteHeader;
   header.appendChild(paletteLabel);
 
   TYPE_ORDER.forEach((type) => {
     const wrap = createTag('div', { class: 'strip-cb-mobile-header__label-wrap' });
     const label = createTag('span', { class: 'strip-cb-mobile-header__label', tabindex: '0' });
-    label.textContent = TYPE_LABELS[type];
-    label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-    label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+    label.textContent = cb.labels[type];
+    label.setAttribute('data-tooltip-content', cb.defs[type]);
+    label.setAttribute('aria-label', `${cb.labels[type]}: ${cb.defs[type]}`);
     label.addEventListener('focus', () => {
-      announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      announceToScreenReader(`${cb.labels[type]}: ${cb.defs[type]}`);
     });
     wrap.appendChild(label);
     header.appendChild(wrap);
@@ -281,9 +300,9 @@ function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS) {
           class: `strip-cb-mobile-row__sim${conflicting.has(colorIndex) ? ' conflict' : ''}${isSuperLight(sim) ? ' super-light' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
           role: 'img',
-          'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,
+          'aria-label': `${sim.toUpperCase()} ${cb.labels[type]}`,
         });
-        if (conflicting.has(colorIndex)) simCell.appendChild(createConflictIcon());
+        if (conflicting.has(colorIndex)) simCell.appendChild(createConflictIcon(cb.conflictIconAria));
         row.appendChild(simCell);
       });
 
@@ -301,10 +320,10 @@ function createMobileCBLayout(controller, maxColumns = MAX_CB_COLUMNS) {
   return container;
 }
 
-export function createFourRowsColorBlindnessLayout(adapter) {
+export function createFourRowsColorBlindnessLayout(adapter, cbStrings) {
   const controller = getAdapterController(adapter);
   // eslint-disable-next-line no-use-before-define
-  const summary = createConflictSummaryBlock(controller);
+  const summary = createConflictSummaryBlock(controller, MAX_CB_COLUMNS, cbStrings);
   const outer = createTag('div', { class: 'strip-with-color-blindness strip-with-color-blindness--four-rows' });
 
   const desktopLayout = createTag('div', { class: 'strip-cb-desktop-layout' });
@@ -318,10 +337,10 @@ export function createFourRowsColorBlindnessLayout(adapter) {
 
   let mobileLayout = null;
   if (controller) {
-    mobileLayout = createMobileCBLayout(controller);
+    mobileLayout = createMobileCBLayout(controller, MAX_CB_COLUMNS, cbStrings);
     outer.appendChild(mobileLayout);
 
-    createFourRowsColorBlindnessTitlesOnly(controller, gridContainer, railContainer);
+    createFourRowsColorBlindnessTitlesOnly(controller, gridContainer, railContainer, cbStrings);
     outer.cleanup = () => {
       gridContainer.unsubFourRowsTitles?.();
       mobileLayout.cleanup?.();
@@ -333,7 +352,8 @@ export function createFourRowsColorBlindnessLayout(adapter) {
   return outer;
 }
 
-function createColorBlindnessRows(controller, orientation) {
+function createColorBlindnessRows(controller, orientation, cbStrings) {
+  const cb = resolveCBLabels(cbStrings);
   const isTwoRows = orientation === 'two-rows';
   const wrap = createTag('div', {
     class: `strip-color-blindness-rows${isTwoRows ? ' strip-color-blindness-rows--two-rows' : ''}`,
@@ -352,11 +372,11 @@ function createColorBlindnessRows(controller, orientation) {
       });
       const header = createTag('div', { class: 'strip-color-blindness-row__header' });
       const label = createTag('span', { class: 'strip-color-blindness-row__label', tabindex: '0' });
-      label.textContent = TYPE_LABELS[type];
-      label.setAttribute('data-tooltip-content', DEFECT_TOOLTIP_DEFINITIONS[type]);
-      label.setAttribute('aria-label', `${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+      label.textContent = cb.labels[type];
+      label.setAttribute('data-tooltip-content', cb.defs[type]);
+      label.setAttribute('aria-label', `${cb.labels[type]}: ${cb.defs[type]}`);
       label.addEventListener('focus', () => {
-        announceToScreenReader(`${TYPE_LABELS[type]}: ${DEFECT_DEFINITIONS[type]}`);
+        announceToScreenReader(`${cb.labels[type]}: ${cb.defs[type]}`);
       });
       header.appendChild(label);
       const swatchesContainer = createTag('div', { class: 'strip-color-blindness-row__grid' });
@@ -372,9 +392,9 @@ function createColorBlindnessRows(controller, orientation) {
           class: `strip-color-blindness-swatch${conflicting.has(colIndex) ? ' conflict' : ''}${isPlaceholder ? ' strip-color-blindness-swatch--placeholder' : ''}`,
           style: `background-color: ${sim}; --cb-conflict-icon-color: ${getContrastTextColor(sim)};`,
           role: 'img',
-          'aria-label': `${sim.toUpperCase()} ${TYPE_LABELS[type]} simulation`,
+          'aria-label': `${sim.toUpperCase()} ${cb.labels[type]}`,
         });
-        if (conflicting.has(colIndex)) swatch.appendChild(createConflictIcon());
+        if (conflicting.has(colIndex)) swatch.appendChild(createConflictIcon(cb.conflictIconAria));
         swatchesContainer.appendChild(swatch);
       });
       row.appendChild(header);
@@ -421,10 +441,11 @@ function createWarningIcon() {
   return el;
 }
 
-function createConflictSummaryBlock(controller, maxColumns = MAX_CB_COLUMNS) {
+function createConflictSummaryBlock(controller, maxColumns = MAX_CB_COLUMNS, cbStrings) {
+  const cb = resolveCBLabels(cbStrings);
   const wrap = createTag('div', { class: 'strip-conflict-summary' });
   const label = createTag('span', { class: 'strip-conflict-summary__label' });
-  label.textContent = 'Potential color blind conflicts';
+  label.textContent = cb.summary;
   const badge = createTag('span', {
     class: 'strip-conflict-summary__badge',
     role: 'status',
@@ -439,7 +460,7 @@ function createConflictSummaryBlock(controller, maxColumns = MAX_CB_COLUMNS) {
       badge.classList.add('none');
       badge.innerHTML = '';
       badge.appendChild(createCheckmarkIcon());
-      badge.appendChild(document.createTextNode('None'));
+      badge.appendChild(document.createTextNode(cb.statusNone));
       return;
     }
     const { hasAny } = getTotalConflictCount(colors, maxColumns);
@@ -448,13 +469,13 @@ function createConflictSummaryBlock(controller, maxColumns = MAX_CB_COLUMNS) {
       badge.classList.add('has-conflicts');
       badge.innerHTML = '';
       badge.appendChild(createWarningIcon());
-      badge.appendChild(document.createTextNode('Conflicts found'));
+      badge.appendChild(document.createTextNode(cb.statusConflictsFound));
     } else {
       badge.classList.remove('has-conflicts');
       badge.classList.add('none');
       badge.innerHTML = '';
       badge.appendChild(createCheckmarkIcon());
-      badge.appendChild(document.createTextNode('None'));
+      badge.appendChild(document.createTextNode(cb.statusNone));
     }
   }
 
@@ -474,7 +495,7 @@ function createConflictSummaryBlock(controller, maxColumns = MAX_CB_COLUMNS) {
   return wrap;
 }
 
-export function createStripWithColorBlindness(adapter, orientation) {
+export function createStripWithColorBlindness(adapter, orientation, cbStrings) {
   const isTwoRows = orientation === 'two-rows';
   const matrixOrRows = createTag('div', {
     class: `strip-with-color-blindness${isTwoRows ? ' strip-with-color-blindness--two-rows' : ''}`,
@@ -491,13 +512,15 @@ export function createStripWithColorBlindness(adapter, orientation) {
   if (controller) {
     let unsub;
     if (isTwoRows) {
-      const { wrap, unsub: u } = createColorBlindnessRows(controller, orientation);
+      const { wrap, unsub: u } = createColorBlindnessRows(controller, orientation, cbStrings);
       matrixOrRows.appendChild(wrap);
       unsub = u;
     } else {
-      unsub = createColorBlindnessRowsInMatrix(controller, orientation, matrixOrRows, railWrap);
+      unsub = createColorBlindnessRowsInMatrix(
+        controller, orientation, matrixOrRows, railWrap, cbStrings,
+      );
     }
-    const conflictSummary = createConflictSummaryBlock(controller);
+    const conflictSummary = createConflictSummaryBlock(controller, MAX_CB_COLUMNS, cbStrings);
     conflictSummary.cleanup = conflictSummary.cleanup || (() => {});
     const origDestroy = adapter.destroy;
     adapter.destroy = () => {
@@ -527,6 +550,9 @@ export function createStripContainerRenderer(options) {
     : null;
 
   const colorBlindness = config?.colorBlindness === true;
+  const cbStrings = config?.colorBlindnessStrings || null;
+  const colorEditStrings = config?.colorEditStrings || null;
+  const baseColorStrings = config?.baseColorStrings || null;
   const { onColorChangeEnd } = options;
   const mobileQuery = typeof options.mobileBreakpointQuery === 'string'
     ? options.mobileBreakpointQuery
@@ -605,13 +631,16 @@ export function createStripContainerRenderer(options) {
     const palette = (state.swatches || []).map((swatch) => swatch?.hex).filter(Boolean);
     const mobile = window.matchMedia?.(mobileQuery)?.matches === true;
 
-    const adapter = createColorEditAdapter({
+    const ceOpts = {
       palette,
       selectedIndex,
       colorMode: 'HEX',
       showPalette: mobile,
       mobile,
-    }, {
+    };
+    if (colorEditStrings) ceOpts.strings = colorEditStrings;
+    if (baseColorStrings) ceOpts.baseColorStrings = baseColorStrings;
+    const adapter = createColorEditAdapter(ceOpts, {
       onColorChange: ({ hex, index }) => {
         if (!hex || !controller?.setState) return;
         const currentState = controller.getState?.() || {};
@@ -746,8 +775,8 @@ export function createStripContainerRenderer(options) {
     let el = adapter.element;
     if (colorBlindness) {
       el = orientation === 'four-rows'
-        ? createFourRowsColorBlindnessLayout(adapter)
-        : createStripWithColorBlindness(adapter, orientation);
+        ? createFourRowsColorBlindnessLayout(adapter, cbStrings)
+        : createStripWithColorBlindness(adapter, orientation, cbStrings);
 
       const controller = getAdapterController(adapter);
       if (controller) {

--- a/test/scripts/color-shared/i18n/loadBaseColorPlaceholders.test.js
+++ b/test/scripts/color-shared/i18n/loadBaseColorPlaceholders.test.js
@@ -1,0 +1,47 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  DEFAULT_PLACEHOLDERS,
+  createBaseColorPlaceholders,
+} from '../../../../express/code/scripts/color-shared/i18n/loadBaseColorPlaceholders.js';
+
+describe('loadBaseColorPlaceholders', () => {
+  describe('DEFAULT_PLACEHOLDERS', () => {
+    it('is frozen', () => {
+      expect(Object.isFrozen(DEFAULT_PLACEHOLDERS)).to.be.true;
+    });
+
+    it('has expected keys', () => {
+      const expected = [
+        'title', 'modeLabel', 'fieldLabel', 'lockedAria', 'unlockedAria',
+        'hexError', 'brightnessContrast', 'channelRed', 'channelGreen',
+        'channelBlue', 'channelHue', 'channelSaturation', 'channelBrightness',
+        'channelLightness', 'channelLabA', 'channelLabB',
+      ];
+      expected.forEach((key) => {
+        expect(DEFAULT_PLACEHOLDERS).to.have.property(key);
+      });
+    });
+
+    it('title defaults to "Base color"', () => {
+      expect(DEFAULT_PLACEHOLDERS.title).to.equal('Base color');
+    });
+  });
+
+  describe('createBaseColorPlaceholders', () => {
+    it('returns defaults when called without overrides', () => {
+      const result = createBaseColorPlaceholders();
+      expect(result).to.deep.equal(DEFAULT_PLACEHOLDERS);
+    });
+
+    it('merges overrides over defaults', () => {
+      const result = createBaseColorPlaceholders({ title: 'Couleur de base' });
+      expect(result.title).to.equal('Couleur de base');
+      expect(result.modeLabel).to.equal(DEFAULT_PLACEHOLDERS.modeLabel);
+    });
+
+    it('does not mutate defaults', () => {
+      createBaseColorPlaceholders({ title: 'custom' });
+      expect(DEFAULT_PLACEHOLDERS.title).to.equal('Base color');
+    });
+  });
+});

--- a/test/scripts/color-shared/i18n/loadColorBlindnessPlaceholders.test.js
+++ b/test/scripts/color-shared/i18n/loadColorBlindnessPlaceholders.test.js
@@ -1,0 +1,80 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  DEFAULT_SHARED_PLACEHOLDERS,
+  DEFAULT_BLOCK_PLACEHOLDERS,
+  createColorBlindnessSharedPlaceholders,
+  createColorBlindnessBlockPlaceholders,
+} from '../../../../express/code/scripts/color-shared/i18n/loadColorBlindnessPlaceholders.js';
+
+describe('loadColorBlindnessPlaceholders', () => {
+  describe('DEFAULT_SHARED_PLACEHOLDERS', () => {
+    it('is frozen', () => {
+      expect(Object.isFrozen(DEFAULT_SHARED_PLACEHOLDERS)).to.be.true;
+    });
+
+    it('has expected keys', () => {
+      const expected = [
+        'typeTritan', 'typeProtan', 'typeDeutan',
+        'typeDescTritan', 'typeDescProtan', 'typeDescDeutan',
+        'tooltip', 'summary', 'statusNone', 'statusNoConflicts',
+        'statusConflictsFound', 'mobilePaletteHeader', 'conflictIconAria',
+        'badgeNoneAria', 'badgeConflictsAria',
+      ];
+      expected.forEach((key) => {
+        expect(DEFAULT_SHARED_PLACEHOLDERS).to.have.property(key);
+      });
+    });
+
+    it('summary defaults to "Potential color blind conflicts"', () => {
+      expect(DEFAULT_SHARED_PLACEHOLDERS.summary).to.equal('Potential color blind conflicts');
+    });
+  });
+
+  describe('DEFAULT_BLOCK_PLACEHOLDERS', () => {
+    it('is frozen', () => {
+      expect(Object.isFrozen(DEFAULT_BLOCK_PLACEHOLDERS)).to.be.true;
+    });
+
+    it('has expected keys', () => {
+      const expected = [
+        'sectionAria', 'navCreatePalette', 'navContrastChecker',
+        'navColorBlindness', 'controlUndo', 'controlRedo',
+        'wheelAria', 'wheelFocusAnnouncement', 'conflictsFocusAnnouncement',
+        'blockError',
+      ];
+      expected.forEach((key) => {
+        expect(DEFAULT_BLOCK_PLACEHOLDERS).to.have.property(key);
+      });
+    });
+  });
+
+  describe('createColorBlindnessSharedPlaceholders', () => {
+    it('returns defaults when called without overrides', () => {
+      const result = createColorBlindnessSharedPlaceholders();
+      expect(result).to.deep.equal(DEFAULT_SHARED_PLACEHOLDERS);
+    });
+
+    it('merges overrides over defaults', () => {
+      const result = createColorBlindnessSharedPlaceholders({
+        typeDeutan: 'Deutéranopie',
+      });
+      expect(result.typeDeutan).to.equal('Deutéranopie');
+      expect(result.typeProtan).to.equal(DEFAULT_SHARED_PLACEHOLDERS.typeProtan);
+    });
+  });
+
+  describe('createColorBlindnessBlockPlaceholders', () => {
+    it('returns defaults when called without overrides', () => {
+      const result = createColorBlindnessBlockPlaceholders();
+      expect(result).to.deep.equal(DEFAULT_BLOCK_PLACEHOLDERS);
+    });
+
+    it('merges overrides over defaults', () => {
+      const result = createColorBlindnessBlockPlaceholders({
+        controlUndo: 'Annuler',
+      });
+      expect(result.controlUndo).to.equal('Annuler');
+      expect(result.controlRedo).to.equal(DEFAULT_BLOCK_PLACEHOLDERS.controlRedo);
+    });
+  });
+});

--- a/test/scripts/color-shared/i18n/loadColorEditPlaceholders.test.js
+++ b/test/scripts/color-shared/i18n/loadColorEditPlaceholders.test.js
@@ -1,0 +1,45 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  DEFAULT_PLACEHOLDERS,
+  createColorEditPlaceholders,
+} from '../../../../express/code/scripts/color-shared/i18n/loadColorEditPlaceholders.js';
+
+describe('loadColorEditPlaceholders', () => {
+  describe('DEFAULT_PLACEHOLDERS', () => {
+    it('is frozen', () => {
+      expect(Object.isFrozen(DEFAULT_PLACEHOLDERS)).to.be.true;
+    });
+
+    it('has expected keys', () => {
+      const expected = [
+        'title', 'dialogAria', 'modeLabel', 'paletteColors',
+        'hexLabel', 'hexFieldLabel',
+      ];
+      expected.forEach((key) => {
+        expect(DEFAULT_PLACEHOLDERS).to.have.property(key);
+      });
+    });
+
+    it('title defaults to "Edit color"', () => {
+      expect(DEFAULT_PLACEHOLDERS.title).to.equal('Edit color');
+    });
+  });
+
+  describe('createColorEditPlaceholders', () => {
+    it('returns defaults when called without overrides', () => {
+      const result = createColorEditPlaceholders();
+      expect(result).to.deep.equal(DEFAULT_PLACEHOLDERS);
+    });
+
+    it('merges overrides over defaults', () => {
+      const result = createColorEditPlaceholders({ title: 'Modifier la couleur' });
+      expect(result.title).to.equal('Modifier la couleur');
+      expect(result.dialogAria).to.equal(DEFAULT_PLACEHOLDERS.dialogAria);
+    });
+
+    it('does not mutate defaults', () => {
+      createColorEditPlaceholders({ title: 'custom' });
+      expect(DEFAULT_PLACEHOLDERS.title).to.equal('Edit color');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Use keys from https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3773167325&spaceKey=~cano&title=Color%2BSEO%2BPlaceholders in code for localization.

---

## Jira Ticket

Resolves: NO JIRA

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-accessibility |
| **After**   | https://color-blindness-placeholders--express-color--adobecom.aem.page/create/color-accessibility?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
