### PR TITLE
[MWPW-176730] [Color] Lana footer errors 

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -394,7 +394,9 @@ async function loadPage() {
   const footer = createTag('meta', { name: 'footer', content: 'global-footer' });
   document.head.append(footer);
 
-  getMetadata('footer-source') || document.head.append(createTag('meta', { name: 'footer-source', content: '/federal/footer/footer' }));
+  if (!getMetadata('footer-source') && CONFIG.contentRoot) {
+    document.head.append(createTag('meta', { name: 'footer-source', content: `${window.location.origin}/federal/footer/footer` }));
+  }
 
   const adobeHomeRedirect = createTag('meta', { name: 'adobe-home-redirect', content: 'on' });
   document.head.append(adobeHomeRedirect);

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -394,7 +394,7 @@ async function loadPage() {
   const footer = createTag('meta', { name: 'footer', content: 'global-footer' });
   document.head.append(footer);
 
-  if (!getMetadata('footer-source') && CONFIG.contentRoot) {
+  if (!getMetadata('footer-source')) {
     document.head.append(createTag('meta', { name: 'footer-source', content: `${window.location.origin}/federal/footer/footer` }));
   }
 


### PR DESCRIPTION
## Summary


The footer-source metadata fallback in scripts.js was injecting a relative path (/federal/footer/footer) that Milo's URL constructor couldn't parse, causing a LANA error on the color site. We made the fallback conditional so it only fires when CONFIG.contentRoot is set (skipping the color site on  prod), and changed the injected value to an absolute URL using window.location.origin so Milo can parse it correctly on localhost and other environments.

---

## Jira Ticket

Resolves: [MWPW-176730](https://jira.corp.adobe.com/browse/MWPW-176730)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/?martech=off  |
| **After**   | https://footer-color-fix--express-color--adobecom.aem.page/?martech=off |

---

## Verification Steps

- Visit before URL and open console log, should see the lana error 
- Visit after URL and it's gone
- Also visit regression potential URL below to verify no errors and footer is still present. 

---

## Potential Regressions

- https://footer-color-fix--da-express-milo--adobecom.aem.page/express/?martech=off

---
