### PR TITLE
[MWPW-194252] use common, localised default color palette name in toolbar

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.js
+++ b/express/code/blocks/color-blindness/color-blindness.js
@@ -75,7 +75,7 @@ export default async function decorate(block) {
       : -1;
     const hasValidBaseColor = baseColorIndex >= 0;
     const initialPalette = {
-      name: getResolvedPaletteName() || 'My Color Theme',
+      name: getResolvedPaletteName() || '',
       colors: paletteColors,
       ...(hasValidBaseColor && { baseColorIndex }),
     };

--- a/express/code/blocks/color-contrast-checker/color-contrast-checker.js
+++ b/express/code/blocks/color-contrast-checker/color-contrast-checker.js
@@ -22,10 +22,10 @@ function getDefaultConfig() {
   };
 }
 
-function getPalette(strings) {
+function getPalette() {
   const { getResolvedPalette, getResolvedPaletteName } = createColorPaletteParamApi();
   const colors = getResolvedPalette();
-  const name = getResolvedPaletteName() || strings.randomPresetName;
+  const name = getResolvedPaletteName() || '';
 
   const dataService = createContrastDataService();
   const { brightest, darkest } = dataService.findBrightestAndDarkest(colors);
@@ -164,7 +164,7 @@ export default async function decorate(block) {
     };
     block.replaceChildren();
 
-    const initialPalette = getPalette(strings);
+    const initialPalette = getPalette();
     layoutInstance = await createColorToolLayout(block, {
       layoutSpans: {
         tablet: { sidebar: 6, canvas: 6 },

--- a/express/code/blocks/color-contrast-checker/utils/placeholders.js
+++ b/express/code/blocks/color-contrast-checker/utils/placeholders.js
@@ -1,7 +1,6 @@
 import { getLibs } from '../../../scripts/utils.js';
 
 export const DEFAULT_PLACEHOLDERS = Object.freeze({
-  randomPresetName: 'Random Preset',
   customPaletteName: 'Custom Palette',
   errorMessage: 'Failed to load Contrast Checker.',
   summaryTabLabel: 'Summary',
@@ -52,7 +51,6 @@ export const DEFAULT_PLACEHOLDERS = Object.freeze({
 });
 
 const PLACEHOLDER_KEY_MAP = Object.freeze({
-  randomPresetName: 'color-contrast-checker-random-preset-name',
   customPaletteName: 'color-contrast-checker-custom-palette-name',
   errorMessage: 'color-contrast-checker-error-message',
   summaryTabLabel: 'color-contrast-checker-summary-tab-label',

--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -1,38 +1,3 @@
-
-/* Express theme fallbacks for floating toolbar (overridden when full theme loads) */
-:where(.color-extract) {
-  --color-white: #ffffff;
-  --color-default-font: #131313;
-  --color-blue-800: #3b63fb;
-  --color-light-gray-2: #f3f3f3;
-  --color-gray-300-variant: #dadada;
-  --color-gray-800-variant: #292929;
-  --Palette-gray-600: #717171;
-  --spacing-80: 6px;
-  --spacing-100: 8px;
-  --spacing-200: 12px;
-  --spacing-300: 16px;
-  --border-width-2: 2px;
-  --body-font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
-  --ax-body-weight: 700;
-  --ax-body-xs-size: 12px;
-  --ax-body-xxs-size: 11px;
-  --ax-toolbar-sticky-z: 40;
-  --gradient-stop-size: 16px;
-  --gradient-stop-border-color: #fff;
-  --gradient-editor-handle-stroke-width: 2px;
-  --Corner-radius-bar: 12px;
-  --Gradient-editor-max-width-l: 668px;
-  --Gradient-editor-max-width-m: 500px;
-  --Gradient-editor-max-width-s: 343px;
-  --Elevation-floating-button: 0 1px 4px rgba(0, 0, 0, 0.16);
-  --Palette-gray-200: #e9e9e9;
-  --Palette-white: #fff;
-  --Spacing-Spacing-50: 2px;
-  --modal-focus-outline-width: 2px;
-  --S2A-Color-border-focus-indicator: #4b75ff;
-}
-
 .color-extract *,
 .color-extract *::before,
 .color-extract *::after {

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -58,7 +58,7 @@ function createExtractController(maxColors = 5, callbacks = {}) {
   let state = {
     swatches: Array.from({ length: maxColors }, () => ({ hex: '#808080' })),
     baseColorIndex: 0,
-    name: 'Extracted Palette',
+    name: '',
     mood: 'colorful',
   };
   const listeners = new Set();
@@ -503,7 +503,7 @@ function createFloatingToolbarMount(controller, variant) {
       const { initFloatingToolbar } = await import('../../scripts/color-shared/toolbar/createFloatingToolbar.js');
       const state = controller.getState();
       const palette = {
-        name: state.name || 'Extracted Palette',
+        name: state.name || '',
         colors: state.swatches.map((s) => s.hex),
         tags: [],
         ...(variant === VARIANTS.GRADIENT ? { angle: 90 } : {}),

--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -237,7 +237,7 @@ function buildDefaultActionMenuConfig(strings) {
     ],
   };
 }
-const THEME_NAME = 'My Color Theme';
+const THEME_NAME = '';
 const HISTORY_EVENT = `${ACTION_MENU_ID}:history-index-changed`;
 const HISTORY_SKIP_SOURCES = new Set(['active-index', 'metadata', 'base-index']);
 let harmonyCarouselCleanup = null;
@@ -831,6 +831,7 @@ export default async function decorate(block) {
 
       const controller = new ColorThemeExpressController({
         swatches: initialPalette.colors,
+        name: initialPalette.name,
         harmonyRule: 'CUSTOM',
         baseColorIndex: 0,
       });

--- a/express/code/scripts/color-shared/controllers/ColorThemeExpressController.js
+++ b/express/code/scripts/color-shared/controllers/ColorThemeExpressController.js
@@ -42,7 +42,7 @@ export default class ColorThemeExpressController {
     harmonyRule = 'ANALOGOUS',
     baseColorIndex = 0,
     activeSwatchIndex,
-    name = 'My Color Theme',
+    name = '',
     config = {},
   } = {}) {
     this.subscribers = new Set();

--- a/express/code/scripts/color-shared/i18n/loadColorExtractPlaceholders.js
+++ b/express/code/scripts/color-shared/i18n/loadColorExtractPlaceholders.js
@@ -26,8 +26,6 @@ export const DEFAULT_PLACEHOLDERS = Object.freeze({
   toolbarReplaceImage: 'Replace image',
   toolbarUndo: 'Undo',
   toolbarRedo: 'Redo',
-  // Default palette name (used by floating toolbar fallback)
-  defaultPaletteName: 'Extracted Palette',
 });
 
 const PLACEHOLDER_KEY_MAP = Object.freeze({
@@ -53,7 +51,6 @@ const PLACEHOLDER_KEY_MAP = Object.freeze({
   toolbarReplaceImage: 'color-extract-toolbar-replace-image',
   toolbarUndo: 'color-extract-toolbar-undo',
   toolbarRedo: 'color-extract-toolbar-redo',
-  defaultPaletteName: 'color-extract-default-palette-name',
 });
 
 export function createColorExtractPlaceholders(overrides = {}) {

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -465,7 +465,10 @@ export function createToolbar(options) {
 
   const { on, emit } = createEventBus(toolbar, 'color-floating-toolbar');
 
-  const getPaletteWithName = () => ({ ...palette, name: nameInput?.value ?? name });
+  const getPaletteWithName = () => ({
+    ...palette,
+    name: nameInput?.value || t.paletteNamePlaceholder,
+  });
 
   const getCTAText = () => (isMobileViewport()
     ? (mobileCTAText || t.ctaText)

--- a/express/code/scripts/color-shared/toolbar/toolbar.css
+++ b/express/code/scripts/color-shared/toolbar/toolbar.css
@@ -214,9 +214,11 @@
 
 .ax-palette-name-label {
   font-family: var(--body-font-family);
-  font-weight: var(--ax-body-weight);
   font-size: var(--ax-body-xxs-size);
+  font-style: normal;
+  font-weight: var(--ax-body-weight);
   line-height: 16px;
+  letter-spacing: 0;
   color: var(--Palette-gray-600);
   min-height: 0;
 }
@@ -229,11 +231,15 @@
 
 
 .ax-palette-name-input {
+  overflow: hidden;
+  color: var(--Alias-content-neutral-default);
+  text-overflow: ellipsis;
   font-family: var(--body-font-family);
-  font-weight: var(--ax-body-weight);
   font-size: var(--ax-body-xs-size);
-  line-height: var(--line-height-100);
-  color: var(--color-gray-800-variant);
+  font-style: normal;
+  font-weight: var(--ax-body-weight);
+  line-height: var(--ax-body-xxs-lh);
+  letter-spacing: 0;
   background: transparent;
   border: none;
   padding: 0;

--- a/express/code/scripts/color-shared/toolbar/toolbar.css
+++ b/express/code/scripts/color-shared/toolbar/toolbar.css
@@ -248,6 +248,16 @@
   min-height: 0;
 }
 
+.ax-palette-name-input::placeholder {
+  color: var(--Alias-content-neutral-default);
+  font-family: var(--body-font-family);
+  font-size: var(--ax-body-xs-size);
+  font-style: normal;
+  font-weight: var(--ax-body-weight);
+  line-height: var(--ax-body-xxs-lh);
+  letter-spacing: 0;
+}
+
 /* ── CTA button (mobile: full-width wrap) ────────────────────── */
 
 .ax-toolbar-main > sp-button {

--- a/test/blocks/color-wheel/color-wheel.test.js
+++ b/test/blocks/color-wheel/color-wheel.test.js
@@ -118,9 +118,9 @@ describe('color-wheel utilities', () => {
       expect(paletteFromThemeState({ swatches: [] }).colors).to.deep.equal(['#FF0000']);
     });
 
-    it('falls back to default name when name is absent', () => {
+    it('falls back to empty string when name is absent', () => {
       const palette = paletteFromThemeState({ swatches: [{ hex: '#FF0000' }] });
-      expect(palette.name).to.be.a('string').and.have.length.above(0);
+      expect(palette.name).to.equal('');
     });
   });
 


### PR DESCRIPTION
## Summary
- Default palette/theme name is no longer hardcoded as an English string (`"My Color Theme"`, `"Extracted Palette"`, `"Random Preset"`) in the toolbar, color-wheel, color-blindness, color-extract, and color-contrast-checker blocks
- All defaults are now `''` so the toolbar's existing localised placeholder (`color-toolbar-palette-placeholder`) is shown instead
- `getPaletteWithName` falls back to `t.paletteNamePlaceholder` (localised) when no name is typed, so share/download/save operations also use the localised string
- `ColorThemeExpressController` now receives the initial palette name so it persists across harmony-rule changes
- Removed unused `randomPresetName` and `defaultPaletteName` placeholder keys that were never consumed by their respective blocks


---

## Jira Ticket

Resolves: [MWPW-194252](https://jira.corp.adobe.com/browse/MWPW-194252)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/image |
| **After**   | https://MWPW-194252-i18n-palette-name--express-color--adobecom.aem.page/create/image?martech=off |
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-accessibility|
| **After**   | https://MWPW-194252-i18n-palette-name--express-color--adobecom.aem.page/create/color-accessibility?martech=off |
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-contrast-analyzer |
| **After**   | https://MWPW-194252-i18n-palette-name--express-color--adobecom.aem.page/create/color-contrast-analyzer?martech=off |
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://MWPW-194252-i18n-palette-name--express-color--adobecom.aem.page/create/color-wheel?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
