### PR TITLE
Adding flag to enable lingo lana logging

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -80,6 +80,7 @@ const CONFIG = {
   imsClientId: 'AdobeExpressWeb',
   prodDomains,
   geoRouting: 'on',
+  lingoProjectSuccessLogging: 'on',
   fallbackRouting: 'on',
   decorateArea,
   faasCloseModalAfterSubmit: 'on',


### PR DESCRIPTION
## Summary

Adding flag to enable lingo lana logging

---

## Jira Ticket

Resolves: [MWPW-190387](https://jira.corp.adobe.com/browse/MWPW-190387)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://enable-log--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Lana logs should be enabled for language-banner and region-modal

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
