### PR TITLE
MWPW-193610: Gradients under pre-selected extract images

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -527,6 +527,11 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 .color-extract .color-extract-suggestion-chip.is-4 { background: var(--color-extract-gray-200); }
 .color-extract .color-extract-suggestion-chip.is-5 { background: var(--color-extract-gray-300); }
 
+.color-extract .color-extract-suggestion-bar.is-gradient {
+  display: block;
+  background: var(--color-extract-gray-100);
+}
+
 /* ---- Edit stage ---- */
 
 .color-extract .color-extract-edit {

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -362,26 +362,26 @@ function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS, v
     decorateAnalyticsAttributes(button, { linkLabel: 'Use this image' });
     const preview = createTag('div', { class: 'color-extract-suggestion-preview' });
     const isGradient = variant === 'gradient';
-    let palette;
+    let colorBar;
     let chips = [];
     if (isGradient) {
-      palette = createTag('div', { class: 'color-extract-suggestion-bar is-gradient' });
+      colorBar = createTag('div', { class: 'color-extract-suggestion-bar is-gradient' });
     } else {
-      palette = createTag('div', { class: 'color-extract-suggestion-bar' }, [
+      colorBar = createTag('div', { class: 'color-extract-suggestion-bar' }, [
         createTag('span', { class: 'color-extract-suggestion-chip is-1' }),
         createTag('span', { class: 'color-extract-suggestion-chip is-2' }),
         createTag('span', { class: 'color-extract-suggestion-chip is-3' }),
         createTag('span', { class: 'color-extract-suggestion-chip is-4' }),
         createTag('span', { class: 'color-extract-suggestion-chip is-5' }),
       ]);
-      chips = [...palette.querySelectorAll('.color-extract-suggestion-chip')];
+      chips = [...colorBar.querySelectorAll('.color-extract-suggestion-chip')];
     }
     const src = getPictureSource(picture);
-    preview.append(picture.cloneNode(true), palette);
+    preview.append(picture.cloneNode(true), colorBar);
     button.append(preview);
     const previewImage = preview.querySelector('img');
     if (previewImage) previewImage.draggable = false;
-    const hydratePalette = async () => {
+    const hydrateColorBar = async () => {
       const imgEl = previewImage?.naturalWidth ? previewImage : null;
       const loadImg = () => {
         if (imgEl) return Promise.resolve(imgEl);
@@ -410,14 +410,14 @@ function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS, v
         const { extractColorsFromImage } = await import('./helpers/extractWorker.js');
         const result = await extractColorsFromImage(imageData, w, h, isGradient ? 5 : chips.length);
         if (isGradient) {
-          applyGradientToBar(result.colors, palette);
+          applyGradientToBar(result.colors, colorBar);
         } else {
           applyPaletteToChips(result.colors, chips);
         }
       } catch (err) {
         window.lana?.log(`Color Extract: extraction failed — ${err?.message}`, { tags: 'color-extract', severity: 'error' });
         if (isGradient) {
-          applyGradientToBar(extractPaletteFromImageElement(img, 5), palette);
+          applyGradientToBar(extractPaletteFromImageElement(img, 5), colorBar);
         } else {
           applyPaletteToChips(extractPaletteFromImageElement(img, chips.length), chips);
         }
@@ -426,9 +426,9 @@ function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS, v
     };
     const scheduleHydrate = () => {
       if (window.requestIdleCallback) {
-        requestIdleCallback(hydratePalette, { timeout: 8000 });
+        requestIdleCallback(hydrateColorBar, { timeout: 8000 });
       } else {
-        setTimeout(hydratePalette, 100);
+        setTimeout(hydrateColorBar, 100);
       }
     };
     if (previewImage?.complete && previewImage.naturalWidth) scheduleHydrate();

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -266,6 +266,12 @@ function applyPaletteToChips(colors, chips) {
   colors.forEach((hex, i) => { if (chips[i]) chips[i].style.background = hex; });
 }
 
+function applyGradientToBar(colors, bar) {
+  if (!colors?.length || !bar) return;
+  const stops = colors.map((hex, i) => `${hex} ${Math.round((i / (colors.length - 1)) * 100)}%`).join(', ');
+  bar.style.backgroundImage = `linear-gradient(90deg, ${stops})`;
+}
+
 function getPictureSource(picture) {
   const img = picture?.querySelector('img');
   const source = picture?.querySelector('source');
@@ -335,7 +341,7 @@ function createColorExtractDropzone(block, config, onImageReady, strings = {}) {
 
 /* ---------- Suggested images ---------- */
 
-function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS) {
+function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS, variant = 'palette') {
   const wrapper = createTag('div', { class: 'color-extract-suggestions' });
   const label = row?.children?.[0] || createTag('div', {}, strings.noImageTryOurs);
   label.classList.add('color-extract-suggestions-label');
@@ -355,17 +361,24 @@ function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS) {
     });
     decorateAnalyticsAttributes(button, { linkLabel: 'Use this image' });
     const preview = createTag('div', { class: 'color-extract-suggestion-preview' });
-    const palette = createTag('div', { class: 'color-extract-suggestion-bar' }, [
-      createTag('span', { class: 'color-extract-suggestion-chip is-1' }),
-      createTag('span', { class: 'color-extract-suggestion-chip is-2' }),
-      createTag('span', { class: 'color-extract-suggestion-chip is-3' }),
-      createTag('span', { class: 'color-extract-suggestion-chip is-4' }),
-      createTag('span', { class: 'color-extract-suggestion-chip is-5' }),
-    ]);
+    const isGradient = variant === 'gradient';
+    let palette;
+    let chips = [];
+    if (isGradient) {
+      palette = createTag('div', { class: 'color-extract-suggestion-bar is-gradient' });
+    } else {
+      palette = createTag('div', { class: 'color-extract-suggestion-bar' }, [
+        createTag('span', { class: 'color-extract-suggestion-chip is-1' }),
+        createTag('span', { class: 'color-extract-suggestion-chip is-2' }),
+        createTag('span', { class: 'color-extract-suggestion-chip is-3' }),
+        createTag('span', { class: 'color-extract-suggestion-chip is-4' }),
+        createTag('span', { class: 'color-extract-suggestion-chip is-5' }),
+      ]);
+      chips = [...palette.querySelectorAll('.color-extract-suggestion-chip')];
+    }
     const src = getPictureSource(picture);
     preview.append(picture.cloneNode(true), palette);
     button.append(preview);
-    const chips = [...palette.querySelectorAll('.color-extract-suggestion-chip')];
     const previewImage = preview.querySelector('img');
     if (previewImage) previewImage.draggable = false;
     const hydratePalette = async () => {
@@ -395,11 +408,19 @@ function buildSuggestedImages(row, onSelect, strings = COLOR_EXTRACT_DEFAULTS) {
         context.drawImage(img, 0, 0, w, h);
         const imageData = context.getImageData(0, 0, w, h);
         const { extractColorsFromImage } = await import('./helpers/extractWorker.js');
-        const result = await extractColorsFromImage(imageData, w, h, chips.length);
-        applyPaletteToChips(result.colors, chips);
+        const result = await extractColorsFromImage(imageData, w, h, isGradient ? 5 : chips.length);
+        if (isGradient) {
+          applyGradientToBar(result.colors, palette);
+        } else {
+          applyPaletteToChips(result.colors, chips);
+        }
       } catch (err) {
         window.lana?.log(`Color Extract: extraction failed — ${err?.message}`, { tags: 'color-extract', severity: 'error' });
-        applyPaletteToChips(extractPaletteFromImageElement(img, chips.length), chips);
+        if (isGradient) {
+          applyGradientToBar(extractPaletteFromImageElement(img, 5), palette);
+        } else {
+          applyPaletteToChips(extractPaletteFromImageElement(img, chips.length), chips);
+        }
         await showExtractionError();
       }
     };
@@ -1346,7 +1367,7 @@ async function renderGradientVariant(block, rows, config, strings = {}) {
   }
 
   const suggestions = resolvedConfig.enableUrlInput
-    ? buildSuggestedImages(rows[0], handleSuggestionClick, colorExtractStrings)
+    ? buildSuggestedImages(rows[0], handleSuggestionClick, colorExtractStrings, 'gradient')
     : null;
   const landing = buildLandingStage(rows[2], colorExtractStrings);
   const dragOverlay = buildDragOverlay(colorExtractStrings);

--- a/test/blocks/color-extract/color-extract.test.js
+++ b/test/blocks/color-extract/color-extract.test.js
@@ -127,4 +127,25 @@ describe('Color Extract — gradient variant', () => {
     // gradient mock HTML has 2 suggestion images
     expect(suggestions.length).to.equal(2);
   });
+
+  it('suggestion bars use gradient style, not palette chips', async () => {
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    const bars = block.querySelectorAll('.color-extract-suggestion-bar');
+    bars.forEach((bar) => {
+      expect(bar.classList.contains('is-gradient')).to.be.true;
+      expect(bar.querySelector('.color-extract-suggestion-chip')).to.not.exist;
+    });
+  });
+
+  it('palette variant suggestion bars use chips, not gradient style', async () => {
+    document.body.innerHTML = basic;
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+    const bars = block.querySelectorAll('.color-extract-suggestion-bar');
+    bars.forEach((bar) => {
+      expect(bar.classList.contains('is-gradient')).to.be.false;
+      expect(bar.querySelectorAll('.color-extract-suggestion-chip').length).to.be.greaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds gradients instead of color palettes under the "Don’t have an image? Try one of ours:" section of extract gradient landing view.

---

## Jira Ticket

Resolves: [MWPW-193610](https://jira.corp.adobe.com/browse/MWPW-193610)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/image-gradient |
| **After**   | https://MWPW-193610--express-color--adobecom.aem.page/create/image-gradient?martech=off |

---

## Verification Steps

- Open after link 
- Observe gradients are under the "Don’t have an image? Try one of ours:" section

---
