### PR TITLE
removed loadAlloy function; deferred instruments.js

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -345,26 +345,6 @@ function decorateHeroLCP(loadStyle, config, createTag) {
   }
 }
 
-const listenAlloy = () => {
-  let resolver;
-  let loaded;
-  window.alloyLoader = new Promise((r) => {
-    resolver = r;
-  });
-  window.addEventListener('alloy_sendEvent', (e) => {
-    if (e.detail.type === 'pageView') {
-      // eslint-disable-next-line no-console
-      loaded = true;
-      resolver(e.detail.result);
-    }
-  }, { once: true });
-  setTimeout(() => {
-    if (!loaded) {
-      resolver();
-    }
-  }, 3000);
-};
-
 async function loadPage() {
   if (window.isTestEnv) return;
   const {
@@ -413,9 +393,6 @@ async function loadPage() {
 
   loadLana({ clientId: 'express' });
 
-  // TODO this method should be removed about two weeks after going live
-  listenAlloy();
-
   // prevent milo gnav from loading
   const headerMeta = createTag('meta', { name: 'custom-header', content: 'on' });
   document.head.append(headerMeta);
@@ -424,10 +401,6 @@ async function loadPage() {
 
   buildAutoBlocks();
   decorateHeroLCP(loadStyle, config, createTag, getMetadata);
-  const urlParams = new URLSearchParams(window.location.search);
-  if (urlParams.get('martech') !== 'off' && getMetadata('martech') !== 'off') {
-    import('./instrument.js').then((mod) => { mod.default(); });
-  }
 
   /* region based redirect to homepage */
   import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then((country) => {
@@ -448,6 +421,11 @@ async function loadPage() {
 
   const { fixIcons } = await import('./utils.js');
   document.querySelectorAll('.section>.text').forEach((block) => fixIcons(block));
+
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('martech') !== 'off' && getMetadata('martech') !== 'off') {
+    import('./instrument.js').then((mod) => { mod.default(); });
+  }
 
   import('./express-delayed.js').then((mod) => {
     mod.default();


### PR DESCRIPTION
## Summary

Modified scripts.js, removed loadAlloy function; deferred loading of instruments.js. 

Here are explanations of both changes that were made:

### Fix 1: Defer instrument.js import until after loadArea()

Previously, instrument.js was imported as a fire-and-forget dynamic import immediately before await loadArea() — meaning the browser was simultaneously trying to download, parse, and execute the analytics module at the same time it was painting the LCP element. This created two forms of contention during the most performance-sensitive window on the page: network bandwidth competition (the Demdex audience segment fetch in instrument.js races against the LCP image fetch) and main thread pressure (the alloy_all data layer setup and event listener registration add JS execution cost while the browser is trying to complete layout and paint).

The fix moves the instrument.js import to after await loadArea() completes, placing it alongside express-delayed.js where deferred work already lands. This is also semantically more correct: instrument.js's default export (martechLoadedCB) calls decorateAnalyticsEvents() which sets data-analytics attributes on DOM elements — work that requires the full DOM to be present anyway. No analytics fidelity is lost by this change; click tracking listeners attached after LCP miss no meaningful interactions during the page-load phase, and the audience segment data for the ratings block arrives only marginally later with no user-visible effect.

### Fix 2: Remove listenAlloy()

listenAlloy() was a function introduced to expose window.alloyLoader — a Promise that was intended to resolve when alloy dispatched a pageView event. The function had a // TODO this method should be removed about two weeks after going live comment indicating it was always meant to be temporary. Investigation confirms it is now dead code for two independent reasons: first, the event listener inside it checks e.detail.type === 'pageView', but the alloy_sendEvent custom event dispatched by milo's helpers.js has a detail object of { destinations, propositions, inferences, decisions } with no type field — so the condition is never true and the promise is never resolved via the event. Second, a codebase-wide search found zero consumers of window.alloyLoader in either da-express-milo or milo, confirming nothing awaits it.

The practical consequence was that the setTimeout(..., 3000) fallback — the only code path that ever resolved the promise — fired unconditionally on every page load at exactly 3 seconds, creating a guaranteed JS task right in the middle of the LCP and TTI measurement windows. Removing the function and its call site eliminates this timer entirely with no effect on analytics, click tracking (which operates through Launch rules and the safelyFireAnalyticsEvent pattern in instrument.js independently), or any other runtime behavior.

---

## Jira Ticket

Resolves: [MWPW-192838](https://jira.corp.adobe.com/browse/MWPW-192838)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-192838--da-express-milo--adobecom.aem.page/express/ |

---

## Verification Steps

These updates should have no visible or functional effect, other than increasing the pageload speed and improving the CWV's of our pages.

---

## Potential Regressions

N/A

---

## Additional Notes

<img width="1556" height="340" alt="stage_trace" src="https://github.com/user-attachments/assets/20ed4bed-a7ff-42a7-9479-e2f8ded591a0" />

<img width="1554" height="329" alt="mwpw-192838_trace" src="https://github.com/user-attachments/assets/b4c37b7f-6ccc-43ac-a536-bee46fd115cf" />

