### PR TITLE
[MWPW-192106] keep floating search bar until scroll reaches footer of explore page

### DIFF
--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -135,7 +135,12 @@ export function setupStickyBounds(block, searchBar) {
   endSentinel.dataset.searchBarEndSentinel = 'true';
   endSentinel.setAttribute('aria-hidden', 'true');
   endSentinel.style.cssText = 'display:block;inline-size:1px;block-size:1px;';
-  colorExploreBlock.after(endSentinel);
+  const footer = document.querySelector('footer');
+  if (footer) {
+    footer.before(endSentinel);
+  } else {
+    colorExploreBlock.after(endSentinel);
+  }
 
   let stickyEnabled = true;
 


### PR DESCRIPTION
## Summary

Increase the sentinal area for floating search bar beyond explore block on explore page.

---

## Jira Ticket

Resolves: [MWPW-192106](https://jira.corp.adobe.com/browse/MWPW-192106)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/explore |
| **After**   | https://MWPW-192106-floating-search--express-color--adobecom.aem.page/explore?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
