### PR TITLE
MWPW-193196 Extract Page Sign-in Redirect to Self

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -81,6 +81,7 @@
     linear-gradient(-45deg, #ccc 25%, transparent 25%),
     linear-gradient(45deg, transparent 75%, #ccc 75%),
     linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  --color-extract-edit-bg-height: 207px;
 }
 
 /* ---- Inner container ---- */
@@ -597,7 +598,13 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   padding: 16px;
   border: 1px solid rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(28px);
-  height: 207px;
+  height: var(--color-extract-edit-bg-height);
+}
+
+.color-extract.has-image .color-extract-edit-left .image-upload-dropzone-container {
+  height: var(--color-extract-edit-bg-height);
+  width: 100%;
+  justify-content: center;
 }
 
 .color-extract .color-extract-edit-bg picture,
@@ -993,6 +1000,10 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 /* ==================== Responsive ==================== */
 
 @media (min-width: 600px) {
+  .color-extract {
+    --color-extract-edit-bg-height: 554px;
+  }
+
   .section:has(.color-extract-marquee-wrapper) {
     align-items: center;
     min-height: 800px;
@@ -1006,10 +1017,6 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   .color-extract.has-image .color-extract-inner {
     padding: 66px 24px 72px;
     gap: 48px;
-  }
-
-  .color-extract.has-image .color-extract-edit-bg {
-    height: 554px;
   }
 
   .color-extract .color-extract-toolbar-divider {
@@ -1056,6 +1063,10 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 }
 
 @media (min-width: 1200px) {
+  .color-extract {
+    --color-extract-edit-bg-height: 458px;
+  }
+
   .color-extract .color-extract-landing-bg {
     display: block;
   }
@@ -1112,10 +1123,6 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
     grid-template-columns: minmax(0, 668fr) minmax(0, 692fr);
   }
 
-  .color-extract.has-image .color-extract-edit-bg {
-    height: 458px;
-  }
-
   .color-extract .color-extract-swatch-rail {
     min-height: 0;
   }
@@ -1131,8 +1138,8 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 }
 
 @media (min-width: 1680px) {
-  .color-extract.has-image .color-extract-edit-bg {
-    height: 602px;
+  .color-extract {
+    --color-extract-edit-bg-height: 602px;
   }
 }
 

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -7,7 +7,7 @@ import parseBlockConfig from './helpers/parseConfig.js';
 import createHistoryManager from './helpers/historyManager.js';
 import { createUploadDropzone } from '../../scripts/color-shared/components/image-upload/image-upload.js';
 import { showExpressToast } from '../../scripts/color-shared/spectrum/components/express-toast.js';
-import { decorateAnalyticsAttributes } from '../../scripts/color-shared/utils/utilities.js';
+import { decorateAnalyticsAttributes, createColorPaletteParamApi, PARAM_NAME } from '../../scripts/color-shared/utils/utilities.js';
 
 let extractionErrorShown = false;
 async function showExtractionError() {
@@ -811,6 +811,9 @@ function renderColorVariant(block, rows, config) {
     if (oldImg && imgLoadHandler) oldImg.removeEventListener('load', imgLoadHandler);
     if (markers) markers.destroy();
 
+    if (!edit.bgWrapper.isConnected) {
+      edit.leftCol.querySelector('.image-upload-dropzone-container')?.replaceWith(edit.bgWrapper);
+    }
     currentCanvas = drawImageToCanvas(image);
     await setupMarkers(currentCanvas);
 
@@ -936,6 +939,18 @@ function renderColorVariant(block, rows, config) {
 
   if (resolvedConfig.enableImageUpload) {
     attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay);
+  }
+
+  if (new URLSearchParams(window.location.search).has(PARAM_NAME)) {
+    const { getResolvedPalette, getResolvedPaletteName } = createColorPaletteParamApi();
+    const colors = getResolvedPalette();
+    const paletteName = getResolvedPaletteName();
+    controller.setState({ swatches: colors.map((hex) => ({ hex })), baseColorIndex: 0 });
+    if (paletteName) controller.setMetadata({ name: paletteName });
+    edit.bgWrapper.replaceWith(dropzone.container);
+    block.classList.add('has-image');
+    window.history.replaceState({ colorExtract: 'results' }, '');
+    floatingToolbar.mount();
   }
 
   window.addEventListener('popstate', (e) => {
@@ -1235,6 +1250,9 @@ async function renderGradientVariant(block, rows, config) {
     if (oldImg && imgLoadHandler) oldImg.removeEventListener('load', imgLoadHandler);
     if (markers) markers.destroy();
 
+    if (!edit.bgWrapper.isConnected) {
+      edit.leftCol.querySelector('.image-upload-dropzone-container')?.replaceWith(edit.bgWrapper);
+    }
     currentCanvas = drawImageToCanvas(image);
     await setupMarkers(currentCanvas);
     runGradientExtraction(currentCanvas);
@@ -1372,6 +1390,22 @@ async function renderGradientVariant(block, rows, config) {
 
   if (resolvedConfig.enableImageUpload) {
     attachWindowDragHandlers(block, dropzone, dragOverlay, loadingOverlay);
+  }
+
+  if (new URLSearchParams(window.location.search).has(PARAM_NAME)) {
+    const { getResolvedPalette } = createColorPaletteParamApi();
+    const colors = getResolvedPalette();
+    const colorStops = colors.map((color, i) => ({
+      color,
+      position: colors.length <= 1 ? 0.5 : i / (colors.length - 1),
+    }));
+    const gradientData = { type: 'linear', angle: 90, colorStops };
+    gradientEditor.setGradient(gradientData);
+    syncSwatchesFromGradient(gradientData);
+    edit.bgWrapper.replaceWith(dropzone.container);
+    block.classList.add('has-image');
+    window.history.replaceState({ colorExtract: 'results' }, '');
+    floatingToolbar.mount();
   }
 
   window.addEventListener('popstate', (e) => {

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -34,7 +34,7 @@ function pageHasBlock(...classNames) {
 export function buildColorSignInRedirectUrl(colors, name) {
   const { setOnUrl } = createColorPaletteParamApi();
 
-  if (pageHasBlock('color-explore', 'color-extract')) {
+  if (pageHasBlock('color-explore')) {
     const prefix = getLocalePrefix();
     const url = new URL(`${prefix}${COLOR_WHEEL_PATH}`, window.location.origin);
     setOnUrl(url, colors, { name });

--- a/test/scripts/color-shared/utils/susiRedirect.test.js
+++ b/test/scripts/color-shared/utils/susiRedirect.test.js
@@ -76,7 +76,7 @@ describe('buildColorSignInRedirectUrl', () => {
     expect(param).to.include('FF0000');
   });
 
-  it('uses current page URL when not on color-explore or color-extract', () => {
+  it('uses current page URL when not on color-explore', () => {
     window.history.replaceState({}, '', '/create/color-wheel');
 
     const result = buildColorSignInRedirectUrl(colors, name);
@@ -96,16 +96,16 @@ describe('buildColorSignInRedirectUrl', () => {
     expect(url.pathname).to.equal('/create/color-wheel');
   });
 
-  it('redirects to color-wheel when on color-extract page', () => {
+  it('uses current page URL for color-extract', () => {
     const el = document.createElement('div');
     el.className = 'color-extract';
     document.body.appendChild(el);
 
-    window.history.replaceState({}, '', '/color-extract');
+    window.history.replaceState({}, '', '/create/image');
 
     const result = buildColorSignInRedirectUrl(colors, name);
     const url = new URL(result);
-    expect(url.pathname).to.equal('/create/color-wheel');
+    expect(url.pathname).to.equal('/create/image');
   });
 
   it('preserves locale prefix on color-explore redirect', () => {


### PR DESCRIPTION
## Summary

On extract page, when a user clicks "save to library" and needs to sign in via SUSI Light, they should be redirected to the same page after sign in (not color wheel page). Palette will be retained. Image will disappear and upload dropzone will be in its place.

---

## Jira Ticket

Resolves: [MWPW-193196](https://jira.corp.adobe.com/browse/MWPW-193196)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image?color-palette=ADEEC5%2CB72818%2CFFA213%2C4B75FF%2C480058&color-palette-name=My+Color+Theme |
| **After**   | https://methomas-extract-redirect--express-color--adobecom.aem.page/create/image?color-palette=ADEEC5%2CB72818%2CFFA213%2C4B75FF%2C480058&color-palette-name=My+Color+Theme |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image-gradient?color-palette=ADEEC5%2CB72818%2CFFA213%2C4B75FF%2C480058&color-palette-name=My+Color+Theme |
| **After**   | https://methomas-extract-redirect--express-color--adobecom.aem.page/create/image-gradient?color-palette=ADEEC5%2CB72818%2CFFA213%2C4B75FF%2C480058&color-palette-name=My+Color+Theme |

---

## Verification Steps
You won't be able to verify the sign-in redirect on the test branch because of ims but you can see the experience that users will be redirected to (with the palette and image dropzone)
- Go to the test page. 
- You should see the "extracted" view of the extract page populated with the palette from the url params. In place of an image, you should see the "upload your image" dropzone.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
