### PR TITLE
Stray Icons For Template X Fix

### DIFF
--- a/express/code/blocks/template-x-carousel/template-x-carousel.css
+++ b/express/code/blocks/template-x-carousel/template-x-carousel.css
@@ -61,7 +61,7 @@
   margin-top: 22px;
 }
 
-.template-x-carousel.v2 .gallery .template:first-child .still-wrapper {
+.template-x-carousel.v2 .gallery .template:first-child {
   margin-left: var(--spacing-300);
 }
 
@@ -653,7 +653,7 @@ nav:has(+ .template-x-carousel.bc.v2) ol.templates-breadcrumbs li:not(:last-chil
     padding-left: var(--spacing-600);
   }
 
-  .template-x-carousel.v2 .gallery .template:first-child .still-wrapper {
+  .template-x-carousel.v2 .gallery .template:first-child {
     margin-left: 24px;
   }
 }
@@ -686,7 +686,7 @@ nav:has(+ .template-x-carousel.bc.v2) ol.templates-breadcrumbs li:not(:last-chil
     padding-left: var(--spacing-600);
   }
 
-  .template-x-carousel.v2 .gallery .template:first-child .still-wrapper {
+  .template-x-carousel.v2 .gallery .template:first-child {
     margin-left: 32px;
   }
 }


### PR DESCRIPTION
Here’s the PR description filled in from **MWPW-193207** and your **template-list-icon-fix** preview URL.

---

## Summary

Fixes stray icons rendering on the far left of the second and third template carousels on the Template Hub page (`/express/templates/`), so only intended carousel content shows.

---

## Jira Ticket

Resolves: [MWPW-193207](https://jira.corp.adobe.com/browse/MWPW-193207)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/templates/ |
| **After** | https://template-list-icon-fix--da-express-milo--adobecom.aem.page/express/templates/ |

---

## Verification Steps

1. Open the **After** URL above (Template Hub).
2. Scroll to the **second** and **third** template carousels on the page.
3. **Before:** Extra/unexpected icons appear on the **far left** of those carousels, outside the normal carousel content.
4. **After:** No stray icons; layout matches carousel content only, consistent with other carousels on the hub.

---

## Potential Regressions

- https://template-list-icon-fix--da-express-milo--adobecom.aem.live/express/templates/?martech=off  
- Spot-check other template hub carousels and any shared template-list / carousel UI for missing controls or incorrect icon visibility.

---

## Additional Notes

- Production reference: https://www.adobe.com/express/templates/  
- Related clone: [MWPW-193205](https://jira.corp.adobe.com/browse/MWPW-193205) (Template Child page thumbnail sizing on mobile).