### PR TITLE
Updating link colors for all variants to ensure authored links match …

### DIFF
--- a/express/code/blocks/wayfinder/wayfinder.css
+++ b/express/code/blocks/wayfinder/wayfinder.css
@@ -4,11 +4,11 @@ body main .section:has(.wayfinder) {
 
 
 .wayfinder {
-    border: 2px solid black;
+    border: 2px solid var(--color-black);
     border-radius: 20px;
-    padding: 16px 0 16px 0;
-    margin-left: 20px;
-    margin-right: 20px;
+    padding: var(--spacing-300) 0 var(--spacing-300) 0;
+    margin-left: var( --spacing-350);
+    margin-right: var( --spacing-350);
     margin-top: 60px;
     text-align: center;
     max-width: 1328px;
@@ -20,7 +20,7 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
   font-style: normal;
   font-weight: 700;
   line-height: 130%; /* 20.8px */
-  margin: 16px 0 2px 0;
+  margin: var(--spacing-300) 0 var(--spacing-50) 0;
 }
 
 .wayfinder.narrow {
@@ -32,29 +32,44 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
 }
 
 .wayfinder.dark {
-    background-color: black;
-    color: white;
+    background-color: var(--color-black);
+    color: var(--color-white);
 }
 
 .wayfinder.light {
     border: 2px solid var(--color-info-accent);
 }
 
+.wayfinder.light a {
+    color: var(--color-black);
+    text-decoration: underline;
+}
+
+.wayfinder.dark a {
+    color: var(--color-white);
+    text-decoration: underline;
+}
+
 .wayfinder.gradient {
-    color: black;
-    border: 2px solid white;
+    color: var(--color-black);
+    border: 2px solid var(--color-white);
+}
+
+.wayfinder.gradient a {
+    color: var(--color-black);
+    text-decoration: underline;
 }
 
 .wayfinder .cta-row .button {
     height: fit-content;
-    margin: 8px;
-    background-color: black;
-    border-color: black;
+    margin: var(--spacing-100);
+    background-color: var(--color-black);
+    border-color: var(--color-black);
 }
 
 .wayfinder.dark .cta-row .button {
-    color: white;
-    border-color: white;
+    color: var(--color-white);
+    border-color: var(--color-white);
 }
 .wayfinder .text-row > div {
   padding: var(--spacing-200);
@@ -67,15 +82,15 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
 
 .wayfinder .cta-row strong .button {
     background-color: var(--color-info-accent);
-    color: white;
+    color: var(--color-white);
     border: none;
-    padding-bottom: 8px;
-    padding-top: 8px;
+    padding-bottom: var(--spacing-100);
+    padding-top: var(--spacing-100);
 }
 
 .wayfinder .cta-row em .button {
     background-color: transparent;
-    color: black;
+    color: var(--color-black);
 }
 .wayfinder .cta-row em .button:hover {
   color: var(--color-white);
@@ -85,11 +100,11 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
     background-color: none;
     border: none;
     text-underline-offset: 5px;
-    margin-left: 0px;
-    margin-right: 0px;
+    margin-left: var(--spacing-0);
+    margin-right: var(--spacing-0);
     text-decoration: underline;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding-left: var(--spacing-100);
+    padding-right: var(--spacing-100);
     margin-top: 11px;
 }
 
@@ -116,7 +131,7 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
     font-style: normal;
     font-weight: 700;
     line-height: 130%; /* 20.8px */
-    margin: 16px 0;
+    margin: var(--spacing-300) 0;
   }
 
     .wayfinder {
@@ -124,7 +139,7 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        margin: 30px 2p0px 2p0px auto;
+        margin: 30px 2p0px 2p0px auto; /* what is this? */
         padding: 10px;
     }
 
@@ -135,13 +150,13 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
 
     .wayfinder .text-row div {
       display: flex;
-        gap: 8px;
+        gap: var(--spacing-80);
     }
 
     .wayfinder .cta-row {
         display: flex;
         position: relative;
-        top: 2px;
+        top: var(--spacing-50);
         margin-left: 10px;
         overflow-x: scroll;
     }

--- a/express/code/blocks/wayfinder/wayfinder.css
+++ b/express/code/blocks/wayfinder/wayfinder.css
@@ -7,8 +7,8 @@ body main .section:has(.wayfinder) {
     border: 2px solid var(--color-black);
     border-radius: 20px;
     padding: var(--spacing-300) 0 var(--spacing-300) 0;
-    margin-left: var( --spacing-350);
-    margin-right: var( --spacing-350);
+    margin-left: var(--spacing-350);
+    margin-right: var(--spacing-350);
     margin-top: 60px;
     text-align: center;
     max-width: 1328px;
@@ -40,25 +40,18 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
     border: 2px solid var(--color-info-accent);
 }
 
-.wayfinder.light a {
-    color: var(--color-black);
+.wayfinder a, .wayfinder.light a, .wayfinder.dark a, .wayfinder.gradient a {
+    color: inherit;
     text-decoration: underline;
 }
 
-.wayfinder.dark a {
-    color: var(--color-white);
-    text-decoration: underline;
-}
+
 
 .wayfinder.gradient {
     color: var(--color-black);
     border: 2px solid var(--color-white);
 }
 
-.wayfinder.gradient a {
-    color: var(--color-black);
-    text-decoration: underline;
-}
 
 .wayfinder .cta-row .button {
     height: fit-content;
@@ -139,7 +132,6 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        margin: 30px 2p0px 2p0px auto; /* what is this? */
         padding: 10px;
     }
 
@@ -150,7 +142,7 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
 
     .wayfinder .text-row div {
       display: flex;
-        gap: var(--spacing-80);
+        gap: var(--spacing-100);
     }
 
     .wayfinder .cta-row {


### PR DESCRIPTION
Updates to wayfinder banner

## Summary

Updates to wayfinder banner to ensure links match the body color and have an underline for accessibility. Updated hard coded spacing values to tokens.
---

## Jira Ticket

Resolves: [DOTCOM-180624](https://jira.corp.adobe.com/browse/DOTCOM-180624)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/in/express/why-choose-express |
| **After**   | https://wayfinding-link-styling--da-express-milo--adobecom.aem.page/in/express/why-choose-express?martech=off |

---

## Verification Steps

- Go to page, observe accent link styling as accent (purple)
- Should now match surrounding text styling with underline.  Note that it will be bold if authoring bolds in DA.

---

## Potential Regressions

- [https://<wayfinding-link-styling--da-express-milo--adobecom.aem.live/express/](https://wayfinding-link-styling--da-express-milo--adobecom.aem.page/uk/express/discover/ideas/funny-awards-for-employees?martech=off)
- [https://wayfinding-link-styling--da-express-milo--adobecom.aem.page/uk/express/discover/tips/instagram/fonts](https://wayfinding-link-styling--da-express-milo--adobecom.aem.page/uk/express/discover/tips/instagram/fonts?martech=off)


---

## Additional Notes


