### PR TITLE
Update comparison-table-v2.css

### DIFF
--- a/express/code/blocks/comparison-table-v2/comparison-table-v2.css
+++ b/express/code/blocks/comparison-table-v2/comparison-table-v2.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   -webkit-text-size-adjust: 100%;
-  --icon-color: #05834E;
+  --icon-color: var(--color-green-900);
   --cell-width: var(--ax-grid-5-col-width);
   --plan-cell-background-color: #F5F5F5;
   --gnav-offset-height: var(--spacing-800);
@@ -1008,6 +1008,7 @@ main .comparison-table-v2 .sticky-header .plan-cell-wrapper:not(:has(p))> :is(h2
     border-radius: 8px;
     border: 1px solid var(--color-gray-325);
     background: var(--color-white);
+    margin: 0;
   }
 
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Removed extra padding between comp chart rows

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-193535

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://comp-chart-margin--da-express-milo--adobecom.aem.page/express/why-choose-express |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page
- There should only be a 16 px gap on desktop instead of the current 16px gap + 16px margin.

---

## Potential Regressions

-  https://comp-chart-margin--da-express-milo--adobecom.aem.page/express/why-choose-express

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
