### PR TITLE
MWPW-192648 Color Wheel - Generate random resets primary color marker

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -830,6 +830,7 @@ export default async function decorate(block) {
             // If no HISTORY_EVENT fires (e.g. all colors locked, palette unchanged),
             // reset the flag so it doesn't corrupt the next undo/redo
             queueMicrotask(() => { isGeneratingRandom = false; });
+            primaryColorAdapter?.element?.resetOriginalColor?.();
           },
           transformPalette: makeTransformPalette(
             () => activeHarmonyRule,
@@ -984,6 +985,7 @@ export default async function decorate(block) {
           onGenerateRandom: () => {
             isGeneratingRandom = true;
             queueMicrotask(() => { isGeneratingRandom = false; });
+            primaryColorAdapter?.element?.resetOriginalColor?.();
           },
           transformPalette: makeTransformPalette(
             () => activeHarmonyRule,


### PR DESCRIPTION
## Summary

Fixes color wheel bug in primary color tab: original color dots don't update when palette is changed by shuffling

---

## Jira Ticket

Resolves: [MWPW-192648](https://jira.corp.adobe.com/browse/MWPW-192648)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-primary-dot--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

1. Go to the Color Wheel page
2. Land on the page with one of the premade palettes loaded
3. Shuffle through colors to change the palette
4. Tab over to the Primary color tab
5. Observe the dots indicating the original color location
6. Before: The dots are still showing the position of the original color from when the page first loaded — not the current first color strip. The reference point is stale and misleading.
7. After: The dots should be aligned to the first color strip in the current (shuffled) palette.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
