### PR TITLE
How To Summary Selector Fix

### DIFF
--- a/express/code/blocks/how-to-cards/how-to-cards.css
+++ b/express/code/blocks/how-to-cards/how-to-cards.css
@@ -199,7 +199,7 @@
   }
 }
 
-.gallery {
+.how-to-cards .gallery {
   display: flex;
   flex-wrap: nowrap;
   gap: var(--spacing-300);
@@ -212,22 +212,22 @@
   scroll-padding: 0 var(--spacing-300);
 }
 
-.gallery::-webkit-scrollbar {
+.how-to-cards .gallery::-webkit-scrollbar {
   -webkit-appearance: none;
   width: 0;
   height: 0;
 }
 
-.gallery.center.gallery--all-displayed {
+.how-to-cards .gallery.center.gallery--all-displayed {
   justify-content: center;
 }
 
-.gallery--item {
+.how-to-cards .gallery--item {
   scroll-snap-align: start;
   width: calc(100% - var(--spacing-300));
 }
 
-.gallery-control {
+.how-to-cards .gallery-control {
   padding: var(--spacing-300) var(--spacing-300) 0;
   display: flex;
   justify-content: flex-end;
@@ -235,16 +235,16 @@
   align-items: center;
 }
 
-.gallery-control.hide,
-.gallery-control .hide {
+.how-to-cards .gallery-control.hide,
+.how-to-cards .gallery-control .hide {
   display: none;
 }
 
-.gallery-control.loading {
+.how-to-cards .gallery-control.loading {
   visibility: hidden;
 }
 
-.gallery-control button {
+.how-to-cards .gallery-control button {
   all: unset;
   cursor: pointer;
   width: 2rem;
@@ -257,38 +257,38 @@
   background-color: var(--color-white);
 }
 
-.gallery-control button:focus {
+.how-to-cards .gallery-control button:focus {
   outline: revert;
 }
 
-.gallery-control button:hover:not(:disabled) {
+.how-to-cards .gallery-control button:hover:not(:disabled) {
   background-color: var(--color-gray-300);
 }
 
-.gallery-control button:disabled {
+.how-to-cards .gallery-control button:disabled {
   cursor: auto;
 }
 
-.gallery-control button .chevron-icon {
+.how-to-cards .gallery-control button .chevron-icon {
   width: 1.25rem;
   height: 1.25rem;
   transform-origin: center;
   display: block;
 }
 
-.gallery-control button.prev .chevron-icon {
+.how-to-cards .gallery-control button.prev .chevron-icon {
   transform: rotate(-90deg) translate(0px, -1px);
 }
 
-.gallery-control button.next .chevron-icon {
+.how-to-cards .gallery-control button.next .chevron-icon {
   transform:rotate(90deg) translate(0px, -1px);
 }
 
-.gallery-control button:disabled .chevron-icon {
+.how-to-cards .gallery-control button:disabled .chevron-icon {
   opacity: 0.35;
 }
 
-.gallery-control .status {
+.how-to-cards .gallery-control .status {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -300,14 +300,14 @@
   box-sizing: border-box;
 }
 
-.gallery-control .status .dot {
+.how-to-cards .gallery-control .status .dot {
   border-radius: 50px;
   width: var(--status-dot-size);
   height: var(--status-dot-size);
   background-color: var(--color-gray-600);
 }
 
-.gallery-control .status .dot.curr {
+.how-to-cards .gallery-control .status .dot.curr {
   width: var(--status-curr-width);
   background-color: var(--color-black);
 }

--- a/express/code/blocks/how-to-cards/how-to-cards.js
+++ b/express/code/blocks/how-to-cards/how-to-cards.js
@@ -96,6 +96,7 @@ export async function buildGallery(
   if (!root) throw new Error('Invalid Gallery input');
   const control = createControl([...items], container);
   container.classList.add('gallery');
+  container.setAttribute('tabindex', '0');
   [...items].forEach((item) => {
     item.classList.add('gallery--item');
   });


### PR DESCRIPTION
## Summary                                                                                                                                              
                                                                                                                                                          
  Scoped all .gallery and .gallery-control CSS selectors in how-to-cards.css to .how-to-cards to prevent style leakage. The unscoped generic class names
  were causing the Template Start Block (carousel) above the new Content Summary Block to render incorrectly — showing fewer templates, empty space, and  
  misaligned CTAs.
                                                                                                                                                          
  ---                                                                                                                                                  
  Jira Ticket                                                                                                                                          
                                                                                                                                                          
  Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-192332)
                                                                                                                                                          
  ---                                                                                                                                                                
## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://how-to-summary-scoped--da-express-milo--adobecom.aem.page/express/create/poster/prom |
                                         
                                                                                                                                                          
  ---                                                                                                                                                     
  Verification Steps                                                                                                                                    
                                                                                                                                                          
  1. Navigate to a page with both the Template Start Block (carousel) and the Content Summary Block.
  2. Before: Template carousel shows only 1–2 items, large empty space below, CTA misaligned.                                                             
  3. After: Full set of templates renders correctly, carousel navigation works, no unexpected whitespace, CTA is correctly positioned.                    
  4. Confirm Content Summary Block still renders correctly and is unaffected by the scoping change.                                                       
                                                                                                                                                          
  ---                                                                                                                                                     
  Potential Regressions                                                                                                                                   
                                                                                                                                                          
  - https://how-to-summary-scoped--da-express-milo--adobecom.aem.live/express/?martech=off                                                              
                                                                                                                                                          
  ---                                                                                                                                                   
  Additional Notes                                                                                                                                        
                                                                                                                                                        
  The root cause was that .gallery, .gallery--item, and .gallery-control in how-to-cards.css were using unscoped global class names. These collided with
  the same class names used by the Template Start Block's carousel. All selectors have been prefixed with .how-to-cards to scope them to the block. No    
  behavioral changes to the how-to-cards block itself.
                                                          
