### PR TITLE
[MWPW-194451] open in express post sign in via open in express CTA

### DIFF
--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -96,17 +96,7 @@ async function checkIsSignedIn() {
   }
 }
 
-async function handleOpenInExpress({ id, name, colors }) {
-  const isSignedIn = await checkIsSignedIn();
-  if (!isSignedIn) {
-    const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
-      '../utils/susiRedirect.js'
-    );
-    setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name, id));
-    await triggerSignInFlow();
-    return;
-  }
-
+async function openInExpress({ id, name, colors }) {
   const { getTrackingAppendedURL } = await import('../../branchlinks.js');
 
   const params = new URLSearchParams(window.location.search);
@@ -128,6 +118,20 @@ async function handleOpenInExpress({ id, name, colors }) {
   url.searchParams.set('category', 'yourStuff');
 
   window.open(url.toString(), '_blank', 'noopener noreferrer');
+}
+
+async function handleOpenInExpress({ id, name, colors }) {
+  const isSignedIn = await checkIsSignedIn();
+  if (!isSignedIn) {
+    const { setSusiColorRedirect, buildColorSignInRedirectUrl } = await import(
+      '../utils/susiRedirect.js'
+    );
+    setSusiColorRedirect(buildColorSignInRedirectUrl(colors, name, id, true));
+    await triggerSignInFlow();
+    return;
+  }
+
+  await openInExpress({ id, name, colors });
 }
 
 async function handleDownload(palette, t) {
@@ -578,6 +582,18 @@ export function createToolbar(options) {
   const mql = window.matchMedia('(max-width: 599px)');
   const mqlHandler = () => { ctaBtn.textContent = getCTAText(); };
   mql.addEventListener('change', mqlHandler);
+
+  const postSignInParams = new URLSearchParams(window.location.search);
+  if (postSignInParams.has('openInExpress')) {
+    postSignInParams.delete('openInExpress');
+    const cleanSearch = postSignInParams.toString();
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${cleanSearch ? `?${cleanSearch}` : ''}${window.location.hash}`,
+    );
+    openInExpress(getPaletteWithName()).catch(() => {});
+  }
 
   const api = {
     element: theme,

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -592,7 +592,12 @@ export function createToolbar(options) {
       '',
       `${window.location.pathname}${cleanSearch ? `?${cleanSearch}` : ''}${window.location.hash}`,
     );
-    openInExpress(getPaletteWithName()).catch(() => {});
+    openInExpress(getPaletteWithName()).catch((err) => {
+      window.lana?.log(`openInExpress post-sign-in failed: ${err.message}`, {
+        tags: 'color-floating-toolbar,open-in-express',
+        severity: 'error',
+      });
+    });
   }
 
   const api = {

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -16,16 +16,16 @@ function pageHasBlock(...classNames) {
   return classNames.some((cls) => document.querySelector(`.${cls}`));
 }
 
-export function buildColorSignInRedirectUrl(colors, name, id = null) {
+export function buildColorSignInRedirectUrl(colors, name, id = null, openInExpress = false) {
   const { setOnUrl } = createColorPaletteParamApi();
+  const url = new URL(window.location.href);
 
   if (pageHasBlock('color-explore')) {
-    const url = new URL(window.location.href);
     if (id) url.searchParams.set('id', id);
-    return url.toString();
+  } else {
+    setOnUrl(url, colors, { name });
   }
 
-  const url = new URL(window.location.href);
-  setOnUrl(url, colors, { name });
+  if (openInExpress) url.searchParams.set('openInExpress', 'true');
   return url.toString();
 }

--- a/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
+++ b/test/scripts/color-shared/toolbar/createToolbarComponent.test.js
@@ -649,6 +649,18 @@ describe('createToolbar', () => {
       expect(stored).to.include('color-palette=');
     });
 
+    it('stores a SUSI redirect URL with openInExpress=true when not signed in', async () => {
+      window.adobeIMS = {
+        isSignedInUser: sinon.stub().returns(false),
+      };
+
+      await clickCTA();
+
+      const stored = consumeSusiColorRedirect();
+      const url = new URL(stored);
+      expect(url.searchParams.get('openInExpress')).to.equal('true');
+    });
+
     it('opens Express in a new tab when user is signed in', async () => {
       window.adobeIMS = {
         isSignedInUser: sinon.stub().returns(true),
@@ -659,6 +671,54 @@ describe('createToolbar', () => {
       expect(openStub.calledOnce).to.be.true;
       expect(openStub.firstCall.args[1]).to.equal('_blank');
       expect(consumeSusiColorRedirect()).to.be.null;
+    });
+  });
+
+  describe('openInExpress post-sign-in redirect', () => {
+    let openStub;
+    let savedHref;
+
+    beforeEach(() => {
+      savedHref = window.location.href;
+      openStub = sinon.stub(window, 'open');
+    });
+
+    afterEach(() => {
+      delete window.adobeIMS;
+      window.history.replaceState({}, '', savedHref);
+    });
+
+    it('automatically opens Express when openInExpress=true is in the URL and user is signed in', async () => {
+      window.adobeIMS = { isSignedInUser: sinon.stub().returns(true) };
+      window.history.replaceState({}, '', '?openInExpress=true');
+
+      const toolbar = createToolbar(defaultOptions({ onCTA: undefined }));
+      document.body.appendChild(toolbar.element);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(openStub.calledOnce).to.be.true;
+      expect(openStub.firstCall.args[1]).to.equal('_blank');
+    });
+
+    it('removes openInExpress from the URL after auto-triggering', async () => {
+      window.adobeIMS = { isSignedInUser: sinon.stub().returns(true) };
+      window.history.replaceState({}, '', '?openInExpress=true');
+
+      const toolbar = createToolbar(defaultOptions({ onCTA: undefined }));
+      document.body.appendChild(toolbar.element);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(new URLSearchParams(window.location.search).has('openInExpress')).to.be.false;
+    });
+
+    it('does not open Express automatically when openInExpress is not in the URL', async () => {
+      window.adobeIMS = { isSignedInUser: sinon.stub().returns(true) };
+
+      const toolbar = createToolbar(defaultOptions({ onCTA: undefined }));
+      document.body.appendChild(toolbar.element);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(openStub.called).to.be.false;
     });
   });
 

--- a/test/scripts/color-shared/utils/susiRedirect.test.js
+++ b/test/scripts/color-shared/utils/susiRedirect.test.js
@@ -132,4 +132,26 @@ describe('buildColorSignInRedirectUrl', () => {
     expect(url.pathname).to.equal('/create/color-wheel');
     expect(url.pathname).to.not.match(/^\/[a-z]{2,3}\//);
   });
+
+  it('does not include openInExpress param by default', () => {
+    const result = buildColorSignInRedirectUrl(colors, name);
+    const url = new URL(result);
+    expect(url.searchParams.has('openInExpress')).to.be.false;
+  });
+
+  it('includes openInExpress=true when openInExpress arg is true', () => {
+    const result = buildColorSignInRedirectUrl(colors, name, null, true);
+    const url = new URL(result);
+    expect(url.searchParams.get('openInExpress')).to.equal('true');
+  });
+
+  it('includes openInExpress=true on color-explore page when openInExpress arg is true', () => {
+    const el = document.createElement('div');
+    el.className = 'color-explore';
+    document.body.appendChild(el);
+
+    const result = buildColorSignInRedirectUrl(colors, name, null, true);
+    const url = new URL(result);
+    expect(url.searchParams.get('openInExpress')).to.equal('true');
+  });
 });


### PR DESCRIPTION
## Summary

- Add `openInExpress=true` URL param to the sign-in redirect URL when a user clicks "Create with my color palette" without being signed in
- On page load after sign-in, detect the param, strip it from the URL, and directly open Express — bypassing the sign-in re-check to avoid a timing race where IMS hasn't settled its auth state yet
- The `openInExpress` flag is opt-in via a new argument on `buildColorSignInRedirectUrl`, so other callers (e.g. drawer component) are unaffected
- Unit tests: `susiRedirect.test.js` and `createToolbarComponent.test.js`

---

## Jira Ticket

Resolves: [MWPW-194451](https://jira.corp.adobe.com/browse/MWPW-194451)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-wheel?hzenv=stage |
| **After**   | https://MWPW-194451-open-in-express--express-color--adobecom.aem.page/create/color-wheel?hzenv=stage&martech=off |

---

## Verification Steps
- Click "Create with my color palette" while signed out → complete sign-in → Express opens automatically in a new tab
- Verify `openInExpress` param is not visible in the URL bar after the redirect
- Click CTA while already signed in → Express opens immediately (no regression)

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
