### PR TITLE
[COLOR] Hide save lib dialogue at footer

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -361,6 +361,7 @@ export async function initFloatingToolbar(container, options = {}) {
       const isVisible = entries[0].isIntersecting || entries[0].intersectionRatio > 0;
       wrapper.classList.toggle('ax-toolbar-footer-hidden', isVisible);
       if (isVisible) {
+        toolbar.closeDrawer?.();
         wrapper.setAttribute('aria-hidden', 'true');
         wrapper.setAttribute('inert', '');
       } else {

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -580,6 +580,12 @@ export function createToolbar(options) {
         nameInput.value = newName;
       }
     },
+    closeDrawer() {
+      if (activeDrawer?.isOpen) {
+        activeDrawer.close();
+        activeDrawer = null;
+      }
+    },
     setVariant(nextVariant = 'standalone') {
       const resolvedVariant = nextVariant === 'sticky' ? 'sticky' : 'standalone';
       if (resolvedVariant === currentVariant) return;


### PR DESCRIPTION
## Summary

Ensure the opened "save to library" dialogue closes when the toolbar hides on footer collide. 

---

## Jira Ticket

Resolves: [MWPW-192499](https://jira.corp.adobe.com/browse/MWPW-192499)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://save-expanded-footer-fix--express-color--adobecom.aem.page/create/color-wheel?martech=off |

---

## Verification Steps

- Open URL, click "Save to Library" 
- Scroll down, with that open, until you hit the footer. 
- Should go away with toolbar 

---

https://save-expanded-footer-fix--express-color--adobecom.aem.page/create/color-contrast-analyzer?color-palette=D73220%2CF9ECE5%2C68150A%2C0B78B3%2C1F0062&color-palette-name=My+Color+Theme&martech=off