### PR TITLE
MWPW-192777 Fix color wheel marker stuck for #000000

### DIFF
--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -388,9 +388,10 @@ export class ColorWheelExpress extends ColorWheel {
     this.getCanvasPosition();
     this._dragIndex = index;
 
-    const markerV = this.swatches[index]?.hsv?.v != null
+    const rawV = this.swatches[index]?.hsv?.v != null
       ? Number(this.swatches[index].hsv.v)
       : this.wheelBrightness;
+    const markerV = rawV > 0 ? rawV : this.wheelBrightness;
 
     const moveHandler = (e) => {
       this._dragFixedBrightness = markerV;
@@ -441,10 +442,10 @@ export class ColorWheelExpress extends ColorWheel {
           this.paint();
         }
 
-        if (this.swatches.length > 0 && active?.hsv != null) {
+        if (this.swatches.length > 0 && active?.hsv != null && this._dragIndex < 0) {
           const activeV = Math.round(Number(active.hsv.v) ?? 100);
           const v = Math.min(100, Math.max(0, activeV));
-          if (this.wheelBrightness !== v) {
+          if (v > 0 && this.wheelBrightness !== v) {
             this.wheelBrightness = v;
             this.generateColorWheel();
           }


### PR DESCRIPTION
## Summary

Fix wheel marker getting stuck at #000000 and being unable to move it

---

## Jira Ticket

Resolves: [MWPW-192777](https://jira.corp.adobe.com/browse/MWPW-192777)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://methomas-center--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

1. Click the hexcode of the first color strip to open the Edit Color popover
2. Manually set the hex value to #000000
3. Try to move the black marker in the center of the color wheel
4. Before: Wouldn't move
5. After: Moves normally

---

## Potential Regressions

- https://methomas-center--express-color--adobecom.aem.page/create/color-accessibility

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
