### PR TITLE
Added font-weight adjustments to blog headers

### DIFF
--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.css
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.css
@@ -26,12 +26,12 @@
 }
 
 .section.ax-blog-posts-container:not([data-padding='none']):not(.xxxl-spacing-static, .xxl-spacing-static, .xl-spacing-static,
-  .xxxl-spacing, .xxl-spacing, .xl-spacing, .l-spacing, .m-spacing, .s-spacing, .xs-spacing, .xxs-spacing)>.content:first-child {
+.xxxl-spacing, .xxl-spacing, .xl-spacing, .l-spacing, .m-spacing, .s-spacing, .xs-spacing, .xxs-spacing)>.content:first-child {
   padding: 0;
 }
 
 .blog main .section:has(.blog-posts-wrapper):not(.xxxl-spacing-static, .xxl-spacing-static, .xl-spacing-static, .xxxl-spacing, .xxl-spacing, .xl-spacing,
-  .l-spacing, .m-spacing, .s-spacing, .xs-spacing, .xxs-spacing)>div:first-child {
+.l-spacing, .m-spacing, .s-spacing, .xs-spacing, .xxs-spacing)>div:first-child {
   padding: 0;
   margin-top: var(--spacing-800);
 }
@@ -52,6 +52,7 @@ main .section:has(.blog-posts-wrapper) .blog-posts-header .header {
   margin-top: 0;
   text-align: left;
   width: 66%;
+  font-weight: var(--heading-font-weight-extra)
 }
 
 .blog main .section:has(.blog-posts-wrapper)>div>h2,

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1474,6 +1474,7 @@ main .section.long-form .content h6 {
 main .section.long-form.long-form-blog .content :is(h3, h4, h5, h6) {
   font-size: var(--Global-Typography-Size-Headings-Heading-L);
   line-height: 104%;
+  font-weight: var(--heading-font-weight-extra);
 }
 
 main .section.long-form .content,


### PR DESCRIPTION
## Summary

Added font-weight adjustments to blog headers

---

## Jira Ticket

Resolves: [MWPW-192142](https://jira.corp.adobe.com/browse/MWPW-192142)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/de/express/learn/blog/heartfelt-get-well-wishes |
| **After**   | https://mwpw-192142-2--da-express-milo--adobecom.aem.page/de/express/learn/blog/heartfelt-get-well-wishes?martech=off |

---

## Verification Steps

- Navigate to the Before link and observe the text in the blog post (h3 headers), as well as the 'blog-posts-header' at the bottom of the page, notice font-weight is too light. 
- Navigate to the After link to notice that the font-weights for those texts are now correct. 

---

## Potential Regressions

- https://mwpw-192142-2--da-express-milo--adobecom.aem.page/br/express/discover/examples/chart/gantt
- https://mwpw-192142-2--da-express-milo--adobecom.aem.page/de/express/learn/blog/modern-logo-design
- https://mwpw-192142-2--da-express-milo--adobecom.aem.page/express/learn/blog/carousels-stand-out
- https://mwpw-192142-2--da-express-milo--adobecom.aem.page/express/learn/blog/cc-libraries-asset-sharing
- https://mwpw-192142-2--da-express-milo--adobecom.aem.page/express/learn/blog/celebrate-earth-day

---

## Additional Notes

N/A
