### PR TITLE
Image Upload Aria Attribute

### DIFF
--- a/express/code/scripts/color-shared/components/image-upload/image-upload.js
+++ b/express/code/scripts/color-shared/components/image-upload/image-upload.js
@@ -80,7 +80,7 @@ export function createUploadDropzone(options = {}) {
     role: 'button',
     tabindex: opts.enabled ? '0' : '-1',
     'aria-label': opts.ariaLabel,
-    'aria-disabled': opts.enabled ? undefined : 'true',
+    ...(!opts.enabled && { 'aria-disabled': 'true' }),
   });
 
   const uploadIcon = createTag('span', { class: `${CLS}-upload-icon`, 'aria-hidden': 'true' }, UPLOAD_SVG);


### PR DESCRIPTION
## Summary

Fixes an accessibility defect on the shared **image upload dropzone** (`.image-upload-dropzone`): when the dropzone was enabled, `createTag` still received `aria-disabled: undefined`, which ended up as the literal attribute `aria-disabled="undefined"`—invalid for ARIA and flagged by axe. **Enabled** dropzones no longer set `aria-disabled`; **disabled** dropzones still set `aria-disabled="true"`.

---

## Jira Ticket

Resolves: [MWPW-194256](https://jira.corp.adobe.com/browse/MWPW-194256)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://mwpwn-194256--express-color--adobecom.aem.page/create/image |

---

## Verification Steps

1. Open an **Extract** (palette / gradient) flow that shows the image upload area on the **after** URL (or the equivalent **express-color** preview if that’s where the block is authored).
2. Run **axe DevTools** (full page scan).
   - **Before:** Violation: invalid ARIA attribute value on the dropzone — `aria-disabled="undefined"`.
   - **After:** No violation for that attribute; when enabled, `aria-disabled` is absent; when disabled, `aria-disabled="true"`.
3. In DevTools, inspect `.image-upload-dropzone` and confirm **enabled** state has **no** `aria-disabled` (or only `"true"` when disabled).

---

## Potential Regressions

- https://mwpwn-194256--da-express-milo--adobecom.aem.live/express/?martech=off  
- Any surface using `createUploadDropzone`: disabled styling, `tabindex`, and file `input.disabled` behavior should be unchanged aside from the fixed attribute.

