### PR TITLE
MWPW-194003: Added gradient support for persistant modal after signing

### DIFF
--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -21,6 +21,7 @@ const VARIANTS = { STRIPS: 'strips', GRADIENTS: 'gradients' };
 const VARIANT_CLASSES = { GRADIENTS: 'gradients', PALETTES: 'palettes' };
 const THEME_URL_PARAM = 'theme';
 const ITEM_ID_URL_PARAM = 'id';
+const PENDING_GRADIENT_SESSION_KEY = 'color-explore-pending-gradient-id';
 const THEME_URL_QUERY_VALUE = {
   [VARIANTS.GRADIENTS]: 'color-gradients',
   [VARIANTS.STRIPS]: 'color-palettes',
@@ -529,6 +530,11 @@ export default async function decorate(block) {
             const item = gradient || {};
             const currentState = BlockMediator.get(stateKey);
             BlockMediator.set(stateKey, { ...currentState, selectedItem: item });
+            if (item.id) {
+              try {
+                sessionStorage.setItem(PENDING_GRADIENT_SESSION_KEY, String(item.id));
+              } catch { /* sessionStorage unavailable */ }
+            }
             await openModalForItem(item, placeholders.modalDefaultGradientTitle);
           });
 
@@ -570,10 +576,26 @@ export default async function decorate(block) {
           const isInitialGradientMount = !hasCompletedInitialModeMount;
           if (!hasCompletedInitialModeMount) hasCompletedInitialModeMount = true;
           if (isInitialGradientMount) {
-            const url = new URL(window.location.href);
-            if (url.searchParams.has(ITEM_ID_URL_PARAM)) {
+            const searchParams = new URLSearchParams(window.location.search);
+            let itemId = searchParams.get(ITEM_ID_URL_PARAM);
+            if (!itemId && searchParams.has('url')) {
+              // susi-light appends a `url` tracking param on sign-in redirect;
+              // use it as a signal that we're returning from sign-in and should
+              // restore the gradient the user was trying to save.
+              itemId = sessionStorage.getItem(PENDING_GRADIENT_SESSION_KEY) || null;
+            }
+            try {
+              sessionStorage.removeItem(PENDING_GRADIENT_SESSION_KEY);
+            } catch { /* sessionStorage unavailable */ }
+            if (itemId) {
+              const url = new URL(window.location.href);
               url.searchParams.delete(ITEM_ID_URL_PARAM);
               window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+              const item = allData.find((g) => String(g.id) === String(itemId))
+                ?? await activeDataService.getTheme(itemId);
+              if (item) {
+                await openModalForItem(item, placeholders.modalDefaultGradientTitle);
+              }
             }
           }
           publishInstances();

--- a/test/scripts/color-shared/utils/susiRedirect.test.js
+++ b/test/scripts/color-shared/utils/susiRedirect.test.js
@@ -96,6 +96,42 @@ describe('buildColorSignInRedirectUrl', () => {
     expect(url.pathname).to.equal('/color-explore');
   });
 
+  it('includes gradient id param when on color-explore page and id is provided', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/color-explore');
+
+    const result = buildColorSignInRedirectUrl(colors, name, 'gradient-abc-123');
+    const url = new URL(result);
+    expect(url.searchParams.get('id')).to.equal('gradient-abc-123');
+  });
+
+  it('omits id param when on color-explore page but no id is provided', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/color-explore');
+
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.searchParams.has('id')).to.be.false;
+  });
+
+  it('omits id param when id is an empty string', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    window.history.replaceState({}, '', '/color-explore');
+
+    const result = buildColorSignInRedirectUrl(colors, name, '');
+    const url = new URL(result);
+    expect(url.searchParams.has('id')).to.be.false;
+  });
+
   it('uses current page URL for color-extract', () => {
     const el = document.createElement('div');
     el.className = 'color-extract';


### PR DESCRIPTION
## Summary

Adds support for gradient modal persistence after clicking sign in to save 

---

## Jira Ticket

Resolves: [MWPW-194003](https://jira.corp.adobe.com/browse/MWPW-194003)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color-milo--adobecom.aem.page/explore/ |
| **After**   | https://MWPW-194003--express-color--adobecom.aem.page/explore/?martech=off |

---

## Verification Steps

- Check out branch locally 
- Spoof stage.color.adobe.com to localhost 
- Run milo libs and append &milolibs=local to the test URL hosted locally 
- Visit after URL on localhost 
- Select gradients, open modal, click "Sign in to save" 
- Follow sign in steps, get redirected back 
- Observe modal is open where you left off

---