### PR TITLE
[MWPW-192344] Explore page sign in redirect and Open in Express mandatory sign in removal

### DIFF
--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -738,6 +738,7 @@ export default async function decorate(block) {
                   onLikeToggle: async ({ id, liked }) => (
                     activeDataService.toggleLike({ id, liked })
                   ),
+                  initialFocusSelector: () => null,
                 });
               }
             }

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -16,6 +16,7 @@ import { loadIconsRail } from '../../scripts/color-shared/spectrum/load-spectrum
 const VARIANTS = { STRIPS: 'strips', GRADIENTS: 'gradients' };
 const VARIANT_CLASSES = { GRADIENTS: 'gradients', PALETTES: 'palettes' };
 const THEME_URL_PARAM = 'theme';
+const ITEM_ID_URL_PARAM = 'id';
 const THEME_URL_QUERY_VALUE = {
   [VARIANTS.GRADIENTS]: 'color-gradients',
   [VARIANTS.STRIPS]: 'color-palettes',
@@ -83,6 +84,7 @@ async function loadStripSharedStyles() {
     }),
   );
 }
+
 
 function getVariantFromBlock(block) {
   if (block.classList.contains(VARIANT_CLASSES.GRADIENTS)) return VARIANTS.GRADIENTS;
@@ -714,7 +716,23 @@ export default async function decorate(block) {
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
           }
 
+          const isInitialStripsMount = !hasCompletedInitialModeMount;
           if (!hasCompletedInitialModeMount) hasCompletedInitialModeMount = true;
+          if (isInitialStripsMount) {
+            const itemId = new URLSearchParams(window.location.search).get(ITEM_ID_URL_PARAM);
+            if (itemId) {
+              const url = new URL(window.location.href);
+              url.searchParams.delete(ITEM_ID_URL_PARAM);
+              window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+              const item = await activeDataService.getTheme(itemId);
+              if (item) {
+                await modalManager.openPaletteSwatchesModal(item, {
+                  verticalMaxPerRow: config.swatchVerticalMaxPerRow,
+                  onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
+                });
+              }
+            }
+          }
           publishInstances();
         } finally {
           isMounting = false;

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -85,7 +85,6 @@ async function loadStripSharedStyles() {
   );
 }
 
-
 function getVariantFromBlock(block) {
   if (block.classList.contains(VARIANT_CLASSES.GRADIENTS)) return VARIANTS.GRADIENTS;
   if (block.classList.contains(VARIANT_CLASSES.PALETTES)) return VARIANTS.STRIPS;
@@ -736,7 +735,9 @@ export default async function decorate(block) {
               if (item) {
                 await modalManager.openPaletteSwatchesModal(item, {
                   verticalMaxPerRow: config.swatchVerticalMaxPerRow,
-                  onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
+                  onLikeToggle: async ({ id, liked }) => (
+                    activeDataService.toggleLike({ id, liked })
+                  ),
                 });
               }
             }

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -553,7 +553,15 @@ export default async function decorate(block) {
             document.dispatchEvent(new CustomEvent('color-explore:results-found', { bubbles: true }));
           }
 
+          const isInitialGradientMount = !hasCompletedInitialModeMount;
           if (!hasCompletedInitialModeMount) hasCompletedInitialModeMount = true;
+          if (isInitialGradientMount) {
+            const url = new URL(window.location.href);
+            if (url.searchParams.has(ITEM_ID_URL_PARAM)) {
+              url.searchParams.delete(ITEM_ID_URL_PARAM);
+              window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+            }
+          }
           publishInstances();
         } finally {
           isMounting = false;

--- a/express/code/libs/services/config.js
+++ b/express/code/libs/services/config.js
@@ -27,7 +27,7 @@ const PROD_CONFIG = {
         api: '/api/v2',
         themePath: '/themes',
         gradientPath: '/gradient',
-        themeBaseUrl: 'https://themes.adobe.io',
+        themeBaseUrl: 'https://themesb3.adobe.io',
         likeBaseUrl: 'https://asset.adobe.io',
         gradientBaseUrl: 'https://gradient.adobe.io',
       },
@@ -101,9 +101,11 @@ const STAGE_CONFIG = {
       // exploreBaseUrl: 'https://themesb3-stage.adobe.io', /** Due to issues we are seeing with stage url not loading, we have removed this for now. */
       endpoints: {
         ...PROD_CONFIG.services.kuler.endpoints,
-        themeBaseUrl: 'https://themes-stage.adobe.io',
+        // themeBaseUrl: 'https://themes-stage.adobe.io',
+        /** Due to issues we are seeing with stage url not loading, we have removed this for now. */
         likeBaseUrl: 'https://asset-stage.adobe.io',
-        gradientBaseUrl: 'https://gradient-stage.adobe.io',
+        // gradientBaseUrl: 'https://gradient-stage.adobe.io',
+        /** Due to issues we are seeing with stage url not loading, we have removed this for now. */
       },
     },
     behance: {

--- a/express/code/libs/services/plugins/kuler/actions/KulerActions.js
+++ b/express/code/libs/services/plugins/kuler/actions/KulerActions.js
@@ -219,19 +219,19 @@ export class ThemeActions extends BaseActionGroup {
    * @returns {string}
    */
   buildThemeUrl(themeId) {
-    const { serviceConfig, endpoints } = this.plugin;
-    const { themeBaseUrl } = serviceConfig;
+    const { endpoints } = this.plugin;
+    const { themeBaseUrl } = endpoints;
     const { api, themePath } = endpoints;
     BaseActionGroup.requireConfig({ themeBaseUrl, api, themePath }, 'Kuler');
-    return `${themeBaseUrl}${api}${themePath}/${themeId}`;
+    return `${themeBaseUrl}${api}${themePath}/${themeId}?metadata=all`;
   }
 
   /**
    * @returns {string}
    */
   buildThemeSaveUrl() {
-    const { serviceConfig, endpoints } = this.plugin;
-    const { themeBaseUrl } = serviceConfig;
+    const { endpoints } = this.plugin;
+    const { themeBaseUrl } = endpoints;
     const { api, themePath } = endpoints;
     BaseActionGroup.requireConfig({ themeBaseUrl, api, themePath }, 'Kuler');
     return `${themeBaseUrl}${api}${themePath}`;
@@ -346,7 +346,7 @@ export class ThemeActions extends BaseActionGroup {
       });
     }
     const url = this.buildThemeUrl(themeId);
-    return this.plugin.fetchWithFullUrl(url, 'GET');
+    return this.plugin.fetchWithFullUrl(url, 'GET', null, { skipAuth: true });
   }
 
   /**
@@ -431,8 +431,8 @@ export class GradientActions extends BaseActionGroup {
    * @returns {string}
    */
   buildGradientSaveUrl() {
-    const { serviceConfig, endpoints } = this.plugin;
-    const { gradientBaseUrl } = serviceConfig;
+    const { endpoints } = this.plugin;
+    const { gradientBaseUrl } = endpoints;
     const { api, gradientPath } = endpoints;
     BaseActionGroup.requireConfig({ gradientBaseUrl, api, gradientPath }, 'Kuler');
     return `${gradientBaseUrl}${api}${gradientPath}`;
@@ -443,8 +443,8 @@ export class GradientActions extends BaseActionGroup {
    * @returns {string}
    */
   buildGradientDeleteUrl(gradientId) {
-    const { serviceConfig, endpoints } = this.plugin;
-    const { gradientBaseUrl } = serviceConfig;
+    const { endpoints } = this.plugin;
+    const { gradientBaseUrl } = endpoints;
     const { api, gradientPath } = endpoints;
     BaseActionGroup.requireConfig({ gradientBaseUrl, api, gradientPath }, 'Kuler');
     return `${gradientBaseUrl}${api}${gradientPath}/${gradientId}`;

--- a/express/code/scripts/color-shared/modal/createModalManager.js
+++ b/express/code/scripts/color-shared/modal/createModalManager.js
@@ -153,6 +153,7 @@ export function createModalManager() {
       title = 'Modal',
       showTitle = false,
       onClose,
+      initialFocusSelector,
     } = options;
 
     onCloseCallback = onClose;
@@ -201,7 +202,7 @@ export function createModalManager() {
     announceToScreenReader(`${title} modal opened`, 'assertive');
 
     escHandler = handleEscapeClose(overlay, close);
-    focusTrap = trapFocus(overlay);
+    focusTrap = trapFocus(overlay, { getInitialFocus: initialFocusSelector });
 
     /* Force reflow so the browser records translateY(100%) before the open class fires. */
     // eslint-disable-next-line no-unused-expressions
@@ -263,6 +264,7 @@ export function createModalManager() {
       onClose: () => {
         contentView.destroy?.();
       },
+      initialFocusSelector: options.initialFocusSelector,
     });
     contentView.initNav?.();
   }

--- a/express/code/scripts/color-shared/services/createColorDataService.js
+++ b/express/code/scripts/color-shared/services/createColorDataService.js
@@ -1,6 +1,10 @@
 /* eslint-disable import/prefer-default-export, no-underscore-dangle */
 import { serviceManager } from '../../../libs/services/core/ServiceManager.js';
-import { gradientApiResponsesToGradients, themesToGradients } from '../../../libs/services/providers/transforms.js';
+import {
+  gradientApiResponsesToGradients,
+  themeToGradient,
+  themesToGradients,
+} from '../../../libs/services/providers/transforms.js';
 
 export const PALETTE_10_COLORS_MODAL = {
   id: 'palette-1',
@@ -322,6 +326,15 @@ export function createColorDataService(config) {
     return results;
   }
 
+  async function getTheme(id) {
+    const kuler = await serviceManager.getProvider('kuler');
+    if (!kuler) return null;
+    const raw = await kuler.getTheme(id);
+    if (!raw) return null;
+    const item = themeToGradient(raw);
+    return withDerivedMeta([ensurePaletteColors([item])[0]])[0] ?? null;
+  }
+
   function clearCache() {
     cache = null;
   }
@@ -336,6 +349,7 @@ export function createColorDataService(config) {
     search,
     searchMore,
     filter,
+    getTheme,
     clearCache,
     loadMore,
     toggleLike,

--- a/express/code/scripts/color-shared/spectrum/utils/a11y.js
+++ b/express/code/scripts/color-shared/spectrum/utils/a11y.js
@@ -85,7 +85,7 @@ function collectTabbable(root) {
  * @param {HTMLElement} root — container that should trap focus
  * @returns {{ release: () => void }} — call release() to remove the trap
  */
-export function trapFocus(root) {
+export function trapFocus(root, options = {}) {
   const controller = new AbortController();
 
   function handler(e) {
@@ -116,8 +116,13 @@ export function trapFocus(root) {
   requestAnimationFrame(() => {
     const active = getDeepActiveElement();
     if (!isWithin(active, root)) {
-      const focusable = collectTabbable(root);
-      if (focusable[0]) focusable[0].focus();
+      const { getInitialFocus } = options;
+      if (getInitialFocus) {
+        getInitialFocus(root)?.focus();
+      } else {
+        const focusable = collectTabbable(root);
+        if (focusable[0]) focusable[0].focus();
+      }
     }
   });
 

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -893,7 +893,7 @@ export async function createDrawer(options) {
           );
           const colors = paletteData?.colors || [];
           const paletteName = paletteData?.name || '';
-          setSusiColorRedirect(buildColorSignInRedirectUrl(colors, paletteName));
+          setSusiColorRedirect(buildColorSignInRedirectUrl(colors, paletteName, paletteData?.id));
           return triggerSignInFlow();
         },
         onLibraryCreated,

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -79,7 +79,7 @@ async function handleOpenInExpress({ id, name, colors }) {
   const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
     '../utils/susiRedirect.js'
   );
-  setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name));
+  setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name, id));
 
   const isSignedIn = await triggerSignInFlow();
   if (!isSignedIn) return;

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -9,7 +9,6 @@ import { loadButton, loadActionButton, loadTooltip } from '../spectrum/load-spec
 import { createThemeWrapper } from '../spectrum/utils/theme.js';
 import { paletteToThemeData } from '../../../libs/services/providers/transforms.js';
 import { serviceManager } from '../../../libs/services/core/ServiceManager.js';
-import { triggerSignInFlow } from '../../../libs/services/middlewares/auth.middleware.js';
 
 function interpolate(tpl, vars) {
   return Object.entries(vars).reduce((s, [k, v]) => s.replaceAll(`{{${k}}}`, v), tpl);
@@ -76,14 +75,6 @@ async function handleShare({ name, colors }, t) {
 // const COLOR_PALETTE_TEMPLATE_ID = 'urn:aaid:sc:VA6C2:60d17865-6817-5343-84db-34219e8ec3a4';
 
 async function handleOpenInExpress({ id, name, colors }) {
-  const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
-    '../utils/susiRedirect.js'
-  );
-  setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name, id));
-
-  const isSignedIn = await triggerSignInFlow();
-  if (!isSignedIn) return;
-
   const { getTrackingAppendedURL } = await import('../../branchlinks.js');
 
   const baseUrl = 'https://273916.prenv.projectx.corp.adobe.com/new';

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -1,7 +1,6 @@
 import { createColorPaletteParamApi } from './utilities.js';
 
 const KEY = '__susiColorRedirect';
-const COLOR_WHEEL_PATH = '/create/color-wheel';
 
 export function setSusiColorRedirect(url) {
   window[KEY] = url;
@@ -11,20 +10,6 @@ export function consumeSusiColorRedirect() {
   const url = window[KEY];
   delete window[KEY];
   return url || null;
-}
-
-/**
- * Extracts the locale prefix from the current URL pathname.
- * URL structure is locale-first: /cn/create/color-wheel, /jp/create/color-wheel, etc.
- * English (default) has no prefix: /create/color-wheel.
- *
- * Matches a leading path segment that looks like a locale code (2-3 letter lang,
- * optional region: /cn, /jp, /br, /uk, /de, /kr, /es, /fr, /it, etc.).
- * Returns the prefix with leading slash (e.g. '/cn') or empty string for default locale.
- */
-function getLocalePrefix() {
-  const match = window.location.pathname.match(/^\/([a-z]{2,3}(?:_[A-Z]{2})?)\//);
-  return match ? `/${match[1]}` : '';
 }
 
 function pageHasBlock(...classNames) {

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -31,13 +31,19 @@ function pageHasBlock(...classNames) {
   return classNames.some((cls) => document.querySelector(`.${cls}`));
 }
 
-export function buildColorSignInRedirectUrl(colors, name) {
+export function buildColorSignInRedirectUrl(colors, name, id = null) {
   const { setOnUrl } = createColorPaletteParamApi();
 
-  if (pageHasBlock('color-explore', 'color-extract')) {
+  if (pageHasBlock('color-extract')) {
     const prefix = getLocalePrefix();
     const url = new URL(`${prefix}${COLOR_WHEEL_PATH}`, window.location.origin);
     setOnUrl(url, colors, { name });
+    return url.toString();
+  }
+
+  if (pageHasBlock('color-explore')) {
+    const url = new URL(window.location.href);
+    if (id) url.searchParams.set('id', id);
     return url.toString();
   }
 

--- a/test/scripts/color-shared/utils/susiRedirect.test.js
+++ b/test/scripts/color-shared/utils/susiRedirect.test.js
@@ -84,7 +84,7 @@ describe('buildColorSignInRedirectUrl', () => {
     expect(url.pathname).to.equal('/create/color-wheel');
   });
 
-  it('redirects to color-wheel when on color-explore page', () => {
+  it('returns current URL when on color-explore page', () => {
     const el = document.createElement('div');
     el.className = 'color-explore';
     document.body.appendChild(el);
@@ -93,7 +93,7 @@ describe('buildColorSignInRedirectUrl', () => {
 
     const result = buildColorSignInRedirectUrl(colors, name);
     const url = new URL(result);
-    expect(url.pathname).to.equal('/create/color-wheel');
+    expect(url.pathname).to.equal('/color-explore');
   });
 
   it('uses current page URL for color-extract', () => {
@@ -108,7 +108,7 @@ describe('buildColorSignInRedirectUrl', () => {
     expect(url.pathname).to.equal('/create/image');
   });
 
-  it('preserves locale prefix on color-explore redirect', () => {
+  it('preserves locale prefix when returning current URL on color-explore page', () => {
     const el = document.createElement('div');
     el.className = 'color-explore';
     document.body.appendChild(el);
@@ -117,7 +117,7 @@ describe('buildColorSignInRedirectUrl', () => {
 
     const result = buildColorSignInRedirectUrl(colors, name);
     const url = new URL(result);
-    expect(url.pathname).to.equal('/cn/create/color-wheel');
+    expect(url.pathname).to.equal('/cn/color-explore');
   });
 
   it('no locale prefix for default (English) locale on color-explore redirect', () => {

--- a/test/services/plugins/kuler/actions/ThemeActions.test.js
+++ b/test/services/plugins/kuler/actions/ThemeActions.test.js
@@ -36,7 +36,7 @@ describe('ThemeActions', () => {
 
   describe('buildThemeUrl', () => {
     it('should build URL from configured endpoints', () => {
-      expect(actions.buildThemeUrl('abc')).to.equal('https://themes.test.io/api/v2/themes/abc');
+      expect(actions.buildThemeUrl('abc')).to.equal('https://themes.test.io/api/v2/themes/abc?metadata=all');
     });
 
     it('should throw ConfigError when serviceConfig is empty', async () => {
@@ -342,7 +342,7 @@ describe('ThemeActions', () => {
     it('should call correct theme URL with GET', async () => {
       await actions.fetchTheme('t-123');
       const [url, opts] = fetchStub.firstCall.args;
-      expect(url).to.equal('https://themes.test.io/api/v2/themes/t-123');
+      expect(url).to.equal('https://themes.test.io/api/v2/themes/t-123?metadata=all');
       expect(opts.method).to.equal('GET');
     });
 
@@ -477,7 +477,7 @@ describe('ThemeActions', () => {
     it('should DELETE to correct URL', async () => {
       await actions.deleteTheme({ id: 'del-1', name: 'Old' });
       const [url, opts] = fetchStub.firstCall.args;
-      expect(url).to.equal('https://themes.test.io/api/v2/themes/del-1');
+      expect(url).to.equal('https://themes.test.io/api/v2/themes/del-1?metadata=all');
       expect(opts.method).to.equal('DELETE');
     });
 

--- a/test/services/plugins/kuler/actions/helpers.js
+++ b/test/services/plugins/kuler/actions/helpers.js
@@ -41,6 +41,8 @@ export function createMockPlugin(overrides = {}) {
       ...overrides.serviceConfig,
     },
     endpoints: {
+      themeBaseUrl: 'https://themes.test.io',
+      gradientBaseUrl: 'https://gradient.test.io',
       search: '/search',
       api: '/api/v2',
       themePath: '/themes',

--- a/test/services/plugins/kuler/providers/KulerProvider.test.js
+++ b/test/services/plugins/kuler/providers/KulerProvider.test.js
@@ -13,6 +13,8 @@ function createTestPlugin(overrides = {}) {
       likeBaseUrl: 'https://asset.test.io',
       apiKey: 'test-key',
       endpoints: {
+        themeBaseUrl: 'https://themes.test.io',
+        gradientBaseUrl: 'https://gradient.test.io',
         search: '/search',
         api: '/api/v2',
         themePath: '/themes',


### PR DESCRIPTION
## Summary

- Added `getTheme(id)` to `KulerProvider`, `KulerActions` (`ThemeActions`), and `createColorDataService` to fetch a single palette by ID
- Added `gradient.get` topic and `getGradient` to the same files, then removed it after confirming no API exists for gradients by ID
- Fixed `themeBaseUrl`, `gradientBaseUrl`, `likeBaseUrl` being read from `serviceConfig` in `KulerActions` — changed to read from `endpoints` where they are defined in config
- Added `?metadata=all` query param to `buildThemeUrl` for the GET request
- Added `skipAuth: true` to `fetchTheme` fetch call
- Added `ITEM_ID_URL_PARAM = 'id'` query param support to `color-explore.js` — on page load, reads `?id=`, fetches the palette via `getTheme`, opens the palette modal, then removes the param from the URL
- Gradients mode also removes `?id=` from the URL on initial mount (no fetch, just cleanup)
- Updated `buildColorSignInRedirectUrl` in `susiRedirect.js` to accept an optional `id` param — `color-explore` no longer redirects to `/create/color-wheel`, stays on current page, sets `?id=` if a palette id is provided, and skips setting colors/name params
- Updated both callers (`createToolbarComponent`, `createDrawerComponent`) to pass `id` to `buildColorSignInRedirectUrl`
- Removed sign-in gate from "Create with my color palette" CTA in `createToolbarComponent` — opens Express directly without `triggerSignInFlow`


---

## Jira Ticket

Resolves: [MWPW-192344](https://jira.corp.adobe.com/browse/MWPW-192344)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/explore |
| **After**   | https://MWPW-192344-explore-signin--express-color--adobecom.aem.page/explore?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://MWPW-192344-explore-signin--express-color--adobecom.aem.page/create/color-wheel?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-contrast-analyzer |
| **After**   | https://MWPW-192344-explore-signin--express-color--adobecom.aem.page/create/color-contrast-analyzer?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-accessibility |
| **After**   | https://MWPW-192344-explore-signin--express-color--adobecom.aem.page/create/color-accessibility?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image |
| **After**   | https://MWPW-192344-explore-signin--express-color--adobecom.aem.page/create/image?martech=off |
| **Before**  | https://stage--express-color--adobecom.aem.page/create/image-gradient |
| **After**   | https://MWPW-192344-explore-signin--express-color--adobecom.aem.page/create/image-gradient?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
