### PR TITLE
Dropdown Duplication Fix

### DIFF
--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -220,9 +220,6 @@ async function createBlockLoadMoreControl(container, onClick, options = {}) {
 }
 
 async function createBlockFilterControl(container, variant, onFilterChange, strings) {
-  const header = container.querySelector('.explore-header, .gradients-header');
-  if (!header) return null;
-
   const filters = await createFiltersComponent({
     variant,
     onFilterChange,
@@ -231,19 +228,26 @@ async function createBlockFilterControl(container, variant, onFilterChange, stri
 
   if (!(filters?.element instanceof Node)) return null;
   filters.element.setAttribute('data-owner', 'color-explore-filters');
-  header.querySelectorAll(':scope > .filters-container').forEach((node) => node.remove());
-  header.appendChild(filters.element);
-  try {
-    await filters.waitForReady?.();
-  } catch (error) {
-    window.lana?.log(`[ColorExplore] Filters waitForReady failed: ${error?.message}`, {
-      tags: 'color-explore,filters',
-      severity: 'warning',
-    });
-  }
 
   return {
     element: filters.element,
+    async attachToHeader() {
+      const header = container.querySelector('.explore-header, .gradients-header');
+      if (!header) return false;
+      header.querySelectorAll(':scope > .filters-container').forEach((node) => {
+        if (node !== filters.element) node.remove();
+      });
+      if (filters.element.parentElement !== header) header.appendChild(filters.element);
+      try {
+        await filters.waitForReady?.();
+      } catch (error) {
+        window.lana?.log(`[ColorExplore] Filters waitForReady failed: ${error?.message}`, {
+          tags: 'color-explore,filters',
+          severity: 'warning',
+        });
+      }
+      return true;
+    },
     destroy() {
       filters.reset?.();
       filters.element?.remove?.();
@@ -486,11 +490,7 @@ export default async function decorate(block) {
 
           await activeRenderer.render();
 
-          const gradientHeader = container.querySelector('.explore-header, .gradients-header');
-          if (gradientHeader && filtersControl?.element) {
-            gradientHeader.querySelectorAll(':scope > .filters-container').forEach((n) => n.remove());
-            gradientHeader.appendChild(filtersControl.element);
-          }
+          await filtersControl?.attachToHeader?.();
 
           // Explore contract: filters are always rendered for gradients/palettes.
           gradientFilterHandler = async (filters) => {
@@ -630,11 +630,7 @@ export default async function decorate(block) {
           });
           await activeRenderer.render?.(container);
 
-          const stripsHeader = container.querySelector('.explore-header, .gradients-header');
-          if (stripsHeader && filtersControl?.element) {
-            stripsHeader.querySelectorAll(':scope > .filters-container').forEach((n) => n.remove());
-            stripsHeader.appendChild(filtersControl.element);
-          }
+          await filtersControl?.attachToHeader?.();
 
           stripsFilterHandler = async (filters) => {
             filterInteractionSuppressUntil = Date.now() + 350;

--- a/express/code/scripts/color-shared/spectrum/components/express-picker.js
+++ b/express/code/scripts/color-shared/spectrum/components/express-picker.js
@@ -220,6 +220,13 @@ export async function createExpressPicker(config) {
 
     /** Clean up listeners (call when removing from DOM). */
     destroy() {
+      try {
+        picker.open = false;
+        picker.removeAttribute('open');
+        picker.blur?.();
+      } catch (error) {
+        // Non-fatal: teardown should still remove the wrapper.
+      }
       picker.removeEventListener('change', onPickerChange);
       theme.remove();
     },

--- a/test/scripts/color-shared/components/createFiltersComponent.test.js
+++ b/test/scripts/color-shared/components/createFiltersComponent.test.js
@@ -57,4 +57,22 @@ describe('createFiltersComponent', () => {
 
     component.reset();
   });
+
+  it('does not duplicate desktop pickers when readiness is awaited more than once', async () => {
+    const component = await createFiltersComponent({
+      variant: 'strips',
+    });
+
+    document.body.appendChild(component.element);
+    await Promise.all([
+      component.waitForReady(),
+      component.waitForReady(),
+    ]);
+
+    const desktopPickers = component.element.querySelectorAll('.filters-desktop sp-picker');
+    expect(desktopPickers.length).to.equal(3);
+
+    component.reset();
+    expect(component.element.querySelectorAll('sp-picker').length).to.equal(0);
+  });
 });

--- a/test/scripts/color-shared/spectrum/components/express-spectrum-components.test.js
+++ b/test/scripts/color-shared/spectrum/components/express-spectrum-components.test.js
@@ -87,7 +87,6 @@ describe('Express Spectrum component wrappers', () => {
     });
 
     document.body.appendChild(picker.element);
-    await picker.waitForReady();
 
     const pickerElement = picker.element.querySelector('sp-picker');
     pickerElement.open = true;

--- a/test/scripts/color-shared/spectrum/components/express-spectrum-components.test.js
+++ b/test/scripts/color-shared/spectrum/components/express-spectrum-components.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import createExpressActionButton from '../../../../../express/code/scripts/color-shared/spectrum/components/express-action-button.js';
 import { createExpressTag } from '../../../../../express/code/scripts/color-shared/spectrum/components/express-tag.js';
 import { createExpressTextfield } from '../../../../../express/code/scripts/color-shared/spectrum/components/express-textfield.js';
+import { createExpressPicker } from '../../../../../express/code/scripts/color-shared/spectrum/components/express-picker.js';
 
 describe('Express Spectrum component wrappers', () => {
   afterEach(() => {
@@ -73,5 +74,29 @@ describe('Express Spectrum component wrappers', () => {
     expect(actionButton.getAttribute('label')).to.equal('Swap colors');
     expect(iconSlot).to.exist;
     expect(iconSlot.querySelector('.test-action-icon')).to.exist;
+  });
+
+  it('closes picker overlays before removing the picker wrapper', async () => {
+    const picker = await createExpressPicker({
+      label: 'Sort',
+      value: 'popular',
+      options: [
+        { label: 'Popular', value: 'popular' },
+        { label: 'All', value: 'all' },
+      ],
+    });
+
+    document.body.appendChild(picker.element);
+    await picker.waitForReady();
+
+    const pickerElement = picker.element.querySelector('sp-picker');
+    pickerElement.open = true;
+    pickerElement.setAttribute('open', '');
+
+    picker.destroy();
+
+    expect(pickerElement.open).to.equal(false);
+    expect(pickerElement.hasAttribute('open')).to.equal(false);
+    expect(picker.element.isConnected).to.equal(false);
   });
 });


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Sometimes you get 4 dropdowns causing them all to break when navigating to new pages. This was caused by a race condition between Spectrum's state and the web page state. Spectrum would continue its own lifecycle while the DOM was reloaded. This fix only attaches the filter widgets after render is done and ensures the process is sequential by using an async function.


https://github.com/user-attachments/assets/af89bf50-9520-4fab-b0fc-2b45acd97b67

<img width="675" height="100" alt="Screenshot 2026-04-30 at 10 16 09 AM" src="https://github.com/user-attachments/assets/c55bb1c1-80ca-4c70-9a03-a0bbb46fe803" />




---

## Jira Ticket

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://color-dropdown--express-color--adobecom.aem.page/de/explore |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- To visualize the bug go to https://main--express-color--adobecom.aem.page/de/explore?q=Prim%C3%A4rfarben and do a hard refresh.
- Delete the `de` in the url and go to the new page, it is likely that the bug shows up. Repeat this with the new branch and it should not appear.

---

## Potential Regressions

- https://color-dropdown--express-color--adobecom.aem.page/de/explore 

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
