### PR TITLE
added tag attribute to lana logs

### DIFF
--- a/express/code/blocks/blog-columns/blog-columns.js
+++ b/express/code/blocks/blog-columns/blog-columns.js
@@ -70,7 +70,7 @@ function addImagePreconnects(imageUrl) {
       });
     }
   } catch (e) {
-    window?.lana?.log('Error adding image preconnect:', e);
+    window?.lana?.log(`Error adding image preconnect: ${e?.message || e}`, { tags: 'blog-columns', severity: 'error' });
   }
 }
 
@@ -89,7 +89,7 @@ function buildOptimizedImageUrl(src, width) {
     const roundedWidth = Math.max(1, Math.round(width));
     return `${url.pathname}?width=${roundedWidth}&format=webp&optimize=medium`;
   } catch (e) {
-    window?.lana?.log('Error building optimized image URL:', e);
+    window?.lana?.log(`Error building optimized image URL: ${e?.message || e}`, { tags: 'blog-columns', severity: 'error' });
     return null;
   }
 }

--- a/express/code/blocks/blog-feature-marquee/blog-feature-marquee.js
+++ b/express/code/blocks/blog-feature-marquee/blog-feature-marquee.js
@@ -55,6 +55,7 @@ async function fetchBlogIndex(locale) {
     return { data, byPath };
   } catch (error) {
     window.lana?.log('blog-feature-marquee: failed to fetch blog index', {
+      tags: 'blog-feature-marquee',
       error,
       severity: 'error',
     });
@@ -76,6 +77,7 @@ function filterFeaturedPosts(index, config, max) {
         if (post) results.push(post);
       } catch (error) {
         window.lana?.log('blog-feature-marquee: invalid featured article URL', {
+          tags: 'blog-feature-marquee',
           url,
           error,
           severity: 'warning',

--- a/express/code/blocks/frictionless-quick-action/easy-upload-files/easy-upload.js
+++ b/express/code/blocks/frictionless-quick-action/easy-upload-files/easy-upload.js
@@ -483,7 +483,7 @@ function attachSecondaryCtaHandler(block, createTag, showErrorToast) {
           easyUploadPaneContent.secondary.qrErrorText,
         );
       } catch (error) {
-        window.lana?.log(`[EasyUpload-UI] Deferred initialization failed: ${error?.message || error}`, { severity: 'error' });
+        window.lana?.log(`[EasyUpload-UI] Deferred initialization failed: ${error?.message || error}`, { tags: 'easy-upload', severity: 'error' });
         showErrorToast?.(block, 'Failed to initialize QR code upload.');
         return;
       }
@@ -524,10 +524,10 @@ function attachSecondaryCtaHandler(block, createTag, showErrorToast) {
 
           easyUploadInstance.startUploadDetectionPolling();
         } else {
-          window.lana?.log('[EasyUpload-UI] Could not find confirm button or EasyUpload instance', { severity: 'warning' });
+          window.lana?.log('[EasyUpload-UI] Could not find confirm button or EasyUpload instance', { tags: 'easy-upload', severity: 'warning' });
         }
       } catch (error) {
-        window.lana?.log(`[EasyUpload-UI] initializeQRCode failed: ${error?.name} ${error?.message} code=${error?.code} status=${error?.statusCode}`, { severity: 'error' });
+        window.lana?.log(`[EasyUpload-UI] initializeQRCode failed: ${error?.name} ${error?.message} code=${error?.code} status=${error?.statusCode}`, { tags: 'easy-upload', severity: 'error' });
         showErrorToast?.(block, 'Failed to load QR code.');
       }
     }
@@ -586,7 +586,7 @@ export async function setupEasyUploadUI({
 
         await easyUploadInstance.setupQRCodeInterface();
       } catch (error) {
-        window.lana?.log(`[EasyUpload-UI] Autoload initialization failed: ${error?.message || error}`, { severity: 'error' });
+        window.lana?.log(`[EasyUpload-UI] Autoload initialization failed: ${error?.message || error}`, { tags: 'easy-upload', severity: 'error' });
         easyUploadInstance?.showFailedQR();
       }
     }, 100);

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -188,7 +188,7 @@ async function maybeHandleEasyUploadQuickAction(
       return true;
     }
   } catch (error) {
-    window.lana?.log(`[FrictionlessQA] Failed to route Easy Upload quick action: ${error?.message || error}`, { severity: 'error' });
+    window.lana?.log(`[FrictionlessQA] Failed to route Easy Upload quick action: ${error?.message || error}`, { tags: 'frictionless-quick-action', severity: 'error' });
     const fallbackHandled = runLegacyEasyUploadFallback(
       quickActionId,
       docConfig,
@@ -964,7 +964,7 @@ export default async function decorate(block) {
       document.body.dataset.suppressfloatingcta = 'false';
       if (easyUploadModulePromise) {
         easyUploadModulePromise.then(({ cleanupEasyUpload }) => cleanupEasyUpload?.())
-          .catch((err) => window.lana?.log(`[FrictionlessQA] Failed to cleanup Easy Upload: ${err?.message || err}`, { severity: 'warning' }));
+          .catch((err) => window.lana?.log(`[FrictionlessQA] Failed to cleanup Easy Upload: ${err?.message || err}`, { tags: 'frictionless-quick-action', severity: 'warning' }));
       }
     }
   }, { passive: true });
@@ -992,7 +992,7 @@ export default async function decorate(block) {
       });
     }
   } catch (e) {
-    window.lana?.log(`Easy upload module failed to load in frictionless-quick-action: ${e?.message}`);
+    window.lana?.log(`Easy upload module failed to load in frictionless-quick-action: ${e?.message}`, { tags: 'frictionless-quick-action', severity: 'error' });
   }
 
   if (

--- a/express/code/scripts/utils/easy-upload-utils.js
+++ b/express/code/scripts/utils/easy-upload-utils.js
@@ -459,7 +459,7 @@ export class EasyUpload {
 
       return extractLinkHref(this.uploadAsset._links, LINK_REL.BLOCK_TRANSFER);
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to generate upload URL: ${error?.name} ${error?.message} code=${error?.code} status=${error?.statusCode}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to generate upload URL: ${error?.name} ${error?.message} code=${error?.code} status=${error?.statusCode}`, { tags: 'easy-upload-utils', severity: 'error' });
       throw error;
     }
   }
@@ -503,7 +503,7 @@ export class EasyUpload {
         } catch (error) {
           clearInterval(this.pollingInterval);
           clearTimeout(timeoutId);
-          window.lana?.log(`[EasyUpload] Error during version polling: ${error?.message || error}`, { severity: 'warning' });
+          window.lana?.log(`[EasyUpload] Error during version polling: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'warning' });
           reject(error);
         }
       }, ACP_STORAGE_CONFIG.SECOND_IN_MS);
@@ -567,7 +567,7 @@ export class EasyUpload {
 
       return file;
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to retrieve uploaded file: ${error?.message || error}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to retrieve uploaded file: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'error' });
       throw error;
     }
   }
@@ -588,7 +588,7 @@ export class EasyUpload {
       this.asset = null;
       this.uploadAsset = null;
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Error during ACP Storage cleanup: ${error?.message || error}`, { severity: 'warning' });
+      window.lana?.log(`[EasyUpload] Error during ACP Storage cleanup: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'warning' });
     }
   }
 
@@ -604,7 +604,7 @@ export class EasyUpload {
       let timeoutId;
       const timeoutPromise = new Promise((_, reject) => {
         timeoutId = setTimeout(() => {
-          window.lana?.log('[EasyUpload] URL generation timed out', { severity: 'error' });
+          window.lana?.log('[EasyUpload] URL generation timed out', { tags: 'easy-upload-utils', severity: 'error' });
           reject(new Error(`QR code generation timed out after ${QR_CODE_CONFIG.GENERATION_TIMEOUT / 1000} seconds`));
         }, QR_CODE_CONFIG.GENERATION_TIMEOUT);
       });
@@ -622,6 +622,7 @@ export class EasyUpload {
         }),
       ]).catch((error) => {
         window.lana?.log(`[EasyUpload] Failed in URL generation promise: ${error?.message || error}`, {
+          tags: 'easy-upload-utils',
           severity: 'error',
           error,
         });
@@ -695,7 +696,7 @@ export class EasyUpload {
       });
 
       if (!response.ok) {
-        window.lana?.log(`[EasyUpload] Failed to shorten URL (HTTP error), using original: ${response.status} ${response.statusText}`, { severity: 'warning' });
+        window.lana?.log(`[EasyUpload] Failed to shorten URL (HTTP error), using original: ${response.status} ${response.statusText}`, { tags: 'easy-upload-utils', severity: 'warning' });
         return longUrl;
       }
 
@@ -704,10 +705,10 @@ export class EasyUpload {
         return data.data;
       }
 
-      window.lana?.log(`[EasyUpload] Failed to shorten URL (unexpected response), using original: ${JSON.stringify(data)}`, { severity: 'warning' });
+      window.lana?.log(`[EasyUpload] Failed to shorten URL (unexpected response), using original: ${JSON.stringify(data)}`, { tags: 'easy-upload-utils', severity: 'warning' });
       return longUrl;
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Error shortening URL, using original: ${error instanceof Error ? error.message : String(error)}`, { severity: 'warning' });
+      window.lana?.log(`[EasyUpload] Error shortening URL, using original: ${error instanceof Error ? error.message : String(error)}`, { tags: 'easy-upload-utils', severity: 'warning' });
       return longUrl;
     }
   }
@@ -882,7 +883,7 @@ export class EasyUpload {
 
       this.scheduleQRRefresh();
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to initialize QR code: ${error?.name} ${error?.message} code=${error?.code} status=${error?.statusCode}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to initialize QR code: ${error?.name} ${error?.message} code=${error?.code} status=${error?.statusCode}`, { tags: 'easy-upload-utils', severity: 'error' });
       this.showFailedQR();
       this.showErrorToast(this.block, 'Failed to generate QR code.');
     }
@@ -910,7 +911,7 @@ export class EasyUpload {
       await this.cleanup();
       await this.initializeQRCode();
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to refresh QR code: ${error?.message || error}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to refresh QR code: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'error' });
     }
   }
 
@@ -932,7 +933,7 @@ export class EasyUpload {
         await this.finalizeUpload();
       }
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to finalize upload: ${error?.message || error}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to finalize upload: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'error' });
       this.showConfirmTooltip('pending');
       this.updateConfirmButtonState(false);
       return;
@@ -946,7 +947,7 @@ export class EasyUpload {
         throw new Error('No file was uploaded');
       }
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to confirm import: ${error?.message || error}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to confirm import: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'error' });
       this.showConfirmTooltip('failed');
       this.refreshQRCode();
     }
@@ -985,7 +986,7 @@ export class EasyUpload {
       e.preventDefault();
       e.stopPropagation();
       this.handleConfirmImport().catch((error) => {
-        window.lana?.log(`[EasyUpload] Unhandled error in handleConfirmImport: ${error?.message || error}`, { severity: 'error' });
+        window.lana?.log(`[EasyUpload] Unhandled error in handleConfirmImport: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'error' });
       });
     };
     confirmButton.addEventListener('click', this.handleConfirmClick);
@@ -1010,7 +1011,7 @@ export class EasyUpload {
         buttonContainer.appendChild(confirmButton);
       }
     } catch (error) {
-      window.lana?.log(`[EasyUpload] Failed to setup QR code interface: ${error?.message || error}`, { severity: 'error' });
+      window.lana?.log(`[EasyUpload] Failed to setup QR code interface: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'error' });
       throw error;
     }
   }
@@ -1064,7 +1065,7 @@ export class EasyUpload {
           this.uploadDetectionInterval = null;
         }
       } catch (error) {
-        window.lana?.log(`[EasyUpload] Polling error: ${error?.message || error}`, { severity: 'warning' });
+        window.lana?.log(`[EasyUpload] Polling error: ${error?.message || error}`, { tags: 'easy-upload-utils', severity: 'warning' });
       }
     }, POLL_INTERVAL_MS);
   }


### PR DESCRIPTION
## Summary

Added missing `tags` attribute to all LANA log calls across the Express codebase. Every `window.lana?.log()` call now includes at least one tag for Splunk filtering and alerting. Also added `severity` to two calls in `blog-columns.js` that had no options object at all, and folded the bare error argument into the message string to match the established pattern.

**Files updated:** `blog-columns.js`, `blog-feature-marquee.js`, `easy-upload-files/easy-upload.js`, `frictionless-quick-action.js`, `easy-upload-utils.js` (25 call sites total)

---

## Jira Ticket

Resolves: [mwpw-138030](https://jira.corp.adobe.com/browse/MWPW-138030)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-138030--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- These changes are isolated to `lana.log()` call options — no logic, rendering, or behavior is affected.
- To verify: open the After URL and trigger any of the updated code paths (e.g. a failed upload, blog columns page, frictionless quick action). Check Splunk with the query `index=lana_nonprod log_message="client=express*"` and confirm logs now appear with a `tags` field populated.
- **Before:** Several log calls had no `tags` field, making them unfilterable in Splunk.
- **After:** All log calls include at least one tag (e.g. `easy-upload-utils`, `frictionless-quick-action`, `blog-columns`, `blog-feature-marquee`, `easy-upload`).

---

## Potential Regressions

Since all changes are confined to `lana.log()` option objects, there is no functional regression risk. The following pages cover all updated blocks:

- https://mwpw-138030--da-express-milo--adobecom.aem.live/express/?martech=off
- https://mwpw-138030--da-express-milo--adobecom.aem.live/express/feature/video/convert/mp4
- https://mwpw-138030--da-express-milo--adobecom.aem.live/express/create/poster
- https://mwpw-138030--da-express-milo--adobecom.aem.live/fr/express/discover/ideas/halloween/craft

---

## Additional Notes

This completes the work originally audited as part of MWPW-186049 (severity levels). A follow-up Splunk query `index=lana_nonprod log_message="client=express*" | where isnull(lana_tags) OR lana_tags=""` should now return zero results for Express logs.
