### PR TITLE
Template X Configurable Mobile Thumbnail Setting

### DIFF
--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1327,10 +1327,15 @@ function toggleMasonryView(block, props, button, toggleButtons) {
 }
 
 const views = ['sm', 'md', 'lg'];
+const MOBILE_TEMPLATE_VIEW_BREAKPOINT = 901;
 function getInitialViewIndex(props) {
-  const authoredViewIndex = views.findIndex(
-    (size) => props.initialTemplateView?.toLowerCase().trim() === size,
-  );
+  const isMobileViewport = window.innerWidth < MOBILE_TEMPLATE_VIEW_BREAKPOINT;
+  const authoredMobileView = props.initialTemplateViewMobile?.toLowerCase().trim();
+  const authoredDefaultView = props.initialTemplateView?.toLowerCase().trim();
+  const selectedView = isMobileViewport && authoredMobileView
+    ? authoredMobileView
+    : authoredDefaultView;
+  const authoredViewIndex = views.findIndex((size) => selectedView === size);
   return authoredViewIndex === -1 ? 0 : authoredViewIndex;
 }
 


### PR DESCRIPTION
## Summary

Adds configurable **default template thumbnail size per breakpoint** on template child pages so **Desktop** and **Mobile** can use different defaults (for example Desktop = Large, Mobile = Medium). If a value is not configured, behavior stays **Large**, matching the previous default on both devices.

---

## Jira Ticket

Resolves: [MWPW-193205](https://jira.corp.adobe.com/browse/MWPW-193205)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://template-x-mobile-setting--da-express-milo--adobecom.aem.page/drafts/templates/apples
 |

**Draft page (branch):** https://template-x-mobile-setting--da-express-milo--adobecom.aem.page/drafts/templates/apples

---

## Verification Steps

1. Open a **template child page** on **main** (or without the new config), e.g. production-style URL such as ` https://template-x-mobile-setting--da-express-milo--adobecom.aem.page/express/templates/flyer`, verify no visual or functional regression.
2. On the **after** URL (or the draft link above), confirm **mobile** uses the configured default size (e.g. **Small** when set).
3. Confirm **desktop** uses its configured default (e.g. **Medium**).

---

## Potential Regressions

- https://template-x-mobile-setting--da-express-milo--adobecom.aem.live/express/templates?martech=off
