### PR TITLE
CKG Pill Fix For Template X

### DIFF
--- a/express/code/scripts/utils/content-replace.js
+++ b/express/code/scripts/utils/content-replace.js
@@ -205,6 +205,7 @@ async function getReplacementsFromSearch() {
     phformat,
     topics,
     q,
+    ckgid,
   } = params;
   if (!tasks && !phformat) {
     return null;
@@ -222,6 +223,7 @@ async function getReplacementsFromSearch() {
   const sanitizedTasksx = tasksx?.match(exp) ? '' : tasksx;
   const sanitizedTopics = topics?.match(exp) ? '' : topics;
   const sanitizedQuery = q?.match(exp) ? '' : q;
+  const sanitizedCkgId = ckgid?.match(exp) ? '' : ckgid;
 
   const tasksPair = Object.entries(categories).find((cat) => cat[1] === sanitizedTasks);
   const xTasksPair = Object.entries(xCategories).find((cat) => cat[1] === sanitizedTasksx);
@@ -229,6 +231,11 @@ async function getReplacementsFromSearch() {
   let translatedTasks = xTasksPair?.[1] ? xTasksPair[0].toLowerCase() : sanitizedTasksx;
   if (!translatedTasks) {
     translatedTasks = tasksPair?.[1] ? tasksPair[0].toLowerCase() : sanitizedTasks;
+  }
+  // CKG searches already include a fully qualified query phrase in `topics`/`q`.
+  // Appending translated tasks duplicates terms in page title, marquee heading, and breadcrumbs.
+  if (sanitizedCkgId) {
+    translatedTasks = '';
   }
   return {
     '{{queryTasks}}': sanitizedTasks || '',


### PR DESCRIPTION
## Summary

Fixes malformed/overlong search-page headings for CKG pill navigation by updating template search metadata replacement logic.

When a search URL includes `ckgid`, we now avoid appending translated task text on top of an already complete `topics/q` phrase, which prevents duplicate terms in:
- search marquee title
- `template-x` toolbar `h2`
- templates breadcrumbs

---

## Jira Ticket

Resolves: [MWPW-192910](https://jira.corp.adobe.com/browse/MWPW-192910)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/templates/search?tasks=+&tasksx=planner%2C+calendar&phformat=3%3A4&topics=weekly+planner+calendar&q=Weekly+Planner+Calendar&ckgid=ckg%3AINTENT%3A14499%3Aweekly_planner&searchId=228312 |
| **After** | https://template-x-ckg-headings--da-express-milo--adobecom.aem.page/express/templates/search?tasks=+&tasksx=planner%2C+calendar&phformat=3%3A4&topics=weekly+planner+calendar&q=Weekly+Planner+Calendar&ckgid=ckg%3AINTENT%3A14499%3Aweekly_planner&searchId=228312&martech=off |

---

## Verification Steps

- Open the **Before** URL and note the page title treatment in:
  - search marquee heading
  - template-x toolbar heading (`h2`)
  - breadcrumbs label
- Open the **After** URL with the same query params.
- Confirm the heading text is no longer malformed/duplicated and reflects the intended query phrase.
- Spot check live template pages for regression.
---

## Potential Regressions

- https://template-x-ckg-headings--da-express-milo--adobecom.aem.live/express/templates/?martech=off

---

## Additional Notes

- Scope is metadata replacement for template search pages (`template-search-page=Y`) when `ckgid` is present.
- This is not a TAAS fetch/render logic change; it targets CKG search URL title composition.