### PR TITLE
MWPW-192452 Edit color harmony from swatch

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -541,9 +541,36 @@ function createSwatchRailControllerBridge(controller) {
           ? Math.min(Math.max(0, requestedBase), nextHexes.length - 1)
           : 0;
 
+        const currentHexes = (current.swatches || []).map((s) => (s?.hex || '').toUpperCase());
+        const sameLength = nextHexes.length === currentHexes.length;
+
+        // If only the base color changed, use setSwatchHex so the harmony engine
+        // recalculates the non-base colors via onBaseColorChange().
+        const onlyBaseChanged = sameLength
+          && !Object.prototype.hasOwnProperty.call(next, 'baseColorIndex')
+          && nextHexes[clampedBase] !== currentHexes[clampedBase]
+          && nextHexes.every((hex, i) => i === clampedBase || hex === currentHexes[i]);
+        if (onlyBaseChanged) {
+          if (Object.prototype.hasOwnProperty.call(next, 'tintIndex')) {
+            tintIndex = Number.isInteger(next.tintIndex) ? next.tintIndex : null;
+          }
+          controller.setSwatchHex(clampedBase, nextHexes[clampedBase]);
+          return;
+        }
+
+        // If a non-base color changed and a harmony is active, switch to CUSTOM
+        // because the palette no longer follows the harmony rule.
+        const currentHarmony = current.harmonyRule || 'CUSTOM';
+        let nextHarmonyRule = currentHarmony;
+        if (currentHarmony !== 'CUSTOM') {
+          const nonBaseChanged = nextHexes.some((hex, i) => (
+            i !== clampedBase && hex !== currentHexes[i]));
+          if (nonBaseChanged) nextHarmonyRule = 'CUSTOM';
+        }
+
         controller.replaceSwatchesFromHexes(nextHexes, {
           baseIndex: clampedBase,
-          harmonyRule: current.harmonyRule || 'CUSTOM',
+          harmonyRule: nextHarmonyRule,
         });
 
         if (requestedBase == null) {


### PR DESCRIPTION
## Summary

On the color wheel page, editing a color from the swatch should update the harmony
- If it's not a base color, the color harmony mode should change to "Custom"
- If it's a base color, the color harmony should remain, and the other colors in the palette should change to retain the harmony

---

## Jira Ticket

Resolves: [MWPW-192452](https://jira.corp.adobe.com/browse/MWPW-192452)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-custom--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- Open the page and select a harmony other than custom
- Edit a non-base color in the swatch (via tint button or via Edit Color component accessed by hexcode button).
- Harmony should change to custom
- Pick a harmony other than custom
- Edit the base color in the swatch
- The harmony should stay the same and the other colors in the swatch should change to respect the harmony relationship

---

## Potential Regressions



---

## Additional Notes


