### PR TITLE
[COLOR] Fix cta-carousel last card not tappable on iOS mobile

### DIFF
--- a/express/code/blocks/cta-carousel/cta-carousel.css
+++ b/express/code/blocks/cta-carousel/cta-carousel.css
@@ -51,6 +51,7 @@
 .cta-carousel .card {
     margin: 0 8px;
     position: relative;
+    cursor: pointer;
 }
 
 .cta-carousel .card:focus-within {

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -487,9 +487,10 @@ export function preDecorateSections(area) {
             const sameHash = currURL.hash === linkToTargetURL?.hash;
             const isNotInFloatingCta = !a.closest('.block')?.classList.contains('floating-button');
             const notFloatingCtaIgnore = !a.classList.contains('floating-cta-ignore');
+            const isNotInCtaCarousel = !a.closest('.cta-carousel');
 
             return (sameText || (samePathname && sameHash))
-              && isNotInFloatingCta && notFloatingCtaIgnore;
+              && isNotInFloatingCta && notFloatingCtaIgnore && isNotInCtaCarousel;
           } catch (error) {
             window.lana?.log(`${error?.message || error?.detail || error}`, { tags: 'utils', severity: 'error' });
             return false;

--- a/express/code/scripts/widgets/floating-cta.js
+++ b/express/code/scripts/widgets/floating-cta.js
@@ -159,7 +159,8 @@ export async function createFloatingButton(block, audience, data) {
     .filter((a) => (
       a.textContent.trim() === aTag.textContent.trim()
         || (new URL(a.href).pathname === aTagURL.pathname && new URL(a.href).hash === aTagURL.hash))
-        && !a.parentElement.parentElement.classList.contains('floating-button'));
+        && !a.parentElement.parentElement.classList.contains('floating-button')
+        && !a.closest('.cta-carousel'));
   sameUrlCTAs.forEach((cta) => {
     cta.classList.add('same-fcta');
   });

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1156,8 +1156,8 @@ main .section:not(.xxxl-spacing-static,
   padding-bottom: var(--spacing-600);
 }
 
-div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards, .simplified-pricing-cards-v2) a.button.same-fcta,
-div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards, .simplified-pricing-cards-v2) a.con-button.same-fcta,
+div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards, .simplified-pricing-cards-v2, .cta-carousel) a.button.same-fcta,
+div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards, .simplified-pricing-cards-v2, .cta-carousel) a.con-button.same-fcta,
 #hero a.same-fcta {
   display: none;
 }


### PR DESCRIPTION
On pages where a floating CTA targets the same URL as a carousel card, same-fcta was added to that card's button, hiding it via display:none. On real iOS Safari, a card with no visible link never fires the hover tap gesture, so the overlay never appears and the CTA is unreachable.

- Exclude .cta-carousel from the same-fcta display:none rule in CSS
- Skip cta-carousel CTAs when marking same-fcta in floating-cta.js
- Skip cta-carousel CTAs when marking same-fcta in utils.js
- Add cursor:pointer to .card so iOS hover fires reliably

## Summary

Carousel Last CTA fix on ios Mobile

---

## Jira Ticket

Resolves: [MWPW-194357](https://jira.corp.adobe.com/browse/MWPW-194357)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/ |
| **After**   | https://last-cta--express-color--adobecom.aem.page/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
