### PR TITLE
MWPW-192929 Color - Add lock to all harmonies

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -614,7 +614,12 @@ function createSwatchRailControllerBridge(controller) {
         } else {
           incoming = [];
         }
+        const prevSize = lockedByIndex.size;
         lockedByIndex = new Set(incoming.filter((index) => Number.isInteger(index) && index >= 0));
+        const lockAdded = lockedByIndex.size > prevSize;
+        if (lockAdded && controller.getState().harmonyRule !== 'CUSTOM') {
+          controller.setHarmonyRule('CUSTOM');
+        }
       }
 
       const current = controller.getState();
@@ -885,10 +890,8 @@ export default async function decorate(block) {
 
       const updateBaseColorBadge = () => {
         const hide = activeTab !== 'color-wheel' || activeHarmonyRule === 'CUSTOM';
-        const hideLock = activeTab === 'color-wheel' && activeHarmonyRule !== 'CUSTOM';
         stripHost.querySelectorAll('color-swatch-rail').forEach((rail) => {
           rail.hideBaseColorBadge = hide;
-          rail.hideLock = hideLock;
         });
       };
 
@@ -1031,8 +1034,12 @@ export default async function decorate(block) {
       const badgeRuleUnsubscribe = controller.subscribe((state) => {
         const rule = state.harmonyRule || 'CUSTOM';
         if (rule !== activeHarmonyRule) {
+          const wasCustom = activeHarmonyRule === 'CUSTOM';
           activeHarmonyRule = rule;
           updateBaseColorBadge();
+          if (wasCustom && rule !== 'CUSTOM') {
+            swatchRailController?.setState?.({ lockedByIndex: new Set() });
+          }
         }
       });
       const prevHistoryCleanup = historyCleanup;


### PR DESCRIPTION
## Summary

Add the lock button to the non-custom harmonies where is was previously excluded

---

## Jira Ticket

Resolves: [MWPW-192929](https://jira.corp.adobe.com/browse/MWPW-192929)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-lock--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

1. Load the page and click the lock on a strip.
3. Select a color harmony from below the color wheel (Analogous, Triad, etc).
5. The strip should unlock. Hover over color strip and see the unlocked icon.
7. Click the lock. The color harmony should revert back to Custom and the strip should remain locked.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
