### PR TITLE
Revert Change To Hero Color

### DIFF
--- a/express/code/blocks/hero-color/hero-color.css
+++ b/express/code/blocks/hero-color/hero-color.css
@@ -28,8 +28,7 @@ main .hero-color .text-container {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: 0;
-  padding: 16px;
+  margin: 15px;
   text-align: left;
   color: var(--color-black);
 }
@@ -88,39 +87,22 @@ main .hero-color .hidden-svg {
 }
 
 @media screen and (min-width: 900px) {
-  main .hero-color {
-    overflow: hidden;
-  }
-
-  main .hero-color::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 120px;
-    background: linear-gradient(to top, #fff 0%, transparent 100%);
-    pointer-events: none;
-    z-index: 1;
-  }
-
   main .hero-color .svg-container {
-    height: 800px;
-    position: relative;
+    min-height: 336px;
+    padding-left: 50%;
   }
 
   main .hero-color .svg-container .color-svg {
-    position: static;
+    position: relative;
   }
 
   main .hero-color .svg-container .color-svg-img {
     margin: 0;
     width: 1424px;
-    height: 800px;
+    height: 336px;
+    overflow: hidden;
     position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    top: 0;
+    left: 0;
   }
 
   main .hero-color .text-container {
@@ -133,7 +115,6 @@ main .hero-color .hidden-svg {
     color: unset;
     box-sizing: border-box;
     margin: 0;
-    padding: 0 var(--spacing-500);
   }
 
   main .hero-color .text-container > div {

--- a/express/code/blocks/hero-color/hero-color.js
+++ b/express/code/blocks/hero-color/hero-color.js
@@ -75,19 +75,34 @@ function decorateColors(block) {
   return { secondaryColor };
 }
 
-const SVG_HEIGHT_DESKTOP = '800px';
-const SVG_HEIGHT_MOBILE = '200px';
+function getContentContainerHeight() {
+  const contentContainer = document.querySelector('.svg-container');
+
+  return contentContainer?.clientHeight;
+}
 
 function resizeSvgOnLoad() {
-  const mediaQuery = window.matchMedia('(min-width: 900px)');
-  const svg = document.querySelector('.color-svg-img');
-  svg.classList.remove('hidden-svg');
-  svg.style.height = mediaQuery.matches ? SVG_HEIGHT_DESKTOP : SVG_HEIGHT_MOBILE;
+  const interval = setInterval(() => {
+    if (document.readyState === 'complete') {
+      const height = getContentContainerHeight();
+      if (height) {
+        const svg = document.querySelector('.color-svg-img');
+        svg.classList.remove('hidden-svg');
+        svg.style.height = `${height}px`;
+        clearInterval(interval);
+      }
+    }
+  }, 50);
 }
 
 export function resizeSvg(event) {
+  const height = getContentContainerHeight();
   const svg = document.querySelector('.color-svg-img');
-  svg.style.height = event.matches ? SVG_HEIGHT_DESKTOP : SVG_HEIGHT_MOBILE;
+  if (event.matches) {
+    svg.style.height = `${height}px`;
+  } else {
+    svg.style.height = '200px';
+  }
 }
 
 function resizeSvgOnMediaQueryChange() {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Reverts a change made to hero color that was causing the header to bleed out. This change was introduced in https://github.com/adobecom/da-express-milo/pull/290 but its not clear if the change was needed since the block is not present on the sample page of that PR.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-193268

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://hero-color-fix--da-express-milo--adobecom.aem.page/express/colors/red |
|**After** | https://hero-color-fix--da-express-milo--adobecom.aem.page/drafts/bradjohn/extract?martech=off

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
Visit the first page and verify the header looks normal again.
Visit the second page and verify nothing was broken with this change.
---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
