### PR TITLE
[COLOR][EXPLORE] Gradient modal fix 

### DIFF
--- a/express/code/scripts/color-shared/modal/createModalManager.js
+++ b/express/code/scripts/color-shared/modal/createModalManager.js
@@ -182,7 +182,10 @@ export function createModalManager(strings = createColorModalPlaceholders()) {
     overlay.removeAttribute('aria-hidden');
 
     if (content !== undefined && content !== null) {
-      const node = typeof content === 'function' ? content() : content;
+      const nodeOrPromise = typeof content === 'function' ? content() : content;
+      const node = (nodeOrPromise && typeof nodeOrPromise.then === 'function')
+        ? await nodeOrPromise
+        : nodeOrPromise;
       if (typeof node === 'string') {
         bodyEl.textContent = node;
       } else if (node && typeof node.nodeType === 'number') {


### PR DESCRIPTION
## Summary

 The open() function in createModalManager was synchronously calling content() without awaiting the result. Since the gradients modal passes an async function as content, it returned a Promise instead of a DOM node — so the nodeType check failed and the fallback "No content provided" was rendered.

The fix awaits the result when the content function returns a Promise. The palettes path passes a real DOM node directly (not a Promise), so it was unaffected.
---

## Jira Ticket

https://jira.corp.adobe.com/browse/MWPW-194220

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/explore?theme=color-gradients |
| **After**   | https://explore-gradient-modal--express-color--adobecom.aem.page/explore?theme=color-gradients&martech=off |

---

## Verification Steps

- Open after link
- Click any gradeint
- Modal opens and gradient shows in modal 
