### PR TITLE
MWPW-190591 configure m@s with express api key

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -191,8 +191,8 @@ const CONFIG = {
     },
   },
   commerce: {
-    'wcs-api-key': 'AdobeExpressWeb',                                                                                                                                                                  
-  }
+    'wcs-api-key': 'AdobeExpressWeb',                                                                                                                                                        
+  },
 };
 
 /*

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -191,7 +191,7 @@ const CONFIG = {
     },
   },
   commerce: {
-    'wcs-api-key': 'AdobeExpressWeb',                                                                                                                                                        
+    'wcs-api-key': 'AdobeExpressWeb',
   },
 };
 

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -190,6 +190,9 @@ const CONFIG = {
       window.location.reload();
     },
   },
+  commerce: {
+    'wcs-api-key': 'AdobeExpressWeb',                                                                                                                                                                  
+  }
 };
 
 /*


### PR DESCRIPTION
## Summary

sets m@s services to use express api key

note i'm still onboarding the key (atm calls give 403)

---

## Jira Ticket

Resolves: [(MWPW-190591](https://jira.corp.adobe.com/browse/(MWPW-190591)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/pricing |
| **After**   | https://MWPW-190591--da-express-milo--adobecom.aem.page/express/pricing?martech=off |

---

## Verification Steps

- check that all mas/io & web_commerce_artifact calls are made with AdobeExpressWeb api key

---

## Potential Regressions

- https://MWPW-190591--da-express-milo--adobecom.aem.live/express/pricing?martech=off

