### PR TITLE
MWPW-194001: Added auto save after sign in

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -763,6 +763,7 @@ export async function createDrawer(options) {
     libraries: userLibraries,
     ccLibraryProvider,
     onLibraryCreated,
+    autoSave = false,
     i18n = {},
     deps = {},
   } = options;
@@ -928,6 +929,10 @@ export async function createDrawer(options) {
     isOpen = true;
 
     announceToScreenReader(t.title);
+
+    if (autoSave && isSignedIn) {
+      await save();
+    }
   }
 
   function destroy() {

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -195,6 +195,7 @@ async function handleSave(
   ccLibraryProvider,
   libCtxCache,
   drawerI18n,
+  { autoSave = false } = {},
 ) {
   try {
     if (activeDrawer?.isOpen) {
@@ -214,6 +215,7 @@ async function handleSave(
       onLibraryCreated: (newLib) => {
         if (libCtxCache) libCtxCache.libraries.push(newLib);
       },
+      autoSave,
       i18n: drawerI18n,
     };
     if (libraries?.length) drawerOpts.libraries = libraries;
@@ -440,7 +442,11 @@ export function createToolbar(options) {
 
   let libCtxCache = null;
   async function fetchLibCtxOnce() {
-    if (!libCtxCache && getLibraryContext) libCtxCache = await getLibraryContext();
+    if (!libCtxCache && getLibraryContext) {
+      const ctx = await getLibraryContext();
+      if (ctx?.provider) libCtxCache = ctx;
+      return ctx ?? { libraries: [], provider: null };
+    }
     return libCtxCache ?? { libraries: [], provider: null };
   }
 
@@ -578,6 +584,37 @@ export function createToolbar(options) {
   const mql = window.matchMedia('(max-width: 599px)');
   const mqlHandler = () => { ctaBtn.textContent = getCTAText(); };
   mql.addEventListener('change', mqlHandler);
+
+  if (new URLSearchParams(window.location.search).get('pendingSave') === '1') {
+    const cleanUrl = new URL(window.location.href);
+    cleanUrl.searchParams.delete('pendingSave');
+    window.history.replaceState({}, '', cleanUrl.toString());
+
+    (async () => {
+      try {
+        await ensureIms();
+        if (!getLibraryContext) return;
+        const ctx = await getLibraryContext();
+        if (!ctx?.provider) return;
+        libCtxCache = ctx;
+        await handleSave(
+          getPaletteWithName(),
+          type,
+          ccLibBtn,
+          ctx.libraries,
+          ctx.provider,
+          libCtxCache,
+          drawerI18n,
+          { autoSave: true },
+        );
+      } catch (err) {
+        window.lana?.log(`Auto-save after sign-in failed: ${err.message}`, {
+          tags: 'color-floating-toolbar,auto-save',
+          severity: 'error',
+        });
+      }
+    })();
+  }
 
   const api = {
     element: theme,

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -22,10 +22,12 @@ export function buildColorSignInRedirectUrl(colors, name, id = null) {
   if (pageHasBlock('color-explore')) {
     const url = new URL(window.location.href);
     if (id) url.searchParams.set('id', id);
+    url.searchParams.set('pendingSave', '1');
     return url.toString();
   }
 
   const url = new URL(window.location.href);
   setOnUrl(url, colors, { name });
+  url.searchParams.set('pendingSave', '1');
   return url.toString();
 }


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: [MWPW-194001](https://jira.corp.adobe.com/browse/MWPW-194001)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://MWPW-194001--express-color--adobecom.aem.page/create/color-wheel?martech=off |

---

## Verification Steps

- Check out branch locally
- Spoof stage.color.adobe.com to localhost
- Run milo libs and append &milolibs=local to the test URL hosted locally
- Visit after URL on localhost
- Click save to library
- Fill out available fields 
- Click sign in to save
- Sign in
- On redirect back to page you should get a green toast message successfully saving to library

---

## Additional Notes

Tests should be repeatable on Explore, Extract, Extract Gradient and Color Wheel
