### PR TITLE
[COLOR] Tests Follow Up For Susi Redirect

### DIFF
--- a/test/scripts/color-shared/utils/susiRedirect.test.js
+++ b/test/scripts/color-shared/utils/susiRedirect.test.js
@@ -14,22 +14,22 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete window.__susiColorRedirect;
+  consumeSusiColorRedirect(); // drain any leftover stored redirect
   sinon.restore();
   document.body.innerHTML = '';
   window.history.replaceState({}, '', savedHref);
 });
 
 describe('setSusiColorRedirect', () => {
-  it('stores the URL on window', () => {
+  it('stores the URL, readable via consumeSusiColorRedirect', () => {
     setSusiColorRedirect('https://example.com/redirect');
-    expect(window.__susiColorRedirect).to.equal('https://example.com/redirect');
+    expect(consumeSusiColorRedirect()).to.equal('https://example.com/redirect');
   });
 
   it('overwrites a previously stored URL', () => {
     setSusiColorRedirect('https://example.com/first');
     setSusiColorRedirect('https://example.com/second');
-    expect(window.__susiColorRedirect).to.equal('https://example.com/second');
+    expect(consumeSusiColorRedirect()).to.equal('https://example.com/second');
   });
 });
 
@@ -40,10 +40,10 @@ describe('consumeSusiColorRedirect', () => {
     expect(result).to.equal('https://example.com/redirect');
   });
 
-  it('deletes the stored URL after consuming', () => {
+  it('clears the stored URL after consuming (second call returns null)', () => {
     setSusiColorRedirect('https://example.com/redirect');
     consumeSusiColorRedirect();
-    expect(window.__susiColorRedirect).to.be.undefined;
+    expect(consumeSusiColorRedirect()).to.be.null;
   });
 
   it('returns null when nothing is stored', () => {

--- a/test/scripts/color-shared/utils/susiRedirect.test.js
+++ b/test/scripts/color-shared/utils/susiRedirect.test.js
@@ -1,0 +1,135 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+import {
+  setSusiColorRedirect,
+  consumeSusiColorRedirect,
+  buildColorSignInRedirectUrl,
+} from '../../../../express/code/scripts/color-shared/utils/susiRedirect.js';
+
+let savedHref;
+
+beforeEach(() => {
+  savedHref = window.location.href;
+});
+
+afterEach(() => {
+  delete window.__susiColorRedirect;
+  sinon.restore();
+  document.body.innerHTML = '';
+  window.history.replaceState({}, '', savedHref);
+});
+
+describe('setSusiColorRedirect', () => {
+  it('stores the URL on window', () => {
+    setSusiColorRedirect('https://example.com/redirect');
+    expect(window.__susiColorRedirect).to.equal('https://example.com/redirect');
+  });
+
+  it('overwrites a previously stored URL', () => {
+    setSusiColorRedirect('https://example.com/first');
+    setSusiColorRedirect('https://example.com/second');
+    expect(window.__susiColorRedirect).to.equal('https://example.com/second');
+  });
+});
+
+describe('consumeSusiColorRedirect', () => {
+  it('returns the stored URL', () => {
+    setSusiColorRedirect('https://example.com/redirect');
+    const result = consumeSusiColorRedirect();
+    expect(result).to.equal('https://example.com/redirect');
+  });
+
+  it('deletes the stored URL after consuming', () => {
+    setSusiColorRedirect('https://example.com/redirect');
+    consumeSusiColorRedirect();
+    expect(window.__susiColorRedirect).to.be.undefined;
+  });
+
+  it('returns null when nothing is stored', () => {
+    const result = consumeSusiColorRedirect();
+    expect(result).to.be.null;
+  });
+
+  it('returns null on a second call (one-time consumption)', () => {
+    setSusiColorRedirect('https://example.com/redirect');
+    consumeSusiColorRedirect();
+    const second = consumeSusiColorRedirect();
+    expect(second).to.be.null;
+  });
+});
+
+describe('buildColorSignInRedirectUrl', () => {
+  const colors = ['#FF0000', '#00FF00', '#0000FF'];
+  const name = 'My Palette';
+
+  it('returns a URL string', () => {
+    const result = buildColorSignInRedirectUrl(colors, name);
+    expect(result).to.be.a('string');
+    expect(() => new URL(result)).to.not.throw();
+  });
+
+  it('encodes color palette in the URL', () => {
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    const param = url.searchParams.get('color-palette');
+    expect(param).to.include('FF0000');
+  });
+
+  it('uses current page URL when not on color-explore or color-extract', () => {
+    window.history.replaceState({}, '', '/create/color-wheel');
+
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.pathname).to.equal('/create/color-wheel');
+  });
+
+  it('redirects to color-wheel when on color-explore page', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/color-explore');
+
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.pathname).to.equal('/create/color-wheel');
+  });
+
+  it('redirects to color-wheel when on color-extract page', () => {
+    const el = document.createElement('div');
+    el.className = 'color-extract';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/color-extract');
+
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.pathname).to.equal('/create/color-wheel');
+  });
+
+  it('preserves locale prefix on color-explore redirect', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/cn/color-explore');
+
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.pathname).to.equal('/cn/create/color-wheel');
+  });
+
+  it('no locale prefix for default (English) locale on color-explore redirect', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/create/color-wheel');
+
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.pathname).to.equal('/create/color-wheel');
+    expect(url.pathname).to.not.match(/^\/[a-z]{2,3}\//);
+  });
+});


### PR DESCRIPTION
## Summary

Didn't have tests in https://github.com/adobecom/da-express-milo/pull/348 
This is a fast follow.

---

No Jira

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://susi-color-tests--da-express-milo--adobecom.aem.page/express/ |?martech=off |

