### PR TITLE
[COLOR] Extract results mobile strips fix

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -961,11 +961,6 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   align-self: stretch;
 }
 
-.color-extract .color-extract-swatch-rail--gradient {
-  flex: 1 1 0;
-  min-height: 0;
-}
-
 .color-extract .color-extract-gradient-editor-col {
   display: flex;
   flex-direction: column;
@@ -1000,6 +995,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 /* ==================== Responsive ==================== */
 
 @media (min-width: 600px) {
+  
   .color-extract {
     --color-extract-edit-bg-height: 554px;
   }
@@ -1069,6 +1065,11 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 
   .color-extract .color-extract-landing-bg {
     display: block;
+  }
+
+  .color-extract .color-extract-swatch-rail--gradient {
+    flex: 1 1 0;
+    min-height: 0;
   }
 
   .section > .color-extract-landing-bg,

--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -995,7 +995,6 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 /* ==================== Responsive ==================== */
 
 @media (min-width: 600px) {
-  
   .color-extract {
     --color-extract-edit-bg-height: 554px;
   }


### PR DESCRIPTION
## Summary

Ensures mobile sees all added colors 

Before
<img width="1060" height="1320" alt="image" src="https://github.com/user-attachments/assets/1099ab2a-9945-4f7e-87ea-a68886007006" />

After: 

<img width="583" height="615" alt="image" src="https://github.com/user-attachments/assets/0aeb8b55-3e2e-4811-83af-1780c2190222" />


---

## Jira Ticket (No JIRA) 

https://adobe-mwp.slack.com/archives/C09UTTN40PM/p1777394602267419

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/image-gradient |
| **After**   | https://color-gradient-mobile-fix--express-color--adobecom.aem.page/create/image-gradient?martech=off |

---

## Verification Steps

- Open URL and trigger results view 
- Switch to mobile and add colors 
- Expect to see all colors added in after link vs before 

---