### PR TITLE
Remove CDN console log on main

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -212,8 +212,6 @@ const CONFIG = {
   },
 };
 
-console.log('CDN test to main');
-
 /*
  * ------------------------------------------------------------
  * Edit below at your own risk


### PR DESCRIPTION
## Summary

**Note: This PR goes to main**

Removes the console log that was added to main to test the color cdn

---

## Jira Ticket

Resolves: N/A

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://methomas-main-log--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Open dev console and load page
- Should not see "CDN test to main" in console

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
