### PR TITLE
[COLOR] susi redirect solution

### DIFF
--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -429,7 +429,18 @@ async function buildSUSITabs(el, locale, imsClientId, noRedirect) {
 
 async function buildSimplifiedSusi(el, locale, imsClientId, noRedirect) {
   const rows = el.querySelectorAll(':scope > div > div');
-  const redirectUrl = rows[0]?.textContent?.trim();
+  const isColor = el.classList.contains('color');
+
+  let redirectUrl;
+  if (isColor) {
+    const { consumeSusiColorRedirect } = await import(
+      '../../scripts/color-shared/utils/susiRedirect.js'
+    );
+    redirectUrl = consumeSusiColorRedirect() || window.location.href;
+  } else {
+    redirectUrl = rows[0]?.textContent?.trim();
+  }
+
   const client_id = rows[1]?.textContent?.trim() || (imsClientId ?? 'AdobeExpressWeb');
   const title = rows[2]?.textContent?.trim();
   const popup = el.classList.contains('popup') || false;
@@ -438,7 +449,7 @@ async function buildSimplifiedSusi(el, locale, imsClientId, noRedirect) {
   const params = buildSUSIParams({
     client_id, variant, destURL, locale, title, popup, responseType: 'token',
   });
-  if (!noRedirect) {
+  if (!noRedirect && !isColor) {
     redirectIfLoggedIn(params.destURL);
   }
   await SUSIUtils.loadSUSIScripts();

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -856,7 +856,20 @@ export async function createDrawer(options) {
       libraries,
       ccLibraryProvider,
       isSignedIn,
-      { onClose: close, onSave: save, onSignIn: triggerSignInFlow, onLibraryCreated },
+      {
+        onClose: close,
+        onSave: save,
+        onSignIn: async () => {
+          const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
+            '../utils/susiRedirect.js'
+          );
+          const colors = paletteData?.colors || [];
+          const paletteName = paletteData?.name || '';
+          setSusiColorRedirect(buildColorSignInRedirectUrl(colors, paletteName));
+          return triggerSignInFlow();
+        },
+        onLibraryCreated,
+      },
       t,
     );
     curtainEl = dom.curtainEl;

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -76,6 +76,11 @@ async function handleShare({ name, colors }, t) {
 const COLOR_PALETTE_LEARN_PARAM = 'exercise:express/how-to/in-app/how-to-apply-your-color-palette-to-the-template:-1';
 
 async function handleOpenInExpress({ id, name, colors }) {
+  const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
+    '../utils/susiRedirect.js'
+  );
+  setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name));
+
   const isSignedIn = await triggerSignInFlow();
   if (!isSignedIn) return;
 

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -1,0 +1,47 @@
+import { createColorPaletteParamApi } from './utilities.js';
+
+const KEY = '__susiColorRedirect';
+const COLOR_WHEEL_PATH = '/create/color-wheel';
+
+export function setSusiColorRedirect(url) {
+  window[KEY] = url;
+}
+
+export function consumeSusiColorRedirect() {
+  const url = window[KEY];
+  delete window[KEY];
+  return url || null;
+}
+
+/**
+ * Extracts the locale prefix from the current URL pathname.
+ * URL structure is locale-first: /cn/create/color-wheel, /jp/create/color-wheel, etc.
+ * English (default) has no prefix: /create/color-wheel.
+ *
+ * Matches a leading path segment that looks like a locale code (2-3 letter lang,
+ * optional region: /cn, /jp, /br, /uk, /de, /kr, /es, /fr, /it, etc.).
+ * Returns the prefix with leading slash (e.g. '/cn') or empty string for default locale.
+ */
+function getLocalePrefix() {
+  const match = window.location.pathname.match(/^\/([a-z]{2,3}(?:_[A-Z]{2})?)\//);
+  return match ? `/${match[1]}` : '';
+}
+
+function pageHasBlock(...classNames) {
+  return classNames.some((cls) => document.querySelector(`.${cls}`));
+}
+
+export function buildColorSignInRedirectUrl(colors, name) {
+  const { setOnUrl } = createColorPaletteParamApi();
+
+  if (pageHasBlock('color-explore', 'color-extract')) {
+    const prefix = getLocalePrefix();
+    const url = new URL(`${prefix}${COLOR_WHEEL_PATH}`, window.location.origin);
+    setOnUrl(url, colors, { name });
+    return url.toString();
+  }
+
+  const url = new URL(window.location.href);
+  setOnUrl(url, colors, { name });
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: [MWPW-192259](https://jira.corp.adobe.com/browse/MWPW-192259)
[MWPW-192260](https://jira.corp.adobe.com/browse/MWPW-192260)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/drafts/bradjohn/extract |
| **After**   | https://color-susi-redirect--express-color--adobecom.aem.page/drafts/bradjohn/extract?martech=off |

---

## Verification Steps
We can test this on stage. I have methods for testing locally as well if you Slack me.

- Visit any color page (extract, explore, color wheel) **logged out**
- Modify a palette or gradient to your liking for testing
- Click Save to Library and follow the prompts to log in via IMS 
- You should be redirected back to where you came from with your colors pre-selected via query param. 

**Important note**: If you're on the extract or explore page, we will redirect you back to color wheel (same as clicking edit color). 

---