### PR TITLE
MWPW-192504: Corrected sticky behavior of toolbar on extract

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -81,7 +81,6 @@
     linear-gradient(-45deg, #ccc 25%, transparent 25%),
     linear-gradient(45deg, transparent 75%, #ccc 75%),
     linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  --color-extract-edit-bg-height: 207px;
 }
 
 /* ---- Inner container ---- */
@@ -598,11 +597,13 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   padding: 16px;
   border: 1px solid rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(28px);
-  height: var(--color-extract-edit-bg-height);
+  aspect-ratio: 835 / 586;
+  height: auto;
 }
 
 .color-extract.has-image .color-extract-edit-left .image-upload-dropzone-container {
-  height: var(--color-extract-edit-bg-height);
+  aspect-ratio: 835 / 586;
+  height: auto;
   width: 100%;
   justify-content: center;
 }
@@ -995,10 +996,6 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 /* ==================== Responsive ==================== */
 
 @media (min-width: 600px) {
-  .color-extract {
-    --color-extract-edit-bg-height: 554px;
-  }
-
   .section:has(.color-extract-marquee-wrapper) {
     align-items: center;
     min-height: 800px;
@@ -1059,7 +1056,17 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 
 @media (min-width: 1200px) {
   .color-extract {
-    --color-extract-edit-bg-height: 458px;
+    --color-extract-edit-bg-height: 490px;
+  }
+
+  .color-extract.has-image .color-extract-edit-bg {
+    aspect-ratio: unset;
+    height: var(--color-extract-edit-bg-height);
+  }
+
+  .color-extract.has-image .color-extract-edit-left .image-upload-dropzone-container {
+    aspect-ratio: unset;
+    height: var(--color-extract-edit-bg-height);
   }
 
   .color-extract .color-extract-landing-bg {

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -7,7 +7,7 @@ import parseBlockConfig from './helpers/parseConfig.js';
 import createHistoryManager from './helpers/historyManager.js';
 import { createUploadDropzone } from '../../scripts/color-shared/components/image-upload/image-upload.js';
 import { showExpressToast } from '../../scripts/color-shared/spectrum/components/express-toast.js';
-import { decorateAnalyticsAttributes, createColorPaletteParamApi, PARAM_NAME } from '../../scripts/color-shared/utils/utilities.js';
+import { decorateAnalyticsAttributes, createColorPaletteParamApi, PARAM_NAME, isMobileOrTabletViewport } from '../../scripts/color-shared/utils/utilities.js';
 import loadColorExtractPlaceholders, { DEFAULT_PLACEHOLDERS as COLOR_EXTRACT_DEFAULTS } from '../../scripts/color-shared/i18n/loadColorExtractPlaceholders.js';
 import loadImageUploadPlaceholders, { DEFAULT_PLACEHOLDERS as IMAGE_UPLOAD_DEFAULTS } from '../../scripts/color-shared/i18n/loadImageUploadPlaceholders.js';
 import loadColorSwatchRailPlaceholders, { DEFAULT_PLACEHOLDERS as COLOR_SWATCH_RAIL_DEFAULTS } from '../../scripts/color-shared/i18n/loadColorSwatchRailPlaceholders.js';
@@ -478,6 +478,7 @@ function buildEditStage(copyRow, imageRow) {
 function createFloatingToolbarMount(controller, variant) {
   const container = createTag('div', { class: 'color-extract-floating-toolbar-mount' });
   let toolbarHandle = null;
+  let mqCleanup = null;
   let mounted = false;
 
   function sync() {
@@ -487,6 +488,8 @@ function createFloatingToolbarMount(controller, variant) {
   }
 
   function destroy() {
+    mqCleanup?.();
+    mqCleanup = null;
     toolbarHandle?.destroy?.();
     toolbarHandle = null;
     mounted = false;
@@ -509,15 +512,27 @@ function createFloatingToolbarMount(controller, variant) {
         ...(variant === VARIANTS.GRADIENT ? { angle: 90 } : {}),
       };
 
+      const initialVariant = isMobileOrTabletViewport() ? 'sticky' : 'sticky-on-scroll';
+
       toolbarHandle = await initFloatingToolbar(container, {
         type: variant === VARIANTS.GRADIENT ? 'gradient' : 'palette',
-        variant: 'sticky',
+        variant: initialVariant,
         standaloneAppearance: 'raised',
         palette,
         showEdit: true,
         showPaletteName: true,
         editPaletteName: true,
       });
+
+      const mq = window.matchMedia('(max-width: 1199px)');
+      const onBreakpointChange = (e) => {
+        toolbarHandle?.setVariant(e.matches ? 'sticky' : 'sticky-on-scroll', {
+          reserveContainer: container,
+          reserveSpace: false,
+        });
+      };
+      mq.addEventListener('change', onBreakpointChange);
+      mqCleanup = () => mq.removeEventListener('change', onBreakpointChange);
 
       controller.subscribe(() => sync());
     } catch (err) {
@@ -1485,4 +1500,17 @@ export default async function decorate(block) {
     await renderGradientVariant(block, contentRows, config, strings);
   }
   trackColorBlockLoad('color-extract');
+
+  const syncFloatingCta = () => {
+    const inResults = block.classList.contains('has-image');
+    document.querySelectorAll('.floating-button-wrapper').forEach((el) => {
+      el.classList.toggle('floating-button--hidden', inResults);
+      el.toggleAttribute('aria-hidden', inResults);
+      el.toggleAttribute('inert', inResults);
+    });
+  };
+
+  const ctaObserver = new MutationObserver(syncFloatingCta);
+  ctaObserver.observe(block, { attributeFilter: ['class'] });
+  syncFloatingCta();
 }


### PR DESCRIPTION
## Summary

Ensures toolbar isn't sticky by default on desktop. Also ensures that the meta driven CTA isn't visible on results view of the extract component to remove conflict of sticky behavior. 

---

## Jira Ticket

Resolves: [MWPW-192504](https://jira.corp.adobe.com/browse/MWPW-192504)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/image |
| **After**   | https://MWPW-192504--express-color--adobecom.aem.page/create/image?martech=off |

https://MWPW-192504--express-color--adobecom.aem.page/drafts/bradjohn/extract?martech=off

---

## Verification Steps

- Open after URL 
- Click pre-selected image to trigger results view 
- Observe on desktop toolbar isn't sticky until scrolled out of original view 
- Scroll to footer and observe it goes away
- Scroll back up, it's restored to sticky 
- Scroll all the way back and it's restored to original location 
- Test second URL (drafts/bradjohn/extract), follow same steps, and observe that the metadata driven CTA is hidden and not conflicting with sticky toolbar 

---
