### PR TITLE
Web JSON Schema

### DIFF
--- a/express/code/scripts/express-delayed.js
+++ b/express/code/scripts/express-delayed.js
@@ -1,5 +1,6 @@
 import { getLibs, decorateButtonsDeprecated } from './utils.js';
 import BlockMediator from './block-mediator.min.js';
+import { loadWebApplicationSchema } from './utils/web-app-schema.js';
 
 let createTag; let getMetadata;
 let getConfig; let loadStyle;
@@ -74,6 +75,7 @@ export default async function loadDelayed() {
     addJapaneseSectionHeaderSizing();
     turnContentLinksIntoButtons();
     preloadSUSILight();
+    loadWebApplicationSchema();
     return null;
   } catch (error) {
     window.lana?.log(`Express-Delayed Error: ${error?.message || error?.detail || error}`, { tags: 'express-delayed', severity: 'error' });

--- a/express/code/scripts/utils/web-app-schema.js
+++ b/express/code/scripts/utils/web-app-schema.js
@@ -2,29 +2,36 @@ function getMeta(name) {
   return document.querySelector(`meta[name="${name}"]`)?.content;
 }
 
+function getPageDescription() {
+  const h1 = document.querySelector('main h1');
+  const intro = h1?.closest('div')?.querySelector('p') || document.querySelector('main p');
+  return intro?.textContent.trim() || '';
+}
+
 export function injectWebApplicationSchema() {
   const name = document.querySelector('main h1')?.textContent.trim() || document.title;
-  const description = getMeta('description') || '';
   const url = document.querySelector('link[rel="canonical"]')?.href || window.location.href;
 
   const offerPrice = getMeta('schema-offer-price') ?? '0';
   const offerPriceCurrency = getMeta('schema-offer-price-currency') || 'USD';
-  const offerUrl = getMeta('schema-offer-url');
-  const offerAvailability = getMeta('schema-offer-availability');
 
-  const offer = { '@type': 'Offer', price: offerPrice, priceCurrency: offerPriceCurrency };
-  if (offerUrl) offer.url = offerUrl;
-  if (offerAvailability) offer.availability = offerAvailability;
+  const offer = {
+    '@type': 'Offer',
+    price: offerPrice,
+    priceCurrency: offerPriceCurrency,
+    url,
+    availability: 'https://schema.org/InStock',
+  };
 
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'WebApplication',
     name,
     url,
-    description,
-    applicationCategory: getMeta('schema-application-category') || 'MultimediaApplication',
-    operatingSystem: getMeta('schema-operating-system') || 'Any',
-    browserRequirements: getMeta('schema-browser-requirements') || 'Requires JavaScript. Requires HTML5.',
+    description: getPageDescription(),
+    applicationCategory: 'MultimediaApplication',
+    operatingSystem: 'Any',
+    browserRequirements: 'Requires JavaScript. Requires HTML5.',
     offers: offer,
     creator: {
       '@type': 'Organization',

--- a/express/code/scripts/utils/web-app-schema.js
+++ b/express/code/scripts/utils/web-app-schema.js
@@ -1,7 +1,22 @@
+function getMeta(name) {
+  return document.querySelector(`meta[name="${name}"]`)?.content;
+}
+
 export function injectWebApplicationSchema() {
   const name = document.querySelector('main h1')?.textContent.trim() || document.title;
-  const description = document.querySelector('meta[name="description"]')?.content || '';
+  const description = getMeta('description') || '';
   const url = document.querySelector('link[rel="canonical"]')?.href || window.location.href;
+
+  const offerPrice = getMeta('schema-offer-price') ?? '0';
+  const offerPriceCurrency = getMeta('schema-offer-price-currency') || 'USD';
+  const offerUrl = getMeta('schema-offer-url');
+  const offerAvailability = getMeta('schema-offer-availability');
+  const offerCategory = getMeta('schema-offer-category');
+
+  const offer = { '@type': 'Offer', price: offerPrice, priceCurrency: offerPriceCurrency };
+  if (offerUrl) offer.url = offerUrl;
+  if (offerAvailability) offer.availability = offerAvailability;
+  if (offerCategory) offer.offerCategory = offerCategory;
 
   const schema = {
     '@context': 'https://schema.org',
@@ -9,14 +24,10 @@ export function injectWebApplicationSchema() {
     name,
     url,
     description,
-    applicationCategory: 'MultimediaApplication',
-    operatingSystem: 'Any',
-    browserRequirements: 'Requires JavaScript. Requires HTML5.',
-    offers: {
-      '@type': 'Offer',
-      price: '0',
-      priceCurrency: 'USD',
-    },
+    applicationCategory: getMeta('schema-application-category') || 'MultimediaApplication',
+    operatingSystem: getMeta('schema-operating-system') || 'Any',
+    browserRequirements: getMeta('schema-browser-requirements') || 'Requires JavaScript. Requires HTML5.',
+    offers: offer,
     creator: {
       '@type': 'Organization',
       name: 'Adobe',
@@ -29,4 +40,10 @@ export function injectWebApplicationSchema() {
   script.id = 'web-application-schema';
   script.textContent = JSON.stringify(schema);
   document.head.appendChild(script);
+}
+
+export function loadWebApplicationSchema() {
+  if (getMeta('web-app-schema') !== 'on') return;
+  if (document.getElementById('web-application-schema')) return;
+  injectWebApplicationSchema();
 }

--- a/express/code/scripts/utils/web-app-schema.js
+++ b/express/code/scripts/utils/web-app-schema.js
@@ -1,0 +1,32 @@
+export function injectWebApplicationSchema() {
+  const name = document.querySelector('main h1')?.textContent.trim() || document.title;
+  const description = document.querySelector('meta[name="description"]')?.content || '';
+  const url = document.querySelector('link[rel="canonical"]')?.href || window.location.href;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name,
+    url,
+    description,
+    applicationCategory: 'MultimediaApplication',
+    operatingSystem: 'Any',
+    browserRequirements: 'Requires JavaScript. Requires HTML5.',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
+    creator: {
+      '@type': 'Organization',
+      name: 'Adobe',
+      url: 'https://www.adobe.com',
+    },
+  };
+
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.id = 'web-application-schema';
+  script.textContent = JSON.stringify(schema);
+  document.head.appendChild(script);
+}

--- a/express/code/scripts/utils/web-app-schema.js
+++ b/express/code/scripts/utils/web-app-schema.js
@@ -11,12 +11,10 @@ export function injectWebApplicationSchema() {
   const offerPriceCurrency = getMeta('schema-offer-price-currency') || 'USD';
   const offerUrl = getMeta('schema-offer-url');
   const offerAvailability = getMeta('schema-offer-availability');
-  const offerCategory = getMeta('schema-offer-category');
 
   const offer = { '@type': 'Offer', price: offerPrice, priceCurrency: offerPriceCurrency };
   if (offerUrl) offer.url = offerUrl;
   if (offerAvailability) offer.availability = offerAvailability;
-  if (offerCategory) offer.offerCategory = offerCategory;
 
   const schema = {
     '@context': 'https://schema.org',

--- a/test/scripts/utils/web-app-schema.test.js
+++ b/test/scripts/utils/web-app-schema.test.js
@@ -1,0 +1,93 @@
+import { expect } from '@esm-bundle/chai';
+
+import {
+  injectWebApplicationSchema,
+  loadWebApplicationSchema,
+} from '../../../express/code/scripts/utils/web-app-schema.js';
+
+function getSchema() {
+  return JSON.parse(document.getElementById('web-application-schema').textContent);
+}
+
+describe('WebApplication schema', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    document.title = '';
+  });
+
+  it('constructs schema fields dynamically from the page', () => {
+    document.head.innerHTML = `
+      <link rel="canonical" href="https://www.adobe.com/express/feature/image/crop/">
+      <meta name="schema-offer-price" content="9.99">
+      <meta name="schema-offer-price-currency" content="EUR">
+      <meta name="schema-offer-url" content="https://authored.example.com">
+      <meta name="schema-offer-availability" content="https://schema.org/PreOrder">
+      <meta name="schema-application-category" content="AuthoredCategory">
+      <meta name="schema-operating-system" content="AuthoredOS">
+      <meta name="schema-browser-requirements" content="Authored requirements">
+    `;
+    document.body.innerHTML = `
+      <main>
+        <div>
+          <div>
+            <h1><em>Crop your image</em> for free.</h1>
+            <p>The online Crop image tool from Adobe Express transforms your images.</p>
+          </div>
+        </div>
+      </main>
+    `;
+
+    injectWebApplicationSchema();
+
+    expect(getSchema()).to.deep.equal({
+      '@context': 'https://schema.org',
+      '@type': 'WebApplication',
+      name: 'Crop your image for free.',
+      url: 'https://www.adobe.com/express/feature/image/crop/',
+      description: 'The online Crop image tool from Adobe Express transforms your images.',
+      applicationCategory: 'MultimediaApplication',
+      operatingSystem: 'Any',
+      browserRequirements: 'Requires JavaScript. Requires HTML5.',
+      offers: {
+        '@type': 'Offer',
+        price: '9.99',
+        priceCurrency: 'EUR',
+        url: 'https://www.adobe.com/express/feature/image/crop/',
+        availability: 'https://schema.org/InStock',
+      },
+      creator: {
+        '@type': 'Organization',
+        name: 'Adobe',
+        url: 'https://www.adobe.com',
+      },
+    });
+  });
+
+  it('uses default offer metadata values when not authored', () => {
+    document.body.innerHTML = `
+      <main>
+        <div>
+          <h1>Resize your image for free.</h1>
+          <p>Resize images quickly in Adobe Express.</p>
+        </div>
+      </main>
+    `;
+
+    injectWebApplicationSchema();
+
+    expect(getSchema().offers.price).to.equal('0');
+    expect(getSchema().offers.priceCurrency).to.equal('USD');
+  });
+
+  it('only loads when web app schema metadata is enabled', () => {
+    loadWebApplicationSchema();
+    expect(document.getElementById('web-application-schema')).to.be.null;
+
+    document.head.innerHTML = '<meta name="web-app-schema" content="on">';
+    loadWebApplicationSchema();
+    loadWebApplicationSchema();
+
+    expect(document.querySelectorAll('#web-application-schema')).to.have.length(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **WebApplication** JSON-LD (`application/ld+json`) for pages that opt in via metadata. The script runs from delayed load, injects a single `<script id="web-application-schema">` in `<head>`, and builds **name** from the main **H1** (fallback: `document.title`), **description** from the meta description, **url** from the canonical link (fallback: current URL), and sensible defaults for category, OS, browser requirements, free **Offer**, and Adobe **creator**. Authors can tune optional fields (`schema-application-category`, `schema-operating-system`, `schema-browser-requirements`, offer-related metas) and must set **`web-app-schema`** to **`on`** to enable injection. Duplicates are avoided if the script tag already exists.

---

## Jira Ticket

Resolves: [MWPW-188099](https://jira.corp.adobe.com/browse/MWPW-188099)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** |  https://fqa-schema--da-express-milo--adobecom.aem.live/drafts/echen/schema-demo |

**Schema demo (branch):** https://fqa-schema--da-express-milo--adobecom.aem.live/drafts/echen/schema-demo
**Page with schema validation turned off**  https://fqa-schema--da-express-milo--adobecom.aem.live/express/
---

## Verification Steps

1. Open a page that includes **`web-app-schema`** metadata set to **`on`** (e.g. the schema demo draft above).
2. View page source or DevTools → **Elements** → `<head>` and confirm a **`script`** with **`type="application/ld+json"`** and **`id="web-application-schema"`** whose JSON has **`@type": "WebApplication"`** and the expected **name**, **description**, and **url**.
3. Run [Schema Validator Test](https://validator.schema.org/#url=https%3A%2F%2Ffqa-schema--da-express-milo--adobecom.aem.live%2Fdrafts%2Fechen%2Fschema-demo) on the deployed URL; confirm no errors for this structured data.
4. **Before:** pages without the opt-in meta should not get this JSON-LD from this utility. **After:** opted-in pages should expose WebApplication schema without conflicting duplicate injection (second load should not add a second script).

---

## Potential Regressions

- https://fqa-schema--da-express-milo--adobecom.aem.live/express/?martech=off  
- Smoke key Express flows on the branch preview; delayed script should not noticeably affect LCP/INP (schema runs in `loadDelayed`).
