### PR TITLE
MWPW-194223: Update CN redirect to always go to adobe.com

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -450,7 +450,9 @@ async function loadPage() {
   /* region based redirect to CN homepage */
   const isAdobeOrigin = /^(www|color)\.(stage\.)?adobe\.com$/.test(window.location.hostname);
   import('./utils/location-utils.js').then(({ getCountry }) => getCountry()).then((country) => {
-    if (country === 'cn' && isAdobeOrigin && !window.location.pathname.startsWith('/cn') && !window.isErrorPage) { window.location.href = '/cn'; }
+    if (country === 'cn' && isAdobeOrigin && !window.location.pathname.startsWith('/cn') && !window.isErrorPage) {
+      window.location.href = window.location.hostname.includes('stage') ? 'https://www.stage.adobe.com/cn' : 'https://www.adobe.com/cn';
+    }
   });
 
   document.head.querySelectorAll('meta').forEach((meta) => {


### PR DESCRIPTION
Ensure the redirect goest to www.adobe.com stage.adobe.com, never the color subdomain.

## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: [MWPW-94223](https://jira.corp.adobe.com/browse/MWPW-94223)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
