### PR TITLE
Adjusted font-weight of long-form-blog h2s

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -136,7 +136,7 @@
   /* 20px */
 
   --heading-font-size-ml : 2rem;
- /* 32px */
+  /* 32px */
  
   --block-sm-max-width: 375px;
   --block-md-max-width: 830px;
@@ -483,16 +483,16 @@ main {
 }
 
 main .section:not([data-padding='none']):not(.xxxl-spacing-static,
-  .xxl-spacing-static,
-  .xl-spacing-static,
-  .xxxl-spacing,
-  .xxl-spacing,
-  .xl-spacing,
-  .l-spacing,
-  .m-spacing,
-  .s-spacing,
-  .xs-spacing,
-  .xxs-spacing)>.content:first-child {
+.xxl-spacing-static,
+.xl-spacing-static,
+.xxxl-spacing,
+.xxl-spacing,
+.xl-spacing,
+.l-spacing,
+.m-spacing,
+.s-spacing,
+.xs-spacing,
+.xxs-spacing)>.content:first-child {
   padding-top: 60px;
 }
 
@@ -1143,16 +1143,16 @@ main .section p {
 }
 
 main .section:not(.xxxl-spacing-static,
-  .xxl-spacing-static,
-  .xl-spacing-static,
-  .xxxl-spacing,
-  .xxl-spacing,
-  .xl-spacing,
-  .l-spacing,
-  .m-spacing,
-  .s-spacing,
-  .xs-spacing,
-  .xxs-spacing):last-of-type>.content:not(:has(+ .template-list-wrapper)) {
+.xxl-spacing-static,
+.xl-spacing-static,
+.xxxl-spacing,
+.xxl-spacing,
+.xl-spacing,
+.l-spacing,
+.m-spacing,
+.s-spacing,
+.xs-spacing,
+.xxs-spacing):last-of-type>.content:not(:has(+ .template-list-wrapper)) {
   padding-bottom: var(--spacing-600);
 }
 
@@ -1459,6 +1459,7 @@ main .section.long-form .content h2 {
 
 main .section.long-form.long-form-blog .content h2 {
   font-size: var(--Global-Typography-Size-Headings-Heading-XL);
+  font-weight: var(--heading-font-weight-extra);
   line-height: 104%;
 }
 


### PR DESCRIPTION
## Summary

Adjusted font-weight of long-form-blog h2s

---

## Jira Ticket

Resolves: [MWPW-192142](https://jira.corp.adobe.com/browse/MWPW-192142)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/fr/express/learn/blog/friendship-messages |
| **After**   | https://mwpw-192142--da-express-milo--adobecom.aem.page/fr/express/learn/blog/friendship-messages?martech=off |

---

## Verification Steps

- Navigate to the Before and After pages and observe the font weight of the h2 headers in each section of the blog content. 
- The After link h2 headers should be bolder, matching the design in Figma

---

## Potential Regressions

Targeted one-line change. Should be no regressions. Affects all long-form-blog content

---

## Additional Notes

N/A
