### PR TITLE
MWPW-192327 Edit Color popover close outside

### DIFF
--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -1021,21 +1021,13 @@ export const style = css`
     height: 32px;
     border-radius: var(--Corner-radius-corner-radius-100);
   }
-  .swatch-column[data-contrast="dark"] button.hex-code:hover {
+  .swatch-column[data-contrast="dark"] button.hex-code:hover,
+  .swatch-column[data-contrast="dark"] button.hex-code.hex-code--editor-open {
     background-color: rgba(255, 255, 255, 0.12);
   }
-  .swatch-column[data-contrast="light"] button.hex-code:hover {
-    background-color: rgba(0, 0, 0, 0.12);
-  }
+  .swatch-column[data-contrast="light"] button.hex-code:hover,
   .swatch-column[data-contrast="light"] button.hex-code.hex-code--editor-open {
-    border-radius: 5px;
-    border: 1px solid var(--color-gray-950);
-    background: transparent;
-  }
-  .swatch-column[data-contrast="dark"] button.hex-code.hex-code--editor-open {
-    border-radius: 5px;
-    border: 1px solid var(--color-gray-400-variant);
-    background: transparent;
+    background-color: rgba(0, 0, 0, 0.12);
   }
   button.hex-code:focus-visible {
     outline: 2px solid var(--color-blue-800);

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -607,7 +607,10 @@ export function createStripContainerRenderer(options) {
       escapeHandler,
       railElement: activeRailElement,
     } = activeColorEditor;
-    if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
+    if (outsideHandler) {
+      document.removeEventListener('click', outsideHandler, true);
+      document.removeEventListener('touchend', outsideHandler, true);
+    }
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
     resizeObserver?.disconnect?.();
     if (mobile) {
@@ -630,7 +633,10 @@ export function createStripContainerRenderer(options) {
     anchorElement,
     anchorRectFromDetail = null,
   ) {
+    const alreadyOpen = activeColorEditor?.railElement === railElement
+      && activeColorEditor?.selectedIndex === selectedIndex;
     closeActiveColorEditor();
+    if (alreadyOpen) return;
     onEditOpen?.(selectedIndex);
 
     const state = controller?.getState?.() || {};
@@ -710,15 +716,18 @@ export function createStripContainerRenderer(options) {
 
     const outsideHandler = (evt) => {
       const path = evt.composedPath?.() || [];
-      if (!path.includes(popover)) {
-        closeActiveColorEditor();
-      }
+      if (path.includes(popover)) return;
+      // Clicks on hex-code/edit-tint elements will call openColorEditorForRail,
+      // which handles the toggle via alreadyOpen. Don't close here.
+      if (path.some((n) => n?.classList?.contains?.('hex-code') || n?.classList?.contains?.('icon-button--edit-tint'))) return;
+      closeActiveColorEditor();
     };
     const escapeHandler = (evt) => {
       if (evt.key === 'Escape') closeActiveColorEditor();
     };
 
     document.addEventListener('click', outsideHandler, true);
+    document.addEventListener('touchend', outsideHandler, true);
     document.addEventListener('keydown', escapeHandler, true);
 
     activeColorEditor = {
@@ -729,6 +738,7 @@ export function createStripContainerRenderer(options) {
       outsideHandler,
       escapeHandler,
       railElement,
+      selectedIndex,
     };
 
     requestAnimationFrame(async () => {


### PR DESCRIPTION
## Summary

Fixes these issues with the Edit Color popover when clicking the hexcode button:

- Tapping on color strip doesn't close the popover on tablet
- Tapping on hexcode button again doesn't close the popover on tablet or desktop
- When popover is open, hexcode button style is different on tablet and desktop (should match tablet)

---

## Jira Ticket

Resolves: [MWPW-192327](https://jira.corp.adobe.com/browse/MWPW-192327)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-popover-tablet--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- Load page and click on the hexcode button to open the popover
- Test the items in the description (closing by button, closing by clicking swatch, etc)
- Clicking anywhere outside the popover should close it

---

## Potential Regressions

- https://methomas-popover-tablet--express-color--adobecom.aem.page/create/color-accessibility

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
