### PR TITLE
[No Jira] mandatory sign in before opening in express

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -9,6 +9,7 @@ import { loadButton, loadActionButton, loadTooltip } from '../spectrum/load-spec
 import { createThemeWrapper } from '../spectrum/utils/theme.js';
 import { paletteToThemeData } from '../../../libs/services/providers/transforms.js';
 import { serviceManager } from '../../../libs/services/core/ServiceManager.js';
+import { triggerSignInFlow, ensureIms } from '../../../libs/services/middlewares/auth.middleware.js';
 
 function interpolate(tpl, vars) {
   return Object.entries(vars).reduce((s, [k, v]) => s.replaceAll(`{{${k}}}`, v), tpl);
@@ -86,7 +87,26 @@ function getStageBaseUrl(base) {
   }
 }
 
+async function checkIsSignedIn() {
+  try {
+    const ims = await ensureIms();
+    return ims.isSignedInUser();
+  } catch {
+    return false;
+  }
+}
+
 async function handleOpenInExpress({ id, name, colors }) {
+  const isSignedIn = await checkIsSignedIn();
+  if (!isSignedIn) {
+    const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
+      '../utils/susiRedirect.js'
+    );
+    setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name, id));
+    await triggerSignInFlow();
+    return;
+  }
+
   const { getTrackingAppendedURL } = await import('../../branchlinks.js');
 
   const params = new URLSearchParams(window.location.search);

--- a/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
@@ -3,6 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { setLibs } from '../../../../express/code/scripts/utils.js';
 import { createToolbar } from '../../../../express/code/scripts/color-shared/toolbar/createToolbarComponent.js';
+import { consumeSusiColorRedirect } from '../../../../express/code/scripts/color-shared/utils/susiRedirect.js';
 import { MOCK_PALETTE, MOCK_GRADIENT } from './mocks/palette.js';
 import { createMockGetLibraryContext } from './mocks/stubs.js';
 
@@ -548,10 +549,14 @@ describe('createToolbar', () => {
 
     beforeEach(() => {
       openStub = sinon.stub(window, 'open');
+      window.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+      };
     });
 
     afterEach(() => {
       window.history.pushState({}, '', '/');
+      delete window.adobeIMS;
     });
 
     async function clickCTA() {
@@ -600,6 +605,60 @@ describe('createToolbar', () => {
       expect(url.searchParams.get('feature-enable')).to.equal('colors-product-entry');
       expect(url.searchParams.get('category')).to.equal('yourStuff');
       expect(url.searchParams.has('colorPalette')).to.be.true;
+    });
+  });
+
+  describe('handleOpenInExpress sign-in enforcement', () => {
+    let openStub;
+
+    beforeEach(() => {
+      openStub = sinon.stub(window, 'open');
+    });
+
+    afterEach(() => {
+      delete window.adobeIMS;
+      consumeSusiColorRedirect();
+    });
+
+    async function clickCTA() {
+      const toolbar = createToolbar(defaultOptions({ onCTA: undefined }));
+      document.body.appendChild(toolbar.element);
+      toolbar.element.querySelector('sp-button[variant="accent"]').click();
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    it('does not open Express when user is not signed in', async () => {
+      window.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+      };
+
+      await clickCTA();
+
+      expect(openStub.called).to.be.false;
+    });
+
+    it('stores a SUSI redirect URL containing the color palette when not signed in', async () => {
+      window.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+      };
+
+      await clickCTA();
+
+      const stored = consumeSusiColorRedirect();
+      expect(stored).to.be.a('string');
+      expect(stored).to.include('color-palette=');
+    });
+
+    it('opens Express in a new tab when user is signed in', async () => {
+      window.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(true),
+      };
+
+      await clickCTA();
+
+      expect(openStub.calledOnce).to.be.true;
+      expect(openStub.firstCall.args[1]).to.equal('_blank');
+      expect(consumeSusiColorRedirect()).to.be.null;
     });
   });
 


### PR DESCRIPTION
## Summary

Force sign in when user clicks on "Create with my color palette". This ensures that user enters Express in a signed in state and the SUSI is same for all color workflows.

---

## Jira Ticket

Resolves: No Jira

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://express-entry-signin--express-color--adobecom.aem.page/create/color-wheel?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
