### PR TITLE
feat(MWPW-192583): add configurable promo-banner block for font generator SEO page

### DIFF
--- a/express/code/blocks/promo-banner/promo-banner.css
+++ b/express/code/blocks/promo-banner/promo-banner.css
@@ -1,0 +1,43 @@
+.promo-banner {
+  padding: var(--spacing-400) var(--spacing-300);
+  text-align: center;
+  background-color: var(--color-info-accent);
+  color: var(--color-white);
+}
+
+.promo-banner .content {
+  max-width: var(--block-sm-max-width);
+  margin: auto;
+}
+
+.promo-banner h1,
+.promo-banner h2,
+.promo-banner h3,
+.promo-banner h4,
+.promo-banner h5,
+.promo-banner p {
+  text-align: center;
+  color: inherit;
+}
+
+.promo-banner a:any-link {
+  color: inherit;
+}
+
+@media (min-width: 768px) {
+  .promo-banner {
+    padding: var(--spacing-600) var(--spacing-300);
+  }
+}
+
+@media (min-width: 900px) {
+  .promo-banner .content {
+    max-width: var(--block-md-max-width);
+  }
+}
+
+@media (min-width: 1200px) {
+  .promo-banner .content {
+    max-width: var(--block-lg-max-width);
+  }
+}

--- a/express/code/blocks/promo-banner/promo-banner.js
+++ b/express/code/blocks/promo-banner/promo-banner.js
@@ -1,0 +1,40 @@
+import { decorateButtonsDeprecated } from '../../scripts/utils.js';
+
+export default async function decorate(block) {
+  await decorateButtonsDeprecated(block);
+
+  const rows = [...block.children];
+  const [contentRow, bgRow, colorRow] = rows;
+
+  // Apply background from second row if present
+  if (bgRow) {
+    const value = bgRow.textContent;
+    if (value && value.trim()) {
+      block.style.background = value.trim();
+      block.classList.add('has-custom-bg');
+    }
+    bgRow.remove();
+  }
+
+  // Apply text color from third row if present
+  if (colorRow) {
+    const value = colorRow.textContent;
+    if (value && value.trim()) {
+      block.style.color = value.trim();
+    }
+    colorRow.remove();
+  }
+
+  // Mark content row
+  if (contentRow) {
+    contentRow.classList.add('content');
+  }
+
+  // Adjust button classes: remove primary/secondary, add accent dark
+  const buttons = block.querySelectorAll('a.button');
+  buttons.forEach((button) => {
+    button.classList.remove('primary');
+    button.classList.remove('secondary');
+    button.classList.add('accent', 'dark');
+  });
+}

--- a/nala/blocks/promo-banner/promo-banner.block.json
+++ b/nala/blocks/promo-banner/promo-banner.block.json
@@ -1,0 +1,22 @@
+{
+  "block": "promo-banner",
+  "variants": [
+    {
+      "tcid": "0",
+      "name": "@promo-banner-default",
+      "selector": "div.promo-banner",
+      "path": "/drafts/saravana/font-generator2",
+      "data": {
+        "headingText": "The free font generator online",
+        "buttonText": "Try for free"
+      },
+      "tags": [
+        "@promo-banner",
+        "@default",
+        "@express",
+        "@smoke",
+        "@regression"
+      ]
+    }
+  ]
+}

--- a/nala/blocks/promo-banner/promo-banner.page.cjs
+++ b/nala/blocks/promo-banner/promo-banner.page.cjs
@@ -1,0 +1,9 @@
+class PromoBannerBlock {
+  constructor(page, selector = '.promo-banner', nth = 0) {
+    this.page = page;
+    this.block = page.locator(selector).nth(nth);
+    this.heading = this.block.locator('h2').first();
+    this.button = this.block.locator('a.button').first();
+  }
+}
+module.exports = PromoBannerBlock;

--- a/nala/blocks/promo-banner/promo-banner.spec.cjs
+++ b/nala/blocks/promo-banner/promo-banner.spec.cjs
@@ -1,0 +1,2 @@
+const schema = require('./promo-banner.block.json');
+module.exports = { features: schema.variants };

--- a/nala/blocks/promo-banner/promo-banner.test.cjs
+++ b/nala/blocks/promo-banner/promo-banner.test.cjs
@@ -1,0 +1,38 @@
+const { test, expect } = require('@playwright/test');
+const { features } = require('./promo-banner.spec.cjs');
+const PromoBannerBlock = require('./promo-banner.page.cjs');
+const { runAccessibilityTest } = require('../../libs/accessibility.cjs');
+const { runSeoChecks } = require('../../libs/seo-check.cjs');
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+test.describe('PromoBannerBlock Test Suite', () => {
+  // Test Id : 0 : @promo-banner-default
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name} ${features[0].tags}`, async ({ page, baseURL }) => {
+    const { data } = features[0];
+    const testUrl = `${baseURL}${features[0].path}${miloLibs}`;
+    const block = new PromoBannerBlock(page, features[0].selector);
+    console.info(`[Test Page]: ${testUrl}`);
+
+    await test.step('step-1: Navigate to page', async () => {
+      await page.goto(testUrl);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(testUrl);
+    });
+
+    await test.step('step-2: Verify block content', async () => {
+      await expect(block.block).toBeVisible();
+      await expect(block.heading).toContainText(data.headingText);
+      await expect(block.button).toBeVisible();
+      await expect(block.button).toContainText(data.buttonText);
+    });
+
+    await test.step('step-3: Accessibility validation', async () => {
+      await runAccessibilityTest({ page, testScope: block.block, skipA11yTest: false });
+    });
+
+    await test.step('step-4: SEO validation', async () => {
+      await runSeoChecks({ page, feature: features[0], skipSeoTest: false });
+    });
+  });
+});

--- a/test/blocks/promo-banner/mocks/body.html
+++ b/test/blocks/promo-banner/mocks/body.html
@@ -1,0 +1,34 @@
+<!-- Variant 1: with bg and text color -->
+<div class="promo-banner block" data-block-name="promo-banner" data-block-status="loading" id="with-bg-color">
+  <div>
+    <div>
+      <h2>Create custom fonts instantly with the free font generator</h2>
+      <p>Design stunning typography for social media, logos, and more.</p>
+      <p class="button-container">
+        <a href="https://www.adobe.com/express/" title="Try for free" class="button accent">Try for free</a>
+      </p>
+    </div>
+  </div>
+  <div><div>#1473e6</div></div>
+  <div><div>#ffffff</div></div>
+</div>
+
+<!-- Variant 2: gradient bg only -->
+<div class="promo-banner block" data-block-name="promo-banner" data-block-status="loading" id="with-gradient-bg">
+  <div>
+    <div>
+      <h2>AI font generator online — free to use</h2>
+      <p>No design skills needed.</p>
+    </div>
+  </div>
+  <div><div>linear-gradient(135deg, #667eea 0%, #764ba2 100%)</div></div>
+</div>
+
+<!-- Variant 3: no config rows -->
+<div class="promo-banner block" data-block-name="promo-banner" data-block-status="loading" id="no-config">
+  <div>
+    <div>
+      <h2>Start creating with Adobe Express</h2>
+    </div>
+  </div>
+</div>

--- a/test/blocks/promo-banner/promo-banner.test.js
+++ b/test/blocks/promo-banner/promo-banner.test.js
@@ -1,0 +1,68 @@
+/* eslint-env mocha */
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const imports = await Promise.all([import('../../../express/code/scripts/scripts.js'), import('../../../express/code/blocks/promo-banner/promo-banner.js')]);
+const { default: decorate } = imports[1];
+
+const body = await readFile({ path: './mocks/body.html' });
+
+describe('PromoBanner', () => {
+  before(() => {
+    window.isTestEnv = true;
+  });
+
+  it('PromoBanner exists', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#with-bg-color.promo-banner');
+    await decorate(block);
+    expect(block).to.exist;
+  });
+
+  it('content row gets content class', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#with-bg-color.promo-banner');
+    await decorate(block);
+    const content = block.querySelector('.content');
+    expect(content).to.exist;
+  });
+
+  it('config rows are removed from DOM', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#with-bg-color.promo-banner');
+    await decorate(block);
+    const rows = block.querySelectorAll(':scope > div');
+    expect(rows.length).to.equal(1);
+  });
+
+  it('background color is applied from config row', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#with-bg-color.promo-banner');
+    await decorate(block);
+    expect(block.style.background).to.equal('#1473e6');
+    expect(block.classList.contains('has-custom-bg')).to.be.true;
+  });
+
+  it('text color is applied from second config row', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#with-bg-color.promo-banner');
+    await decorate(block);
+    expect(block.style.color).to.equal('#ffffff');
+  });
+
+  it('gradient background is applied', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#with-gradient-bg.promo-banner');
+    await decorate(block);
+    expect(block.style.background).to.include('linear-gradient');
+    expect(block.classList.contains('has-custom-bg')).to.be.true;
+  });
+
+  it('no inline styles when no config rows', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('#no-config.promo-banner');
+    await decorate(block);
+    expect(block.style.background).to.equal('');
+    expect(block.style.color).to.equal('');
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new `promo-banner` reusable block to da-express-milo that supports configurable text content, background color/gradient, and text color via DA block properties. The block is designed to appear as the first element on the Adobe Express Font Generator SEO landing page.

## Changes
- `express/code/blocks/promo-banner/promo-banner.js` — Block decorator that reads config rows for background and text color, applies inline styles, and decorates CTA buttons
- `express/code/blocks/promo-banner/promo-banner.css` — Responsive styles with CSS custom property tokens, breakpoints at 768px/900px/1200px
- `test/blocks/promo-banner/promo-banner.test.js` — WTR/mocha unit tests (7 test cases)
- `test/blocks/promo-banner/mocks/body.html` — Three fixture variants for unit tests
- `nala/blocks/promo-banner/promo-banner.block.json` — Nala block descriptor
- `nala/blocks/promo-banner/promo-banner.page.cjs` — Playwright page object
- `nala/blocks/promo-banner/promo-banner.spec.cjs` — Nala spec
- `nala/blocks/promo-banner/promo-banner.test.cjs` — Playwright integration test with accessibility and SEO checks

## Testing
Unit tests cover: block existence, content class assignment, config row removal, background color application, text color application, gradient background, and no-config fallback. Playwright integration test covers navigation, content verification, accessibility, and SEO checks.

Jira: MWPW-192583