### PR TITLE
[NO JIRA] Update the branch url for opening color palette in express

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -74,12 +74,24 @@ async function handleShare({ name, colors }, t) {
 
 // const COLOR_PALETTE_TEMPLATE_ID = 'urn:aaid:sc:VA6C2:60d17865-6817-5343-84db-34219e8ec3a4';
 
+function getStageBaseUrl(base) {
+  if (!base) return 'https://stage.projectx.corp.adobe.com/new';
+  try {
+    const { hostname } = new URL(base);
+    const isAllowed = hostname === 'stage.projectx.corp.adobe.com'
+      || hostname.endsWith('.prenv.projectx.corp.adobe.com');
+    return isAllowed ? base : 'https://stage.projectx.corp.adobe.com/new';
+  } catch {
+    return 'https://stage.projectx.corp.adobe.com/new';
+  }
+}
+
 async function handleOpenInExpress({ id, name, colors }) {
   const { getTrackingAppendedURL } = await import('../../branchlinks.js');
 
   const params = new URLSearchParams(window.location.search);
   const baseUrl = params.get('hzenv') === 'stage'
-    ? (params.get('base') || 'https://stage.projectx.corp.adobe.com/new')
+    ? getStageBaseUrl(params.get('base'))
     : 'https://adobesparkpost.app.link/color-palette';
   const url = new URL(await getTrackingAppendedURL(baseUrl, {
     placement: 'color-explorer',

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -77,7 +77,10 @@ async function handleShare({ name, colors }, t) {
 async function handleOpenInExpress({ id, name, colors }) {
   const { getTrackingAppendedURL } = await import('../../branchlinks.js');
 
-  const baseUrl = 'https://273916.prenv.projectx.corp.adobe.com/new';
+  const params = new URLSearchParams(window.location.search);
+  const baseUrl = params.get('hzenv') === 'stage'
+    ? (params.get('base') || 'https://stage.projectx.corp.adobe.com/new')
+    : 'https://adobesparkpost.app.link/color-palette';
   const url = new URL(await getTrackingAppendedURL(baseUrl, {
     placement: 'color-explorer',
     isSearchOverride: true,
@@ -92,7 +95,7 @@ async function handleOpenInExpress({ id, name, colors }) {
   url.searchParams.set('feature-enable', 'colors-product-entry');
   url.searchParams.set('category', 'yourStuff');
 
-  window.open(url.toString(), '_blank');
+  window.open(url.toString(), '_blank', 'noopener noreferrer');
 }
 
 async function handleDownload(palette, t) {

--- a/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
@@ -543,6 +543,59 @@ describe('createToolbar', () => {
     });
   });
 
+  describe('handleOpenInExpress URL selection', () => {
+    let openStub;
+
+    beforeEach(() => {
+      openStub = sinon.stub(window, 'open');
+    });
+
+    afterEach(() => {
+      window.history.pushState({}, '', '/');
+    });
+
+    async function clickCTA() {
+      const toolbar = createToolbar(defaultOptions({ onCTA: undefined }));
+      document.body.appendChild(toolbar.element);
+      toolbar.element.querySelector('sp-button[variant="accent"]').click();
+      await new Promise((r) => setTimeout(r, 100));
+      return openStub.firstCall.args[0];
+    }
+
+    it('opens with noopener noreferrer', async () => {
+      await clickCTA();
+      expect(openStub.firstCall.args[1]).to.equal('_blank');
+      expect(openStub.firstCall.args[2]).to.equal('noopener noreferrer');
+    });
+
+    it('uses the branch link URL by default', async () => {
+      const url = await clickCTA();
+      expect(url).to.include('adobesparkpost.app.link/color-palette');
+    });
+
+    it('uses stage URL when hzenv=stage', async () => {
+      window.history.pushState({}, '', '?hzenv=stage');
+      const url = await clickCTA();
+      expect(url).to.include('stage.projectx.corp.adobe.com');
+    });
+
+    it('uses custom URL when hzenv=stage&base=<url>', async () => {
+      window.history.pushState({}, '', '?hzenv=stage&base=https%3A%2F%2Fcustom.example.com%2Fnew');
+      const url = await clickCTA();
+      expect(url).to.include('custom.example.com');
+    });
+
+    it('appends color palette params to the URL', async () => {
+      const urlStr = await clickCTA();
+      const url = new URL(urlStr);
+      expect(url.searchParams.get('referrer')).to.equal('express-colors');
+      expect(url.searchParams.get('entryPoint')).to.equal('color-explorer');
+      expect(url.searchParams.get('feature-enable')).to.equal('colors-product-entry');
+      expect(url.searchParams.get('category')).to.equal('yourStuff');
+      expect(url.searchParams.has('colorPalette')).to.be.true;
+    });
+  });
+
   describe('responsive CTA text', () => {
     it('CTA text updates based on isMobileViewport() when matchMedia fires', () => {
       const origMatchMedia = window.matchMedia;
@@ -553,8 +606,8 @@ describe('createToolbar', () => {
           return {
             get matches() { return mobileMatches; },
             media: query,
-            addEventListener(evt, cb) { changeListeners.push(cb); },
-            removeEventListener(evt, cb) { changeListeners = changeListeners.filter((l) => l !== cb); },
+            addEventListener(_evt, cb) { changeListeners.push(cb); },
+            removeEventListener(_evt, cb) { changeListeners = changeListeners.filter((l) => l !== cb); },
             addListener() {},
             removeListener() {},
           };

--- a/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
@@ -579,10 +579,17 @@ describe('createToolbar', () => {
       expect(url).to.include('stage.projectx.corp.adobe.com');
     });
 
-    it('uses custom URL when hzenv=stage&base=<url>', async () => {
-      window.history.pushState({}, '', '?hzenv=stage&base=https%3A%2F%2Fcustom.example.com%2Fnew');
+    it('uses prenv base URL when hostname matches *.prenv.projectx.corp.adobe.com', async () => {
+      window.history.pushState({}, '', '?hzenv=stage&base=https%3A%2F%2F273916.prenv.projectx.corp.adobe.com%2Fnew');
       const url = await clickCTA();
-      expect(url).to.include('custom.example.com');
+      expect(url).to.include('273916.prenv.projectx.corp.adobe.com');
+    });
+
+    it('falls back to stage URL when base hostname is not in the allowlist', async () => {
+      window.history.pushState({}, '', '?hzenv=stage&base=https%3A%2F%2Fattacker.com%2F');
+      const url = await clickCTA();
+      expect(url).to.include('stage.projectx.corp.adobe.com');
+      expect(url).not.to.include('attacker.com');
     });
 
     it('appends color palette params to the URL', async () => {


### PR DESCRIPTION
## Summary
Update the express base url to the branch url.

---

## Jira Ticket

Resolves: No Jira

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/explore |
| **After**   | https://color-branch-urls--express-color--adobecom.aem.page/explore?martech=off |

---

## Verification Steps

- Open any color palette in modal by clicking on it.
- Click on "Create with color palette"
- It should open a template specific to color page.
Note: Right now the express side changes are in stage so modal to save color palette to cc library in Express won't appear on prod.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
