### PR TITLE
MWPW-194223: Color CN redirect

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -448,7 +448,7 @@ async function loadPage() {
   }
 
   /* region based redirect to CN homepage */
-  const isAdobeOrigin = /^(www\.stage\.|www\.)adobe\.com$/.test(window.location.hostname);
+  const isAdobeOrigin = /^(www|color)\.(stage\.)?adobe\.com$/.test(window.location.hostname);
   import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then((country) => {
     if (country === 'cn' && isAdobeOrigin && !window.location.pathname.startsWith('/cn') && !window.isErrorPage) { window.location.href = '/cn'; }
   });


### PR DESCRIPTION
Update adobe domain check to include color subdomain so that the CN locale forwards as CN is not allowed to view color.

## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: [MWPW-194223](https://jira.corp.adobe.com/browse/MWPW-194223)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- You must be on an adobe domain such as www.adobe.com, color.adobe.com, www.stage.adobe.com or color.stage.adobe.com
- Make sure the pages load correctly
- Make sure the page forwards to Adobe.com if you're from China by using the ?country=cn queryparam

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
