### PR TITLE
MWPW-193195 Color - Apply gradient toolbar

### DIFF
--- a/express/code/scripts/color-shared/modal/createGradientModalContent.js
+++ b/express/code/scripts/color-shared/modal/createGradientModalContent.js
@@ -156,6 +156,7 @@ export function createGradientModalContent(gradient, opts = {}) {
   const paletteForToolbar = {
     id: gradient?.id ?? '',
     name: gradient?.name ?? 'Gradient',
+    angle: angle || 90,
     colors: colorStops.map((s) => s.color),
   };
 

--- a/express/code/scripts/color-shared/modal/createGradientModalContent.js
+++ b/express/code/scripts/color-shared/modal/createGradientModalContent.js
@@ -160,6 +160,7 @@ export function createGradientModalContent(gradient, opts = {}) {
   };
 
   initFloatingToolbar(toolbarMount, {
+    type: 'gradient',
     palette: paletteForToolbar,
     ctaText: 'Create with color palette',
     showPaletteName: false,


### PR DESCRIPTION
## Summary

Use the gradient toolbar in the gradient modal on the explore page

---

## Jira Ticket

Resolves: [MWPW-193195](https://jira.corp.adobe.com/browse/MWPW-193195)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/explore |
| **After**   | https://methomas-gradient-toolbar--express-color--adobecom.aem.page/explore |

---

## Verification Steps

- Go to the test page and change the "color palettes" dropdown to "color gradients."
- Click on a gradient and the modal pops up.
- Toolbar should have the gradient preview and all actions (such as download) should use the gradient, not palette.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
