### PR TITLE
[COLOR] save to library tweaks

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -371,8 +371,8 @@ function createLibraryPickerField(
 function createKeywordSuggestions(keywords, { onSuggestionClick } = {}) {
   const wrapper = createTag('div', { class: 'ax-drawer-keyword-suggestions' });
   keywords.forEach((keyword) => {
-    const btn = createTag('button', { type: 'button', class: 'ax-tag-pill ax-drawer-tag-btn' });
-    const label = createTag('span', { class: 'ax-tag-pill-label' });
+    const btn = createTag('button', { type: 'button', class: 'ax-tag-pill ax-drawer-tag-btn', 'aria-label': `Add ${keyword}` });
+    const label = createTag('span', { class: 'ax-tag-pill-label', 'aria-hidden': 'true' });
     label.textContent = keyword;
     const icon = createSpectrumIcon('Add');
     icon.setAttribute('aria-hidden', 'true');

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -4,6 +4,7 @@ import {
   getTagValues,
   addTagFromInput as addTagFromInputHelper,
   createTagPill,
+  MAX_TAGS,
 } from './createTagField.js';
 import {
   isMobileViewport,
@@ -367,21 +368,19 @@ function createLibraryPickerField(
 
 /* ── Keyword suggestion pills ────────────────────────────────── */
 
-function createKeywordSuggestions(keywords, mobile, { onSuggestionClick } = {}) {
+function createKeywordSuggestions(keywords, { onSuggestionClick } = {}) {
   const wrapper = createTag('div', { class: 'ax-drawer-keyword-suggestions' });
-  const size = mobile ? 'm' : 's';
   keywords.forEach((keyword) => {
-    const btn = document.createElement('sp-button');
-    btn.setAttribute('variant', 'primary');
-    btn.setAttribute('size', size);
-    btn.classList.add('ax-drawer-tag-btn');
-    btn.textContent = keyword;
-    decorateAnalyticsAttributes(btn, { linkLabel: keyword });
+    const btn = createTag('button', { type: 'button', class: 'ax-tag-pill ax-drawer-tag-btn' });
+    const label = createTag('span', { class: 'ax-tag-pill-label' });
+    label.textContent = keyword;
     const icon = createSpectrumIcon('Add');
-    icon.setAttribute('slot', 'icon');
-    btn.prepend(icon);
+    icon.setAttribute('aria-hidden', 'true');
+    icon.classList.add('ax-drawer-tag-btn-icon');
+    btn.append(label, icon);
+    decorateAnalyticsAttributes(btn, { linkLabel: keyword });
     if (onSuggestionClick) {
-      btn.addEventListener('click', () => onSuggestionClick(keyword));
+      btn.addEventListener('click', () => onSuggestionClick(keyword, btn));
     }
     wrapper.appendChild(btn);
   });
@@ -628,22 +627,25 @@ function buildDrawerDOM(mobile, titleId, palette, libs, ccLibProvider, isSignedI
     syncState: syncTagState,
   } = tagFieldResult;
 
-  const onSuggestionClick = (keyword) => {
+  const onSuggestionClick = (keyword, btn) => {
     const existing = getTagValues(tagsContainerEl).map((v) => v.toLowerCase());
-    if (existing.includes(keyword.toLowerCase())) return;
+    if (existing.includes(keyword.toLowerCase()) || existing.length >= MAX_TAGS) return;
     const pill = createTagPill(keyword, {
       removeLabel: t.tagRemoveAriaLabel,
-      onRemove: syncTagState,
+      onRemove: () => {
+        btn.hidden = false;
+        syncTagState();
+      },
       class: 'ax-drawer-tag-pill',
     });
     tagsContainerEl.appendChild(pill);
+    btn.hidden = true;
     tagsInputEl.focus();
     syncTagState();
   };
 
   tagsWrapper.appendChild(createKeywordSuggestions(
     t.keywordSuggestions.split(',').map((s) => s.trim()),
-    mobile,
     { onSuggestionClick },
   ));
   formFields.appendChild(tagsWrapper);

--- a/express/code/scripts/color-shared/toolbar/createTagField.js
+++ b/express/code/scripts/color-shared/toolbar/createTagField.js
@@ -1,6 +1,8 @@
 import { createSpectrumIcon } from '../utils/icons.js';
 import { createTag } from '../../utils.js';
 
+export const MAX_TAGS = 10;
+
 /* ── Tag text helpers ─────────────────────────────────────────── */
 
 export function normalizeTagText(t) {
@@ -78,7 +80,7 @@ export function addTagFromInput(input, tagsContainer, { onStateChange, removeLab
   if (!text) return;
   const existing = getTagValues(tagsContainer)
     .map((v) => v.toLowerCase());
-  if (existing.includes(text.toLowerCase())) {
+  if (existing.includes(text.toLowerCase()) || existing.length >= MAX_TAGS) {
     input.value = '';
     input.focus();
     return;
@@ -152,6 +154,12 @@ export function createTagField(label, tags, placeholder, {
     requestAnimationFrame(doSync);
   });
   input.addEventListener('input', doSync);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Backspace' && !input.value && tagsContainer.lastElementChild) {
+      tagsContainer.lastElementChild.querySelector('.ax-tag-pill-close')?.click();
+      doSync();
+    }
+  });
 
   wrapper.append(labelEl, field, helpText);
 

--- a/express/code/scripts/color-shared/toolbar/drawer.css
+++ b/express/code/scripts/color-shared/toolbar/drawer.css
@@ -44,7 +44,6 @@
   --ax-drawer-chevron-size: 16px;
   --ax-drawer-chevron-icon-size: 10px;
   --ax-drawer-chevron-transition: transform 0.15s;
-  --ax-drawer-keyword-icon-size: 10px;
   --ax-drawer-title-min-height: 24px;
   --ax-drawer-save-border-radius: 24px;
   --ax-drawer-popover-z: 10;
@@ -52,12 +51,7 @@
   --ax-drawer-divider-height: 1px;
   --ax-drawer-focus-ring-width: 2px;
   --ax-drawer-focus-ring-offset: 2px;
-  --ax-drawer-tag-btn-gap: var(--spacing-75);
-  --ax-drawer-tag-icon-size: 12px;
   --ax-drawer-tag-icon-size-mobile: 14px;
-  --ax-drawer-tag-min-width-mobile: 27px;
-  --ax-drawer-tag-height-mobile: 32px;
-  --ax-drawer-tag-max-inline-size-mobile: 224px;
   --ax-tag-field-min-height: 56px;
   --ax-tag-field-gap: 6px;
   --ax-tag-pill-max-width: 224px;
@@ -233,6 +227,10 @@
   gap: var(--spacing-100);
 }
 
+.ax-drawer-tag-section .ax-drawer-field-label:first-child {
+  padding-bottom: 0;
+}
+
 /* ── Tag field (bordered container) ─────────────────────────── */
 
 .ax-tag-field {
@@ -295,6 +293,10 @@
   box-sizing: border-box;
 }
 
+.ax-tag-pill[hidden] {
+  display: none;
+}
+
 .ax-tag-pill-label {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -331,24 +333,31 @@
   display: none;
 }
 
-/* ── Tag chip buttons (sp-button.ax-drawer-tag-btn — suggestions) ── */
+/* ── Tag chip buttons (native button.ax-drawer-tag-btn — suggestions) ── */
 
 .ax-drawer-tag-btn {
-  --mod-button-border-radius: 7px;
-  --mod-button-edge-to-text: var(--spacing-100);
-  --mod-button-text-to-icon: var(--ax-drawer-tag-btn-gap);
-  --mod-button-background-color-default: var(--color-light-gray);
-  --mod-button-background-color-hover: var(--color-light-gray-2);
-  --mod-button-background-color-down: var(--color-gray-300-variant);
-  --mod-button-background-color-focus: var(--color-light-gray-2);
-  --mod-button-content-color-default: var(--color-gray-800-variant);
-  --mod-button-content-color-hover: var(--color-gray-800-variant);
-  --mod-button-content-color-down: var(--color-gray-800-variant);
-  --mod-button-content-color-focus: var(--color-gray-800-variant);
-  --mod-icon-size: var(--ax-drawer-tag-icon-size);
-  --mod-icon-color: var(--color-black);
-  flex-direction: row-reverse;
+  border: none;
   cursor: pointer;
+}
+
+.ax-drawer-tag-btn:hover {
+  background: var(--color-light-gray-2);
+}
+
+.ax-drawer-tag-btn:active {
+  background: var(--color-gray-300-variant);
+}
+
+.ax-drawer-tag-btn:focus-visible {
+  outline: var(--ax-drawer-focus-ring-width) solid var(--color-blue-800);
+  outline-offset: var(--ax-drawer-focus-ring-offset);
+}
+
+.ax-drawer-tag-btn-icon {
+  --mod-icon-inline-size: var(--ax-tag-pill-icon-size);
+  --mod-icon-block-size: var(--ax-tag-pill-icon-size);
+  color: var(--color-black);
+  flex-shrink: 0;
 }
 
 /* ── Keyword suggestion pills ────────────────────────────────── */
@@ -358,10 +367,6 @@
   flex-wrap: wrap;
   gap: var(--spacing-100);
   align-items: flex-start;
-}
-
-.ax-drawer-keyword-suggestions .ax-drawer-tag-btn {
-  --mod-icon-size: var(--ax-drawer-keyword-icon-size);
 }
 
 .ax-drawer-field-input::placeholder {
@@ -545,12 +550,9 @@
 
 /* ── Mobile drawer overrides ────────────────────── */
 
-.ax-drawer-mobile .ax-drawer-tag-btn {
-  --ax-drawer-tag-btn-gap: var(--spacing-200);
-  --mod-icon-size: var(--ax-drawer-tag-icon-size-mobile);
-  --mod-button-border-radius: var(--Corner-radius-corner-radius-100);
-  --mod-button-edge-to-text: var(--spacing-200);
-  font-weight: var(--ax-drawer-font-weight-medium);
+.ax-drawer-mobile .ax-drawer-tag-btn-icon {
+  --mod-icon-inline-size: var(--ax-drawer-tag-icon-size-mobile);
+  --mod-icon-block-size: var(--ax-drawer-tag-icon-size-mobile);
 }
 
 .ax-drawer-mobile .ax-lib-picker-create-section {
@@ -600,7 +602,12 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-300);
-    padding: 0 !important; 
+    padding: 0 !important;
+  }
+
+  .ax-drawer-panel > sp-theme {
+    overflow: visible;
+    min-block-size: auto;
   }
 
   .ax-drawer-content {

--- a/express/code/scripts/color-shared/utils/utilities.js
+++ b/express/code/scripts/color-shared/utils/utilities.js
@@ -141,8 +141,8 @@ export function restoreFocusedElement(el) {
   }
 }
 
-let overlayZCounter = 89;
-const OVERLAY_Z_MAX = 98;
+let overlayZCounter = 8;
+const OVERLAY_Z_MAX = 17;
 
 export function getNextOverlayZIndex() {
   if (overlayZCounter < OVERLAY_Z_MAX) overlayZCounter += 1;

--- a/express/code/scripts/color-shared/utils/utilities.js
+++ b/express/code/scripts/color-shared/utils/utilities.js
@@ -141,8 +141,8 @@ export function restoreFocusedElement(el) {
   }
 }
 
-let overlayZCounter = 8;
-const OVERLAY_Z_MAX = 17;
+let overlayZCounter = 89;
+const OVERLAY_Z_MAX = 98;
 
 export function getNextOverlayZIndex() {
   if (overlayZCounter < OVERLAY_Z_MAX) overlayZCounter += 1;

--- a/test/scripts/color-shared/toolbar/createDrawerComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createDrawerComponent.test.js
@@ -742,7 +742,7 @@ describe.skip('createDrawer', function drawerSuite() {
       expect(field).to.exist;
       const tagsContainer = field.querySelector('.ax-tag-field-tags');
       expect(tagsContainer).to.exist;
-      const pills = tagsContainer.querySelectorAll('.ax-tag-pill');
+      const pills = tagsContainer.querySelectorAll('div.ax-tag-pill');
       expect(pills.length).to.equal(2);
 
       drawer.close();
@@ -768,7 +768,7 @@ describe.skip('createDrawer', function drawerSuite() {
       const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
       await openDrawer(drawer);
 
-      const pills = document.querySelectorAll('.ax-tag-pill');
+      const pills = document.querySelectorAll('div.ax-tag-pill');
       expect(pills[0].dataset.tagValue).to.equal('bold');
       expect(pills[1].dataset.tagValue).to.equal('bright');
 
@@ -816,7 +816,7 @@ describe.skip('createDrawer', function drawerSuite() {
       input.value = 'Custom';
       input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
-      const pills = document.querySelectorAll('.ax-tag-pill');
+      const pills = document.querySelectorAll('div.ax-tag-pill');
       expect(pills.length).to.equal(3);
       expect(pills[2].dataset.tagValue).to.equal('Custom');
       expect(input.value).to.equal('');
@@ -834,8 +834,62 @@ describe.skip('createDrawer', function drawerSuite() {
       input.value = '   ';
       input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 
-      const pills = document.querySelectorAll('.ax-tag-pill');
+      const pills = document.querySelectorAll('div.ax-tag-pill');
       expect(pills.length).to.equal(2);
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('Backspace on empty input removes the last tag pill', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+      expect(input.value).to.equal('');
+
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+
+      const pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(1);
+      expect(pills[0].dataset.tagValue).to.equal('bold');
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('Backspace with text in input does not remove a tag pill', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+      input.value = 'typ';
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+
+      const pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(2);
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('Backspace on empty input with no tags does not throw', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({
+        anchorElement: anchor,
+        paletteData: { ...MOCK_PALETTE, tags: [] },
+      }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+      expect(() => {
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+      }).to.not.throw();
+
+      const pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(0);
 
       drawer.close();
       await waitForClose();
@@ -849,7 +903,7 @@ describe.skip('createDrawer', function drawerSuite() {
       const suggestions = document.querySelectorAll('.ax-drawer-keyword-suggestions .ax-drawer-tag-btn');
       suggestions[0].click();
 
-      const pills = document.querySelectorAll('.ax-tag-pill');
+      const pills = document.querySelectorAll('div.ax-tag-pill');
       expect(pills.length).to.equal(3);
       expect(pills[2].dataset.tagValue).to.equal('Blue');
 
@@ -862,12 +916,12 @@ describe.skip('createDrawer', function drawerSuite() {
       const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
       await openDrawer(drawer);
 
-      let pills = document.querySelectorAll('.ax-tag-pill');
+      let pills = document.querySelectorAll('div.ax-tag-pill');
       expect(pills.length).to.equal(2);
 
       pills[0].querySelector('.ax-tag-pill-close').click();
 
-      pills = document.querySelectorAll('.ax-tag-pill');
+      pills = document.querySelectorAll('div.ax-tag-pill');
       expect(pills.length).to.equal(1);
       expect(pills[0].dataset.tagValue).to.equal('bright');
 
@@ -898,6 +952,125 @@ describe.skip('createDrawer', function drawerSuite() {
       const input = document.querySelector('.ax-tag-field-input');
       const help = document.querySelector('.ax-tag-field-help');
       expect(input.getAttribute('aria-describedby')).to.equal(help.id);
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('clicking a keyword suggestion hides it from the suggestions list', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const suggestionsContainer = document.querySelector('.ax-drawer-keyword-suggestions');
+      const initialCount = suggestionsContainer.children.length;
+      const firstBtn = suggestionsContainer.children[0];
+
+      expect(firstBtn.hidden).to.be.false;
+      firstBtn.click();
+
+      expect(suggestionsContainer.children.length).to.equal(initialCount);
+      expect(firstBtn.hidden).to.be.true;
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('removing a suggestion pill via close button re-adds its suggestion button', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const suggestionsContainer = document.querySelector('.ax-drawer-keyword-suggestions');
+      const btn = suggestionsContainer.children[0];
+      btn.click();
+      expect(btn.hidden).to.be.true;
+
+      const pill = [...document.querySelectorAll('div.ax-tag-pill')]
+        .find((p) => p.dataset.tagValue === 'Blue');
+      expect(pill).to.exist;
+      pill.querySelector('.ax-tag-pill-close').click();
+
+      expect(btn.hidden).to.be.false;
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('removing a suggestion pill via backspace re-adds its suggestion button', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const suggestionsContainer = document.querySelector('.ax-drawer-keyword-suggestions');
+      const btn = suggestionsContainer.children[0];
+      btn.click();
+      expect(btn.hidden).to.be.true;
+
+      // Backspace on empty input should remove the last pill (which is the suggestion pill)
+      const input = document.querySelector('.ax-tag-field-input');
+      expect(input.value).to.equal('');
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+
+      expect(btn.hidden).to.be.false;
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('does not add more than 10 tags via Enter key', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+
+      // MOCK_PALETTE starts with 2 tags ('bold', 'bright'), add 8 more to reach the limit
+      for (let i = 0; i < 8; i += 1) {
+        input.value = `tag${i}`;
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      }
+
+      let pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(10);
+
+      // Attempting to add an 11th tag should be ignored
+      input.value = 'overflow';
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(10);
+
+      drawer.close();
+      await waitForClose();
+    });
+
+    it('does not add more than 10 tags via keyword suggestion click', async () => {
+      anchor = createAnchor();
+      const drawer = await createDrawer(defaultOptions({ anchorElement: anchor }));
+      await openDrawer(drawer);
+
+      const input = document.querySelector('.ax-tag-field-input');
+
+      // Fill to 9 tags via input (2 existing + 7 new)
+      for (let i = 0; i < 7; i += 1) {
+        input.value = `tag${i}`;
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      }
+
+      // Click a suggestion to reach 10 (Blue is the first suggestion and not yet added)
+      const suggestionsContainer = document.querySelector('.ax-drawer-keyword-suggestions');
+      suggestionsContainer.children[0].click();
+
+      let pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(10);
+
+      // The next visible suggestion click should be ignored (limit reached)
+      const visibleBtn = [...suggestionsContainer.children].find((b) => !b.hidden);
+      if (visibleBtn) visibleBtn.click();
+
+      pills = document.querySelectorAll('div.ax-tag-pill');
+      expect(pills.length).to.equal(10);
 
       drawer.close();
       await waitForClose();


### PR DESCRIPTION
## Summary

- Matches styles consistently in tagged items for save library 
- Limits the tags to 10 
- Removes and re-adds suggested tags when you add/remove them
- Gives the ability to hit the backspace not just the x 
- Ensures panel doesn't fall behind navigation 
- Maintains adequate height and scrolling when labels are extensive and at max capacity 

---

## Jira Ticket

Resolves: [MWPW-192493](https://jira.corp.adobe.com/browse/MWPW-192493)
Resolves: [MWPW-192483](https://jira.corp.adobe.com/browse/MWPW-192483)
Resolves: [MWPW-192499](https://jira.corp.adobe.com/browse/MWPW-192499)
Resolves: [MWPW-192497](https://jira.corp.adobe.com/browse/MWPW-192497)
Resolves: [MWPW-192459](https://jira.corp.adobe.com/browse/MWPW-192459)
Resolves: [MWPW-192458](https://jira.corp.adobe.com/browse/MWPW-192458)
---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/create/color-wheel |
| **After**   | https://color-save-libs-patches--express-color--adobecom.aem.page/drafts/bradjohn/extract?martech=off |

---

## Verification Steps

- Get to toolbar 
- Verify changes in tickets (add, remove tags, check paddings) 
- Check regression potential links for modal and drawer functionality on both desktop and mobile

---

## Potential Regressions 
https://color-save-libs-patches--express-color--adobecom.aem.page/explore
https://color-save-libs-patches--express-color--adobecom.aem.page/create/image
https://color-save-libs-patches--express-color--adobecom.aem.page/create/color-wheel
https://color-save-libs-patches--express-color--adobecom.aem.page/create/color-contrast-analyzer?color-palette=D73220%2CF9ECE5%2C68150A%2C0B78B3%2C1F0062&color-palette-name=My+Color+Theme
https://color-save-libs-patches--express-color--adobecom.aem.page/create/color-accessibility?color-palette=F9ECE5%2C1F0062%2CD73220%2C68150A%2C0B78B3&color-palette-name=My+Color+Theme
