### PR TITLE
[MWPW-192106] hide floating search bar and floating toolbar as scroll reaches banner

### DIFF
--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -136,10 +136,7 @@ export function setupStickyBounds(block, searchBar) {
   endSentinel.setAttribute('aria-hidden', 'true');
   endSentinel.style.cssText = 'display:block;inline-size:1px;block-size:1px;';
   const footer = document.querySelector('footer');
-  const bannerBg = document.querySelector('.banner-bg');
-  const bannerBeforeFooter = bannerBg
-    && (!footer || document.querySelectorAll('.banner-bg, footer')[0] === bannerBg);
-  const sentinelTarget = bannerBeforeFooter ? bannerBg : footer;
+  const sentinelTarget = document.querySelector('.banner-bg, footer');
   if (sentinelTarget) {
     sentinelTarget.before(endSentinel);
   } else {

--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -135,7 +135,6 @@ export function setupStickyBounds(block, searchBar) {
   endSentinel.dataset.searchBarEndSentinel = 'true';
   endSentinel.setAttribute('aria-hidden', 'true');
   endSentinel.style.cssText = 'display:block;inline-size:1px;block-size:1px;';
-  const footer = document.querySelector('footer');
   const sentinelTarget = document.querySelector('.banner-bg, footer');
   if (sentinelTarget) {
     sentinelTarget.before(endSentinel);

--- a/express/code/blocks/color-search-marquee/color-search-marquee.js
+++ b/express/code/blocks/color-search-marquee/color-search-marquee.js
@@ -136,8 +136,12 @@ export function setupStickyBounds(block, searchBar) {
   endSentinel.setAttribute('aria-hidden', 'true');
   endSentinel.style.cssText = 'display:block;inline-size:1px;block-size:1px;';
   const footer = document.querySelector('footer');
-  if (footer) {
-    footer.before(endSentinel);
+  const bannerBg = document.querySelector('.banner-bg');
+  const bannerBeforeFooter = bannerBg
+    && (!footer || document.querySelectorAll('.banner-bg, footer')[0] === bannerBg);
+  const sentinelTarget = bannerBeforeFooter ? bannerBg : footer;
+  if (sentinelTarget) {
+    sentinelTarget.before(endSentinel);
   } else {
     colorExploreBlock.after(endSentinel);
   }

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -355,23 +355,46 @@ export async function initFloatingToolbar(container, options = {}) {
     reserveSpace,
   });
 
-  /* Hide toolbar when the page footer scrolls into view (mirrors floating-cta pattern) */
+  /* Hide toolbar when the page footer or .banner-bg scrolls into view */
   let footerIo = null;
-  const footer = document.querySelector('footer');
-  if (footer && typeof IntersectionObserver !== 'undefined') {
-    footerIo = new IntersectionObserver((entries) => {
-      const isVisible = entries[0].isIntersecting || entries[0].intersectionRatio > 0;
-      wrapper.classList.toggle('ax-toolbar-footer-hidden', isVisible);
-      if (isVisible) {
-        toolbar.closeDrawer?.();
-        wrapper.setAttribute('aria-hidden', 'true');
-        wrapper.setAttribute('inert', '');
-      } else {
-        wrapper.removeAttribute('aria-hidden');
-        wrapper.removeAttribute('inert');
-      }
-    }, { rootMargin: '32px', threshold: 0 });
-    footerIo.observe(footer);
+  let bannerBgIo = null;
+  const hiddenBy = new Set();
+
+  const updateHiddenState = () => {
+    const shouldHide = hiddenBy.size > 0;
+    wrapper.classList.toggle('ax-toolbar-footer-hidden', shouldHide);
+    if (shouldHide) {
+      toolbar.closeDrawer?.();
+      wrapper.setAttribute('aria-hidden', 'true');
+      wrapper.setAttribute('inert', '');
+    } else {
+      wrapper.removeAttribute('aria-hidden');
+      wrapper.removeAttribute('inert');
+    }
+  };
+
+  if (typeof IntersectionObserver !== 'undefined') {
+    const footer = document.querySelector('footer');
+    if (footer) {
+      footerIo = new IntersectionObserver((entries) => {
+        const isVisible = entries[0].isIntersecting || entries[0].intersectionRatio > 0;
+        if (isVisible) hiddenBy.add('footer');
+        else hiddenBy.delete('footer');
+        updateHiddenState();
+      }, { rootMargin: '32px', threshold: 0 });
+      footerIo.observe(footer);
+    }
+
+    const bannerBg = document.querySelector('.banner-bg');
+    if (bannerBg) {
+      bannerBgIo = new IntersectionObserver((entries) => {
+        const isVisible = entries[0].isIntersecting || entries[0].intersectionRatio > 0;
+        if (isVisible) hiddenBy.add('banner-bg');
+        else hiddenBy.delete('banner-bg');
+        updateHiddenState();
+      }, { threshold: 0 });
+      bannerBgIo.observe(bannerBg);
+    }
   }
 
   return {
@@ -384,6 +407,7 @@ export async function initFloatingToolbar(container, options = {}) {
     destroy() {
       clearStickyBehavior(wrapper, stickyReserveContainer, stickyIo);
       if (footerIo) footerIo.disconnect();
+      if (bannerBgIo) bannerBgIo.disconnect();
       toolbar.destroy();
       wrapper.remove();
     },


### PR DESCRIPTION
## Summary

- **`createFloatingToolbar.js`**: Refactored the footer-based hide observer into a shared `updateHiddenState` helper tracked by a `hiddenBy` set. Added a second `IntersectionObserver` on `.banner-bg` so the floating toolbar (used on color-wheel, color-extract, color-blindness, and color-contrast-checker pages) is hidden when either the footer or the banner section scrolls into view. `destroy()` also disconnects the new banner observer.

- **`color-search-marquee.js`**: Updated `setupStickyBounds` to anchor the scroll end-sentinel before `.banner-bg` when it appears earlier in the DOM than the footer (determined via `querySelectorAll` document ordering). This causes the floating search bar on the color-explore page to deactivate its sticky behavior as the banner section approaches the viewport.

---

## Jira Ticket

Resolves: [MWPW-192106](https://jira.corp.adobe.com/browse/MWPW-192106)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/explore |
| **After**   | https://MWPW-192106-floating-disappear--express-color--adobecom.aem.page/explore?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://MWPW-192106-floating-disappear--express-color--adobecom.aem.page/create/color-wheel?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-contrast-analyzer |
| **After**   | https://MWPW-192106-floating-disappear--express-color--adobecom.aem.page/create/color-contrast-analyzer?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-accessibility |
| **After**   | https://MWPW-192106-floating-disappear--express-color--adobecom.aem.page/create/color-accessibility?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image |
| **After**   | https://MWPW-192106-floating-disappear--express-color--adobecom.aem.page/create/image?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image-gradient |
| **After**   | https://MWPW-192106-floating-disappear--express-color--adobecom.aem.page/create/image-gradient?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
