### PR TITLE
MWPW-194126 Color - Fix 404 redirect loop on geo homepages

### DIFF
--- a/404.html
+++ b/404.html
@@ -136,15 +136,16 @@
 
         let userLocale, redirectURL, redirectMapping, valueInMap;
         const noop = ()=>{};
+        const isColor = /color(\.(stage))?\.adobe\.com|--express-color--adobecom\.aem\.(page|live)/.test(hostname);
 
-        if (pathname.includes(eduWithExpressPrefix) && search) {
+        if (pathname.includes(eduWithExpressPrefix) && search && !isColor) {
           [_, userLocale] =   search.split('=');
           valueInMap = redirectMap.get(userLocale);
           redirectMapping =  valueInMap ? `${valueInMap}${eduRedirectPath}` : `/${eduRedirectPath}`;
           redirectURL = `${protocol}${adobeDomain}${redirectMapping}`;
           win.location.replace(redirectURL);
         }
-        else if (pathname.includes(eduWithoutPrefix) && search ) {
+        else if (pathname.includes(eduWithoutPrefix) && search && !isColor) {
 
           [_, userLocale] =   search.split('=');
           valueInMap = redirectMap.get(userLocale);
@@ -160,7 +161,11 @@
         else {
           [_, userLocale] = pathname.split('/');
           valueInMap = redirectMap.get(userLocale);
-          valueInMap ? win.location.replace( href.replace(`/${userLocale}/`, valueInMap)) : noop;
+          if (isColor) {
+            valueInMap ? win.location.replace( href.replace(`/${userLocale}`, valueInMap)) : noop;
+          } else {
+            valueInMap ? win.location.replace( href.replace(`/${userLocale}/`, valueInMap)) : noop;
+          }
         }
       }(window));
 


### PR DESCRIPTION
## Summary

Fix issue where https://color.stage.adobe.com/se is getting stuck in a 404 redirect loop. This applies to all color geo homepages without a trailing slash

---

## Jira Ticket

Resolves: [MWPW-194126](https://jira.corp.adobe.com/browse/MWPW-194126)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/se |
| **After**   | https://methomas-redirect-loop--express-color--adobecom.aem.page/se |

---

## Verification Steps

- Go to the url
- Before: Page never resolves because it's in a redirect loop. You can see this in the dev console by turning on Preserve logs.
- After: Page redirects once from /se to / (US homepage) and page resolves. (This follows behavior on express).

---

## Potential Regressions

Should not redirect:
- https://methomas-redirect-loop--express-color--adobecom.aem.page
- https://methomas-redirect-loop--express-color--adobecom.aem.page/create/color-wheel
- https://methomas-redirect-loop--express-color--adobecom.aem.page/fr/create/color-wheel

Should redirect to /express:
- https://methomas-redirect-loop--da-express-milo--adobecom.aem.page/se/express

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
