### PR TITLE
Mood Selector Accessibility

### DIFF
--- a/express/code/blocks/color-extract/helpers/moodSelector.js
+++ b/express/code/blocks/color-extract/helpers/moodSelector.js
@@ -70,6 +70,14 @@ export default function createMoodSelector(initialMood, onChange, options = {}) 
     });
   }
 
+  function getOptions() {
+    return [...popover.querySelectorAll('.color-extract-mood-option')];
+  }
+
+  function focusOption(option) {
+    if (option) option.focus();
+  }
+
   MOOD_LIST.forEach((mood) => {
     const option = createTag('button', {
       class: `color-extract-mood-option ${mood === currentMood ? 'is-selected' : ''}`,
@@ -83,11 +91,13 @@ export default function createMoodSelector(initialMood, onChange, options = {}) 
       e.stopPropagation();
       if (mood === currentMood) {
         closePopover();
+        trigger.focus();
         return;
       }
       setMood(mood);
       onChange(mood);
       closePopover();
+      trigger.focus();
     });
 
     popover.append(option);
@@ -99,6 +109,9 @@ export default function createMoodSelector(initialMood, onChange, options = {}) 
     popover.hidden = false;
     trigger.setAttribute('aria-expanded', 'true');
     dropdown.classList.add('is-open');
+    const selected = popover.querySelector('.color-extract-mood-option.is-selected')
+      || getOptions()[0];
+    focusOption(selected);
   }
 
   trigger.addEventListener('click', (e) => {
@@ -110,7 +123,43 @@ export default function createMoodSelector(initialMood, onChange, options = {}) 
   document.addEventListener('click', () => closePopover());
 
   trigger.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closePopover();
+    if (e.key === 'Escape') {
+      closePopover();
+    } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (popover.hidden) openPopover();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      if (popover.hidden) {
+        e.preventDefault();
+        openPopover();
+      }
+    }
+  });
+
+  popover.addEventListener('keydown', (e) => {
+    const options = getOptions();
+    const focused = document.activeElement;
+    const index = options.indexOf(focused);
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusOption(options[(index + 1) % options.length]);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      focusOption(options[(index - 1 + options.length) % options.length]);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      focusOption(options[0]);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      focusOption(options[options.length - 1]);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closePopover();
+      trigger.focus();
+    } else if (e.key === 'Tab') {
+      closePopover();
+    }
   });
 
   wrapper.append(label, dropdown);

--- a/express/code/blocks/color-extract/helpers/moodSelector.js
+++ b/express/code/blocks/color-extract/helpers/moodSelector.js
@@ -137,22 +137,22 @@ export default function createMoodSelector(initialMood, onChange, options = {}) 
   });
 
   popover.addEventListener('keydown', (e) => {
-    const options = getOptions();
+    const pOptions = getOptions();
     const focused = document.activeElement;
-    const index = options.indexOf(focused);
+    const index = pOptions.indexOf(focused);
 
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      focusOption(options[(index + 1) % options.length]);
+      focusOption(pOptions[(index + 1) % pOptions.length]);
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      focusOption(options[(index - 1 + options.length) % options.length]);
+      focusOption(pOptions[(index - 1 + pOptions.length) % pOptions.length]);
     } else if (e.key === 'Home') {
       e.preventDefault();
-      focusOption(options[0]);
+      focusOption(pOptions[0]);
     } else if (e.key === 'End') {
       e.preventDefault();
-      focusOption(options[options.length - 1]);
+      focusOption(pOptions[pOptions.length - 1]);
     } else if (e.key === 'Escape') {
       e.preventDefault();
       closePopover();

--- a/test/blocks/color-extract/helpers/moodSelector.test.js
+++ b/test/blocks/color-extract/helpers/moodSelector.test.js
@@ -1,0 +1,285 @@
+/* eslint-env mocha */
+
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setLibs } from '../../../../express/code/scripts/utils.js';
+import createMoodSelector from '../../../../express/code/blocks/color-extract/helpers/moodSelector.js';
+import { MOOD_LIST, MOODS } from '../../../../express/code/blocks/color-extract/helpers/constants.js';
+
+setLibs('/test/mocks/libs', { hostname: 'prod.example.com', search: '' });
+
+function key(element, k) {
+  element.dispatchEvent(new KeyboardEvent('keydown', { key: k, bubbles: true }));
+}
+
+describe('createMoodSelector', () => {
+  let container;
+  let onChange;
+  let selector;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    onChange = sinon.stub();
+    selector = createMoodSelector(MOODS.COLORFUL, onChange);
+    container.appendChild(selector.element);
+  });
+
+  afterEach(() => {
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    container.remove();
+    sinon.restore();
+  });
+
+  const getTrigger = () => selector.element.querySelector('.color-extract-mood-trigger');
+  const getPopover = () => selector.element.querySelector('.color-extract-mood-popover');
+  const getOptions = () => [...selector.element.querySelectorAll('.color-extract-mood-option')];
+
+  // ── DOM structure ──────────────────────────────────────────────────────────
+
+  describe('DOM structure', () => {
+    it('renders mood label text', () => {
+      const label = selector.element.querySelector('.color-extract-mood-label');
+      expect(label).to.exist;
+      expect(label.textContent).to.equal('Color mood');
+    });
+
+    it('trigger is a <button> with aria-haspopup="listbox"', () => {
+      const trigger = getTrigger();
+      expect(trigger.tagName.toLowerCase()).to.equal('button');
+      expect(trigger.getAttribute('aria-haspopup')).to.equal('listbox');
+    });
+
+    it('popover has role="listbox"', () => {
+      expect(getPopover().getAttribute('role')).to.equal('listbox');
+    });
+
+    it('renders one option per mood', () => {
+      expect(getOptions().length).to.equal(MOOD_LIST.length);
+    });
+
+    it('each option has role="option"', () => {
+      getOptions().forEach((opt) => {
+        expect(opt.getAttribute('role')).to.equal('option');
+      });
+    });
+  });
+
+  // ── Initial state ──────────────────────────────────────────────────────────
+
+  describe('initial state', () => {
+    it('trigger aria-expanded is "false"', () => {
+      expect(getTrigger().getAttribute('aria-expanded')).to.equal('false');
+    });
+
+    it('popover is hidden', () => {
+      expect(getPopover().hidden).to.be.true;
+    });
+
+    it('initialMood option has aria-selected="true" and is-selected class', () => {
+      const selected = getOptions().find((o) => o.dataset.mood === MOODS.COLORFUL);
+      expect(selected.getAttribute('aria-selected')).to.equal('true');
+      expect(selected.classList.contains('is-selected')).to.be.true;
+    });
+
+    it('non-initial options have aria-selected="false"', () => {
+      getOptions()
+        .filter((o) => o.dataset.mood !== MOODS.COLORFUL)
+        .forEach((o) => expect(o.getAttribute('aria-selected')).to.equal('false'));
+    });
+  });
+
+  // ── Open / close ───────────────────────────────────────────────────────────
+
+  describe('open / close', () => {
+    it('clicking trigger opens the popover', () => {
+      getTrigger().click();
+      expect(getPopover().hidden).to.be.false;
+      expect(getTrigger().getAttribute('aria-expanded')).to.equal('true');
+    });
+
+    it('clicking trigger again closes the popover', () => {
+      getTrigger().click();
+      getTrigger().click();
+      expect(getPopover().hidden).to.be.true;
+      expect(getTrigger().getAttribute('aria-expanded')).to.equal('false');
+    });
+
+    it('document click closes the popover', () => {
+      getTrigger().click();
+      document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(getPopover().hidden).to.be.true;
+    });
+
+    it('opening focuses the selected option', () => {
+      getTrigger().click();
+      const selected = getOptions().find((o) => o.classList.contains('is-selected'));
+      expect(document.activeElement).to.equal(selected);
+    });
+
+    it('opening with no is-selected option focuses the first option', () => {
+      getOptions().forEach((o) => o.classList.remove('is-selected'));
+      getTrigger().click();
+      expect(document.activeElement).to.equal(getOptions()[0]);
+    });
+  });
+
+  // ── Option selection ───────────────────────────────────────────────────────
+
+  describe('option selection', () => {
+    beforeEach(() => { getTrigger().click(); });
+
+    it('clicking a new option calls onChange with the mood value', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.BRIGHT).click();
+      expect(onChange.calledOnceWith(MOODS.BRIGHT)).to.be.true;
+    });
+
+    it('clicking a new option closes the popover', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.DARK).click();
+      expect(getPopover().hidden).to.be.true;
+    });
+
+    it('clicking a new option updates aria-selected', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.MUTED).click();
+      getOptions().forEach((o) => {
+        expect(o.getAttribute('aria-selected')).to.equal(o.dataset.mood === MOODS.MUTED ? 'true' : 'false');
+      });
+    });
+
+    it('clicking a new option updates trigger text', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.DEEP).click();
+      expect(selector.element.querySelector('.color-extract-mood-trigger-text').textContent).to.equal('Deep');
+    });
+
+    it('clicking a new option returns focus to trigger', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.BRIGHT).click();
+      expect(document.activeElement).to.equal(getTrigger());
+    });
+
+    it('clicking the already-selected option closes popover without calling onChange', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.COLORFUL).click();
+      expect(onChange.called).to.be.false;
+      expect(getPopover().hidden).to.be.true;
+    });
+
+    it('clicking the already-selected option returns focus to trigger', () => {
+      getOptions().find((o) => o.dataset.mood === MOODS.COLORFUL).click();
+      expect(document.activeElement).to.equal(getTrigger());
+    });
+  });
+
+  // ── setMood() API ──────────────────────────────────────────────────────────
+
+  describe('setMood()', () => {
+    it('updates trigger text', () => {
+      selector.setMood(MOODS.DARK);
+      expect(selector.element.querySelector('.color-extract-mood-trigger-text').textContent).to.equal('Dark');
+    });
+
+    it('updates aria-selected on all options', () => {
+      selector.setMood(MOODS.DEEP);
+      getOptions().forEach((o) => {
+        expect(o.getAttribute('aria-selected')).to.equal(o.dataset.mood === MOODS.DEEP ? 'true' : 'false');
+      });
+    });
+
+    it('does not call onChange', () => {
+      selector.setMood(MOODS.MUTED);
+      expect(onChange.called).to.be.false;
+    });
+  });
+
+  // ── Keyboard — trigger ─────────────────────────────────────────────────────
+
+  describe('keyboard — trigger', () => {
+    it('Escape on trigger closes the popover', () => {
+      getTrigger().click();
+      key(getTrigger(), 'Escape');
+      expect(getPopover().hidden).to.be.true;
+    });
+
+    it('ArrowDown on trigger opens the popover', () => {
+      key(getTrigger(), 'ArrowDown');
+      expect(getPopover().hidden).to.be.false;
+    });
+
+    it('ArrowUp on trigger opens the popover', () => {
+      key(getTrigger(), 'ArrowUp');
+      expect(getPopover().hidden).to.be.false;
+    });
+
+    it('Enter on trigger opens the popover', () => {
+      key(getTrigger(), 'Enter');
+      expect(getPopover().hidden).to.be.false;
+    });
+
+    it('Space on trigger opens the popover', () => {
+      key(getTrigger(), ' ');
+      expect(getPopover().hidden).to.be.false;
+    });
+
+    it('ArrowDown focuses the selected option on open', () => {
+      key(getTrigger(), 'ArrowDown');
+      expect(document.activeElement).to.equal(getOptions().find((o) => o.classList.contains('is-selected')));
+    });
+  });
+
+  // ── Keyboard — arrow navigation ────────────────────────────────────────────
+
+  describe('keyboard — arrow navigation', () => {
+    let options;
+
+    beforeEach(() => {
+      getTrigger().click();
+      options = getOptions();
+    });
+
+    it('ArrowDown moves focus to the next option', () => {
+      options[0].focus();
+      key(options[0], 'ArrowDown');
+      expect(document.activeElement).to.equal(options[1]);
+    });
+
+    it('ArrowDown wraps from the last option to the first', () => {
+      options[options.length - 1].focus();
+      key(options[options.length - 1], 'ArrowDown');
+      expect(document.activeElement).to.equal(options[0]);
+    });
+
+    it('ArrowUp moves focus to the previous option', () => {
+      options[2].focus();
+      key(options[2], 'ArrowUp');
+      expect(document.activeElement).to.equal(options[1]);
+    });
+
+    it('ArrowUp wraps from the first option to the last', () => {
+      options[0].focus();
+      key(options[0], 'ArrowUp');
+      expect(document.activeElement).to.equal(options[options.length - 1]);
+    });
+
+    it('Home moves focus to the first option', () => {
+      options[3].focus();
+      key(options[3], 'Home');
+      expect(document.activeElement).to.equal(options[0]);
+    });
+
+    it('End moves focus to the last option', () => {
+      options[1].focus();
+      key(options[1], 'End');
+      expect(document.activeElement).to.equal(options[options.length - 1]);
+    });
+
+    it('Escape closes the popover and returns focus to trigger', () => {
+      options[2].focus();
+      key(options[2], 'Escape');
+      expect(getPopover().hidden).to.be.true;
+      expect(document.activeElement).to.equal(getTrigger());
+    });
+
+    it('Tab closes the popover', () => {
+      key(options[1], 'Tab');
+      expect(getPopover().hidden).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Improves keyboard accessibility for the color-extract **mood** dropdown: opening the list moves focus to the selected option (or the first), **Arrow Up/Down** and **Enter/Space** on the trigger open the list, options support **Arrow Up/Down**, **Home**, and **End**, **Escape** closes the list and returns focus to the trigger, and **Tab** closes the list. After choosing a mood (or choosing the already-selected one), focus returns to the trigger.

---

## Jira Ticket

Resolves: [MWPW-194259](https://jira.corp.adobe.com/browse/MWPW-194259)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://mwpw-194259--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

1. Open a page that includes the color-extract block (or the relevant Express flow) on the **after** URL.
2. Tab to the mood control and use **Enter** or **Space** to open the list.
   - **Before:** Limited keyboard support; focus behavior was inconsistent when opening or closing.
   - **After:** The list opens; focus lands on the current mood (or the first option).
3. Use **Arrow Down/Up**, **Home**, and **End** to move among moods; confirm highlight/selection state updates as expected.
4. Press **Escape** and confirm the list closes and focus returns to the trigger.
5. Open the list again, press **Tab**, and confirm the list closes.
6. Select a mood with **Enter** or click; confirm the list closes and focus returns to the trigger.
7. Optionally repeat on **before** (main) to contrast keyboard and focus behavior.

---

## Potential Regressions

- https://mwpw-194259--da-express-milo--adobecom.aem.live/express/?martech=off  
- Mouse/touch: open/close, outside click to close, and mood selection still work.
- Screen readers: trigger `aria-expanded`, listbox/options, and `aria-selected` still announce sensibly after focus moves.

---

## Additional Notes

- Change is scoped to `express/code/blocks/color-extract/helpers/moodSelector.js` (keyboard handlers, focus management, small helpers `getOptions` / `focusOption`).