### PR TITLE
MWPW-192736: Add check for milolibs query param

### DIFF
--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -20,6 +20,7 @@ export const [setLibs, getLibs] = (() => {
         const { hostname, search } = location || window.location;
         if (!['.aem.', '.hlx.', '.stage.', 'local', '.da.'].some((i) => hostname.includes(i))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        if (!/^[a-zA-Z0-9_-]+$/.test(branch)) throw new Error('Invalid branch name.');
         if (branch === 'local') return 'http://localhost:6456/libs';
         if (branch === 'main' && hostname.includes('.stage.')) return '/libs';
         return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;


### PR DESCRIPTION
Whitelist branch parameter with `/^[a-zA-Z0-9_-]+$/`; throw on any other characters.

## Ticket
https://jira.corp.adobe.com/browse/MWPW-192736

## Test URLs
Before: https://stage--da-express-milo--adobecom.aem.page/
After: https://MWPW-192736--da-express-milo--zagi25.aem.page/

---
_This PR was generated by Claude (Anthropic's Claude Code CLI)._