### PR TITLE
MWPW-192646 Fix Image Extract Black Edges

### DIFF
--- a/express/code/blocks/color-extract/helpers/imageMarkers.js
+++ b/express/code/blocks/color-extract/helpers/imageMarkers.js
@@ -198,7 +198,10 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
   function getContainerRect() { return overlay.getBoundingClientRect(); }
 
   function pctToCanvas(pctX, pctY) {
-    return { cx: pctX * canvas.width, cy: pctY * canvas.height };
+    return {
+      cx: clamp(pctX * canvas.width, 0, canvas.width - 1),
+      cy: clamp(pctY * canvas.height, 0, canvas.height - 1),
+    };
   }
 
   /** Center-based positioning via CSS transform — size-independent. */


### PR DESCRIPTION
## Summary

Fix bug in image extraction where dragging color marker to right or bottom edge of image returns #000000 instead of actual image color


---

## Jira Ticket

Resolves: [MWPW-192646](https://jira.corp.adobe.com/browse/MWPW-192646)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-black--express-color--adobecom.aem.page/create/color-wheel |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image |
| **After**   | https://methomas-black--express-color--adobecom.aem.page/create/image |

---

## Verification Steps

- In image extraction section, upload an image or click a suggested image
- Once on result screen, move a marker to the right edge or the bottom edge of the image
- The swatch color should be the actual color from the image, not #000000

---

## Potential Regressions


---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
