### PR TITLE
[No Jira] fix color edit tab navigation

### DIFF
--- a/express/code/scripts/color-shared/components/base-color/index.js
+++ b/express/code/scripts/color-shared/components/base-color/index.js
@@ -76,6 +76,7 @@ class BaseColor extends LitElement {
     this._originalSaturation = 0;
     this._originalBrightness = 0;
     this._pickerInputEnabled = false;
+    this._keyboardActive = false;
   }
 
   get _rgb() {
@@ -463,10 +464,12 @@ class BaseColor extends LitElement {
   _onPointerDown(e) {
     this._lastPointerType = e.pointerType;
     this._pickerInputEnabled = true;
+    this._keyboardActive = false;
   }
 
   _onPickerKeyDown() {
     this._pickerInputEnabled = true;
+    this._keyboardActive = true;
   }
 
   _blurOnTouch(target) {
@@ -479,7 +482,7 @@ class BaseColor extends LitElement {
   // --- Color area (Saturation/Brightness) ---
 
   _snapColorAreaToOriginal(area, saturation, brightness) {
-    if (!this._hasOriginal) return { saturation, brightness };
+    if (!this._hasOriginal || this._keyboardActive) return { saturation, brightness };
     const ds = Math.abs(saturation - this._originalSaturation);
     const db = Math.abs(brightness - this._originalBrightness);
     if (ds > ORIGINAL_COLOR_AREA_SNAP_PCT || db > ORIGINAL_COLOR_AREA_SNAP_PCT) {
@@ -524,7 +527,7 @@ class BaseColor extends LitElement {
     if (slider.value == null) return;
 
     let hue = slider.value;
-    if (this._hasOriginal) {
+    if (this._hasOriginal && !this._keyboardActive) {
       const diff = Math.abs(hue - this._originalHue);
       const wrappedDiff = Math.min(diff, 360 - diff);
       if (wrappedDiff <= ORIGINAL_COLOR_HUE_SNAP_DEG) {

--- a/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
+++ b/express/code/scripts/color-shared/renderers/createStripContainerRenderer.js
@@ -567,6 +567,7 @@ export function createStripContainerRenderer(options) {
 
   let listElement = null;
   let activeColorEditor = null;
+  let isEditorOpening = false;
   const cleanupHandlers = [];
 
   function resolveAnchorRect(anchorElement, anchorRectFromDetail) {
@@ -601,26 +602,33 @@ export function createStripContainerRenderer(options) {
     const {
       adapter,
       popover,
-      mobile,
       resizeObserver,
       outsideHandler,
       escapeHandler,
       railElement: activeRailElement,
+      selectedIndex: editedIndex,
     } = activeColorEditor;
+    activeColorEditor = null;
     if (outsideHandler) document.removeEventListener('click', outsideHandler, true);
     if (escapeHandler) document.removeEventListener('keydown', escapeHandler, true);
     resizeObserver?.disconnect?.();
-    if (mobile) {
-      try {
-        adapter.hide?.();
-      } catch (_err) {
-        // no-op
-      }
+    try {
+      adapter.hide?.();
+    } catch (_err) {
+      // no-op
     }
     adapter.destroy?.();
     popover?.remove();
     activeRailElement?.setActiveEditIndex?.(null);
-    activeColorEditor = null;
+    requestAnimationFrame(() => {
+      const column = activeRailElement?.shadowRoot?.querySelector(
+        `.swatch-column[data-swatch-index="${editedIndex}"]`,
+      );
+      if (column) {
+        column.setAttribute('tabindex', '0');
+        column.focus();
+      }
+    });
   }
 
   function openColorEditorForRail(
@@ -631,7 +639,9 @@ export function createStripContainerRenderer(options) {
     anchorRectFromDetail = null,
   ) {
     closeActiveColorEditor();
+    isEditorOpening = true;
     onEditOpen?.(selectedIndex);
+    isEditorOpening = false;
 
     const state = controller?.getState?.() || {};
     const palette = (state.swatches || []).map((swatch) => swatch?.hex).filter(Boolean);
@@ -672,7 +682,7 @@ export function createStripContainerRenderer(options) {
     const editorElement = adapter.getElement?.() || adapter.element;
     if (mobile) {
       document.body.appendChild(editorElement);
-      activeColorEditor = { adapter, mobile: true, railElement };
+      activeColorEditor = { adapter, mobile: true, railElement, selectedIndex };
       requestAnimationFrame(async () => {
         try {
           await customElements.whenDefined('color-edit');
@@ -694,7 +704,8 @@ export function createStripContainerRenderer(options) {
     popover.style.position = 'absolute';
     popover.style.top = '0';
     popover.style.left = '0';
-    popover.style.visibility = 'hidden';
+    popover.style.opacity = '0';
+    popover.style.pointerEvents = 'none';
     popover.style.zIndex = '2';
     popover.appendChild(editorElement);
     container.appendChild(popover);
@@ -703,7 +714,8 @@ export function createStripContainerRenderer(options) {
       const { height } = entries[0].contentRect;
       if (height > 0) {
         positionPopover(popover, anchorRect, container);
-        popover.style.visibility = 'visible';
+        popover.style.opacity = '1';
+        popover.style.pointerEvents = '';
       }
     });
     observer.observe(popover);
@@ -715,7 +727,10 @@ export function createStripContainerRenderer(options) {
       }
     };
     const escapeHandler = (evt) => {
-      if (evt.key === 'Escape') closeActiveColorEditor();
+      if (evt.key === 'Escape') {
+        evt.stopPropagation();
+        closeActiveColorEditor();
+      }
     };
 
     document.addEventListener('click', outsideHandler, true);
@@ -729,6 +744,7 @@ export function createStripContainerRenderer(options) {
       outsideHandler,
       escapeHandler,
       railElement,
+      selectedIndex,
     };
 
     requestAnimationFrame(async () => {
@@ -813,7 +829,7 @@ export function createStripContainerRenderer(options) {
   }
 
   function update(newData) {
-    if (!listElement) return;
+    if (!listElement || isEditorOpening) return;
     closeActiveColorEditor();
     cleanupHandlers.splice(0).forEach((fn) => fn());
     listElement.innerHTML = '';


### PR DESCRIPTION
## Summary
## Focus & Keyboard Accessibility Fixes for Color Editor

### Focus returns to strip after closing the color editor

When editing a color via the hex code on a strip, pressing Escape or clicking outside to close the editor would lose keyboard focus entirely — it would jump to the toolbar instead of staying on the strip the user was working on. This has been fixed so focus returns to the correct color strip, allowing users to continue navigating with the keyboard seamlessly.

### Arrow keys now work on color area and hue slider handles

The color area (saturation/brightness) and hue slider handles inside the color editor were unresponsive to arrow keys. Users relying on keyboard navigation couldn't adjust colors at all. This was caused by a snap-to-original-color feature that was too aggressive for the small increments keyboard input produces, effectively canceling every adjustment. The fix preserves the snap behavior for mouse/touch users (where it helps return to the original color) while allowing keyboard users to make fine-grained adjustments with arrow keys as expected.

---

## Jira Ticket

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  |https://stage--express-color--adobecom.aem.page/create/color-accessibility|
| **After**   | https://color-edit-bug-fixes--express-color--adobecom.aem.page/create/color-accessibility?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
