### PR TITLE
MWPW-192826 Color Wheel - Primary color can move

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -475,7 +475,8 @@ function buildPrimaryColorContent(controller) {
   primaryColorAdapter = null;
 
   const state = controller.getState();
-  const baseColor = swatchHexListFromState(state)[0];
+  const baseColorIndex = state.baseColorIndex ?? 0;
+  const baseColor = state.swatches?.[baseColorIndex]?.hex || '#FF0000';
   const adapter = createBaseColorAdapter(
     baseColor,
     'HEX',
@@ -483,7 +484,6 @@ function buildPrimaryColorContent(controller) {
       onColorChange: (detail) => {
         if (!detail?.hex) return;
         controller.setBaseColor(detail.hex);
-        controller.setSwatchHex(0, detail.hex);
       },
       onColorChangeEnd: () => {
         // eslint-disable-next-line no-underscore-dangle
@@ -493,10 +493,11 @@ function buildPrimaryColorContent(controller) {
         const locked = detail?.locked;
         const current = swatchRailController?.getState?.()?.lockedByIndex || new Set();
         const next = new Set(current);
+        const currentBaseIndex = controller.getState().baseColorIndex ?? 0;
         if (locked) {
-          next.add(0);
+          next.add(currentBaseIndex);
         } else {
-          next.delete(0);
+          next.delete(currentBaseIndex);
         }
         swatchRailController?.setState?.({ lockedByIndex: next });
       },
@@ -1070,11 +1071,12 @@ export default async function decorate(block) {
       paletteUnsubscribe = controller.subscribe((state) => {
         currentPalette = paletteFromThemeState(state);
         layoutInstance?.context?.set('palette', currentPalette);
-        const firstHex = swatchHexListFromState(state)[0];
+        const baseIdx = state.baseColorIndex ?? 0;
+        const baseHex = state.swatches?.[baseIdx]?.hex;
         const currentColor = primaryColorAdapter?.element?.color;
-        if (primaryColorAdapter?.setColor && firstHex
-          && String(currentColor).toUpperCase() !== String(firstHex).toUpperCase()) {
-          primaryColorAdapter.setColor(firstHex);
+        if (primaryColorAdapter?.setColor && baseHex
+          && String(currentColor).toUpperCase() !== String(baseHex).toUpperCase()) {
+          primaryColorAdapter.setColor(baseHex);
         }
       });
 


### PR DESCRIPTION
## Summary

Fixes color wheel bug where dragging color strip updates wrong strip(s) instead of the dragged strip. Primary color should be able to be dragged to any position and retain its primary color status.

---

## Jira Ticket

Resolves: [MWPW-192826](https://jira.corp.adobe.com/browse/MWPW-192826)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-primary-drag--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

- Navigate to the Color Wheel page and open the Primary Color tab.
- Observe the row of color strips.
- Change the left most color strip.
- Drag the left most color strip to the last position in the row.
- Change the color on the large color picker.
- Before: Two strips changed simultaneously.
- After: Only the primary color strip (in the last position) should change.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
