### PR TITLE
Content Toggle V2 CLS Fix

### DIFF
--- a/express/code/blocks/content-toggle-v2/content-toggle-v2.css
+++ b/express/code/blocks/content-toggle-v2/content-toggle-v2.css
@@ -182,9 +182,9 @@ main .content-toggle-v2 .carousel-container.circleless-button a.button.carousel-
 
 /* Visibility-based hiding for content toggle sections */
 main .section.content-toggle-hidden {
-  display: none;
+  padding: 0;
 }
 
-main .section.content-toggle-active {
-  display: block;
+main .section.content-toggle-hidden > * {
+  display: none;
 }

--- a/express/code/blocks/content-toggle-v2/content-toggle-v2.css
+++ b/express/code/blocks/content-toggle-v2/content-toggle-v2.css
@@ -185,6 +185,8 @@ main .section.content-toggle-hidden {
   padding: 0;
 }
 
+
+main .fragment .section.content-toggle-hidden > *,
 main .section.content-toggle-hidden > * {
   display: none;
 }


### PR DESCRIPTION
## Summary

Addresses Merch at Scale (M@S) pricing-card **loading delay, flicker, and brief visibility of fragment links** tied to layout/visibility behavior around **`content-toggle-v2`**. R

oot cause discussed in the ticket: the block was effectively fighting Milo’s **decorated section** behavior (core `data-status="decorated"` styling), which contributed to **CLS** and poor perceived load on pages such as the pricing POC. 

This change keeps toggle visibility behavior without overriding how Milo treats decorated sections, so cards can settle in line with the rest of the page. Duplicate-card cleanup and related QA links are noted in Jira comments for validation.

---

## Jira Ticket

Resolves: [MWPW-190656](https://jira.corp.adobe.com/browse/MWPW-190656)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://content-toggle-v2-styles--da-express-milo--adobecom.aem.page/express/?martech=off |

**Additional QA URLs (branch preview)**

- https://content-toggle-v2-styles--da-express-milo--adobecom.aem.page/express/ai  
- https://content-toggle-v2-styles--da-express-milo--adobecom.aem.page/br/express/feature  
- https://content-toggle-v2-styles--da-express-milo--adobecom.aem.page/express/pricing-copy  
- https://content-toggle-v2-styles--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/content-toggle-v2  
- Draft / pricing POC: https://content-toggle-v2-styles--da-express-milo--adobecom.aem.page/drafts/echen/pricing-poc-2?tab=1#pricing-table-2  

**Prod repro context (ticket)**

- https://www.adobe.com/express/pre-launch/mas/pricing-poc-2  

---

## Verification Steps

1. Open the **After** URL (and draft pricing POC link above).
2. Hard refresh and watch the **pricing / M@S card** region as the page loads.
3. **Before:** Other chrome loads first; **fragment link or raw placeholder** can flash ~1s; cards pop in late (flicker / CLS).
4. **After:** Cards should appear **without** exposing the fragment URL, with **reduced layout shift** and timing closer to surrounding content.
5. Exercise **content toggle** tabs (e.g. `?tab=1` on the draft) and confirm hidden panels stay hidden without breaking decorated sections elsewhere.
6. On the **kitchen-sink** `content-toggle-v2` page, confirm toggles and spacing still match expectations.

---

## Potential Regressions

- https://content-toggle-v2-styles--da-express-milo--adobecom.aem.live/express/?martech=off  
- Any page using **`content-toggle-v2`** next to **M@S / fragment** content (pricing, feature compare, AI entry points).  
- **“Compare all”** deep links: Jira notes some may still target the wrong tab—verify if out of scope for this PR.

---

## Additional Notes

- Thread reference from ticket: [Slack (adobe-mwp)](https://adobe-mwp.slack.com/archives/C04UH0M1CRG/p1776148751862949).  
- Related analysis in comments: avoid overriding Milo behavior for sections with **`data-status="decorated"`**; **`content-toggle-v2`** was called out as the CLS source.  
- Linked Jira items: clone/parent **MWPW-180521**; related **MWPW-190927** (padding); **DOTCOM-183881** (POC sitemap).  
