### PR TITLE
MWPW-187451 Color Wheel Design QA Batch 3

### DIFF
--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -577,7 +577,7 @@ export function createStripContainerRenderer(options) {
   }
 
   function positionPopover(popover, anchorRect, container) {
-    const gap = 8;
+    const gap = 4;
     const popRect = popover.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
 

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -576,24 +576,24 @@ export function createStripContainerRenderer(options) {
     return anchorElement.getBoundingClientRect();
   }
 
-  function positionPopover(popover, anchorRect) {
+  function positionPopover(popover, anchorRect, container) {
     const gap = 8;
     const popRect = popover.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
 
-    let top = anchorRect.bottom + gap;
-    if (top + popRect.height > window.innerHeight) {
-      top = anchorRect.top - popRect.height - gap;
+    let viewportTop = anchorRect.bottom + gap;
+    if (viewportTop + popRect.height > window.innerHeight) {
+      viewportTop = anchorRect.top - popRect.height - gap;
     }
-    top = Math.max(gap, top);
 
-    let { left } = anchorRect;
-    if (left + popRect.width > window.innerWidth - gap) {
-      left = anchorRect.right - popRect.width;
+    let viewportLeft = anchorRect.left;
+    if (viewportLeft + popRect.width > window.innerWidth - gap) {
+      viewportLeft = anchorRect.right - popRect.width;
     }
-    left = Math.max(gap, Math.min(left, window.innerWidth - popRect.width - gap));
+    viewportLeft = Math.max(gap, Math.min(viewportLeft, window.innerWidth - popRect.width - gap));
 
-    popover.style.top = `${top}px`;
-    popover.style.left = `${left}px`;
+    popover.style.top = `${viewportTop - containerRect.top + container.scrollTop}px`;
+    popover.style.left = `${viewportLeft - containerRect.left + container.scrollLeft}px`;
   }
 
   function closeActiveColorEditor() {
@@ -605,12 +605,10 @@ export function createStripContainerRenderer(options) {
       resizeObserver,
       outsideHandler,
       escapeHandler,
-      scrollHandler,
       railElement: activeRailElement,
     } = activeColorEditor;
     if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
-    if (scrollHandler) window.removeEventListener('scroll', scrollHandler, true);
     resizeObserver?.disconnect?.();
     if (mobile) {
       try {
@@ -686,20 +684,25 @@ export function createStripContainerRenderer(options) {
       return;
     }
 
+    const container = railElement.closest('.ax-shell-slot--canvas') || document.body;
+
     const popover = document.createElement('div');
     popover.className = 'swatches-color-edit-popover';
     popover.setAttribute('role', 'dialog');
     popover.setAttribute('aria-label', 'Edit color');
-    popover.style.position = 'fixed';
-    popover.style.zIndex = '10002';
+    popover.style.position = 'absolute';
+    popover.style.top = '0';
+    popover.style.left = '0';
+    popover.style.visibility = 'hidden';
+    popover.style.zIndex = '2';
     popover.appendChild(editorElement);
-    document.body.appendChild(popover);
+    container.appendChild(popover);
     const anchorRect = resolveAnchorRect(anchorElement, anchorRectFromDetail);
     const observer = new ResizeObserver((entries) => {
       const { height } = entries[0].contentRect;
       if (height > 0) {
-        observer.disconnect();
-        positionPopover(popover, anchorRect);
+        positionPopover(popover, anchorRect, container);
+        popover.style.visibility = 'visible';
       }
     });
     observer.observe(popover);
@@ -713,13 +716,9 @@ export function createStripContainerRenderer(options) {
     const escapeHandler = (evt) => {
       if (evt.key === 'Escape') closeActiveColorEditor();
     };
-    const scrollHandler = () => {
-      closeActiveColorEditor();
-    };
 
     document.addEventListener('click', outsideHandler, true);
     document.addEventListener('keydown', escapeHandler, true);
-    window.addEventListener('scroll', scrollHandler, true);
 
     activeColorEditor = {
       adapter,
@@ -728,7 +727,6 @@ export function createStripContainerRenderer(options) {
       resizeObserver: observer,
       outsideHandler,
       escapeHandler,
-      scrollHandler,
       railElement,
     };
 

--- a/express/code/scripts/color-shared/renderers/createSwatchesRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createSwatchesRenderer.js
@@ -74,8 +74,6 @@ export function createSwatchesRenderer(options) {
   function positionPopover(popover, anchorRect) {
     const gap = 8;
     const popRect = popover.getBoundingClientRect();
-    const scrollX = window.scrollX || window.pageXOffset || 0;
-    const scrollY = window.scrollY || window.pageYOffset || 0;
 
     let top = anchorRect.bottom + gap;
     if (top + popRect.height > window.innerHeight) {
@@ -86,8 +84,8 @@ export function createSwatchesRenderer(options) {
     let left = anchorRect.left + (anchorRect.width - popRect.width) / 2;
     left = Math.max(gap, Math.min(left, window.innerWidth - popRect.width - gap));
 
-    popover.style.top = `${top + scrollY}px`;
-    popover.style.left = `${left + scrollX}px`;
+    popover.style.top = `${top}px`;
+    popover.style.left = `${left}px`;
   }
 
   function closeActiveColorEditor() {
@@ -98,9 +96,11 @@ export function createSwatchesRenderer(options) {
       mobile,
       outsideHandler,
       escapeHandler,
+      scrollHandler,
     } = activeColorEditor;
     if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
+    if (scrollHandler) window.removeEventListener('scroll', scrollHandler, true);
     if (mobile) {
       try {
         adapter.hide?.();
@@ -162,7 +162,7 @@ export function createSwatchesRenderer(options) {
     popover.className = 'swatches-color-edit-popover';
     popover.setAttribute('role', 'dialog');
     popover.setAttribute('aria-label', 'Edit color');
-    popover.style.position = 'absolute';
+    popover.style.position = 'fixed';
     popover.style.zIndex = '10002';
     popover.appendChild(editorElement);
     document.body.appendChild(popover);
@@ -181,8 +181,13 @@ export function createSwatchesRenderer(options) {
     const escapeHandler = (evt) => {
       if (evt.key === 'Escape') closeActiveColorEditor();
     };
+    const scrollHandler = () => {
+      closeActiveColorEditor();
+    };
+
     document.addEventListener('click', outsideHandler, true);
     document.addEventListener('keydown', escapeHandler, true);
+    window.addEventListener('scroll', scrollHandler, true);
 
     activeColorEditor = {
       adapter,
@@ -190,6 +195,7 @@ export function createSwatchesRenderer(options) {
       mobile: false,
       outsideHandler,
       escapeHandler,
+      scrollHandler,
     };
   }
 

--- a/express/code/scripts/color-shared/renderers/createSwatchesRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createSwatchesRenderer.js
@@ -74,6 +74,8 @@ export function createSwatchesRenderer(options) {
   function positionPopover(popover, anchorRect) {
     const gap = 8;
     const popRect = popover.getBoundingClientRect();
+    const scrollX = window.scrollX || window.pageXOffset || 0;
+    const scrollY = window.scrollY || window.pageYOffset || 0;
 
     let top = anchorRect.bottom + gap;
     if (top + popRect.height > window.innerHeight) {
@@ -84,8 +86,8 @@ export function createSwatchesRenderer(options) {
     let left = anchorRect.left + (anchorRect.width - popRect.width) / 2;
     left = Math.max(gap, Math.min(left, window.innerWidth - popRect.width - gap));
 
-    popover.style.top = `${top}px`;
-    popover.style.left = `${left}px`;
+    popover.style.top = `${top + scrollY}px`;
+    popover.style.left = `${left + scrollX}px`;
   }
 
   function closeActiveColorEditor() {
@@ -96,11 +98,9 @@ export function createSwatchesRenderer(options) {
       mobile,
       outsideHandler,
       escapeHandler,
-      scrollHandler,
     } = activeColorEditor;
     if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
-    if (scrollHandler) window.removeEventListener('scroll', scrollHandler, true);
     if (mobile) {
       try {
         adapter.hide?.();
@@ -162,7 +162,7 @@ export function createSwatchesRenderer(options) {
     popover.className = 'swatches-color-edit-popover';
     popover.setAttribute('role', 'dialog');
     popover.setAttribute('aria-label', 'Edit color');
-    popover.style.position = 'fixed';
+    popover.style.position = 'absolute';
     popover.style.zIndex = '10002';
     popover.appendChild(editorElement);
     document.body.appendChild(popover);
@@ -181,13 +181,8 @@ export function createSwatchesRenderer(options) {
     const escapeHandler = (evt) => {
       if (evt.key === 'Escape') closeActiveColorEditor();
     };
-    const scrollHandler = () => {
-      closeActiveColorEditor();
-    };
-
     document.addEventListener('click', outsideHandler, true);
     document.addEventListener('keydown', escapeHandler, true);
-    window.addEventListener('scroll', scrollHandler, true);
 
     activeColorEditor = {
       adapter,
@@ -195,7 +190,6 @@ export function createSwatchesRenderer(options) {
       mobile: false,
       outsideHandler,
       escapeHandler,
-      scrollHandler,
     };
   }
 

--- a/express/code/scripts/color-shared/shell/layouts/styles/color-tool-layout.css
+++ b/express/code/scripts/color-shared/shell/layouts/styles/color-tool-layout.css
@@ -114,7 +114,6 @@
   grid-area: var(--ax-area-canvas);
   background-color: var(--ax-bg-canvas);
   padding: var(--ax-padding-canvas-mobile);
-  overflow-y: auto;
   block-size: var(--ax-slot-canvas-block-size);
 }
 


### PR DESCRIPTION
## Summary

Fixes these items from the color wheel design qa:

1. Edit Color overlay disappears if I scroll down the page, even slightly. Desired behavior is it to stay opened and in place if I scroll up or down the page.
2. When I switch between hex and RGB color modes, the panel should stay aligned to the bottom, so the distance between it and the hex code doesn't change (currently aligned to top). Spacing between bottom of the Edit Color overlay and the hex code container should be 4 px.

---

## Jira Ticket

Resolves: [MWPW-187451](https://jira.corp.adobe.com/browse/MWPW-187451)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel  |
| **After**   | https://methomas-popover--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- Click the hexcode button on desktop or large tablet.
- Popover should appear.
- Scroll down the page, and the popover should scroll up with the rest of the content.
- Scroll back and the popover should still be there.
- For issue no 2, when the popover is open above the button, switch the mode from HEX to RGB. The popover should remain 4px from the button.

---

## Potential Regressions

- https://methomas-popover--express-color--adobecom.aem.page/create/color-accessibility

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
