### PR TITLE
Mwpwp 194022

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -571,16 +571,3 @@ color-wheel-express {
 }
 
 
-.color-wheel sp-tab-panel[selected] {
-  display: block;
-  min-width: 0;
-}
-.color-wheel sp-tab-panel[selected] .color-wheel-content {
-  width: 100%;
-  max-width: 370px;
-  min-width: 0;
-}
-.color-wheel-harmony-carousel-host {
-  width: 100%;
-  min-width: 0;
-}

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -499,6 +499,7 @@ color-wheel-express {
 
   .color-wheel-content {
     gap: var(--spacing-100);
+    max-width: 370px;
   }
 
   .color-wheel .action-menu-controls-only {
@@ -568,3 +569,5 @@ color-wheel-express {
     display: flex;
   }
 }
+
+

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -493,6 +493,8 @@ color-wheel-express {
     flex: 1 1 0;
     min-height: 0;
     width: 100%;
+    display: block;
+
   }
 
   .color-wheel-content {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -571,3 +571,16 @@ color-wheel-express {
 }
 
 
+.color-wheel sp-tab-panel[selected] {
+  display: block;
+  min-width: 0;
+}
+.color-wheel sp-tab-panel[selected] .color-wheel-content {
+  width: 100%;
+  max-width: 370px;
+  min-width: 0;
+}
+.color-wheel-harmony-carousel-host {
+  width: 100%;
+  min-width: 0;
+}

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -252,7 +252,7 @@ color-wheel-express {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 2px;
+  gap: var(--spacing-50);
   margin-bottom: 0.75rem;
 }
 
@@ -297,27 +297,27 @@ color-wheel-express {
 .color-wheel-harmony-carousel-host .simple-carousel-fader-right {
   display: flex;
   width: 88px;
-  height: 48px;
+  height: var(--spacing-700);
   align-items: center;
   gap: 10px;
 }
 
 .color-wheel-harmony-carousel-host .simple-carousel-fader-left {
-  background: linear-gradient(90deg, #FFFFFF 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
+  background: linear-gradient(90deg, var(--color-white) 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
   padding-inline-start: var(--spacing-100);
   justify-content: flex-start;
 }
 
 .color-wheel-harmony-carousel-host .simple-carousel-fader-right {
-  background: linear-gradient(270deg, #FFFFFF 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
+  background: linear-gradient(270deg, var(--color-white) 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
   padding-inline-end: var(--spacing-100);
   justify-content: flex-end;
 }
 
 .color-wheel-harmony-option {
   box-sizing: border-box;
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-700);
+  height: var(--spacing-700);
   padding: 0;
   margin: 0;
   border-radius: var(--Radius-corner-radius-75);
@@ -345,8 +345,8 @@ color-wheel-express {
 }
 
 .color-wheel .icon.simple-carousel-arrow-icon {
-  height: 18px;
-  width: 18px;
+  height: var(--spacing-325);
+  width: var(--spacing-325);
 }
 
 .mobile-container {
@@ -570,3 +570,22 @@ color-wheel-express {
 }
 
 
+@media (min-width: 1200px) {
+  .color-wheel .ax-color-tool-layout {
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    align-items: stretch;
+  }
+  .color-wheel .ax-shell-slot--sidebar {
+    grid-row: 1 / span 3;
+  }
+  .color-wheel .ax-shell-slot--topbar {
+    grid-row: 1;
+  }
+  .color-wheel .ax-shell-slot--canvas {
+    grid-row: 2;
+    min-height: 0;
+  }
+  .color-wheel .ax-shell-slot--footer {
+    grid-row: 3;
+  }
+}

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -483,10 +483,9 @@ color-wheel-express {
   }
 
   .color-wheel .ax-shell-slot--sidebar > sp-theme {
-    flex: 1 1 0;
+  
     min-height: 0;
-    display: flex;
-    flex-direction: column;
+    display: block;
   }
 
   .color-wheel sp-tabs {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -455,8 +455,9 @@ color-wheel-express {
 @media (min-width: 1200px) {
   .color-wheel .ax-color-tool-layout {
     padding: var(--spacing-600);
-    grid-template-rows: auto;
+    grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-columns: minmax(0, var(--cw-sidebar-fr, 4fr)) minmax(0, 8fr);
+    align-items: stretch;
     transition: grid-template-columns 0.35s ease, column-gap 0.35s ease;
   }
 
@@ -469,6 +470,7 @@ color-wheel-express {
     align-self: stretch;
     min-height: 0;
     grid-column: 1;
+    grid-row: 1 / span 3;
   }
 
   .color-wheel .ax-shell-slot--topbar,
@@ -477,13 +479,25 @@ color-wheel-express {
     grid-column: 2;
   }
 
+  .color-wheel .ax-shell-slot--topbar {
+    grid-row: 1;
+  }
+
+  .color-wheel .ax-shell-slot--canvas {
+    grid-row: 2;
+    min-height: 0;
+  }
+
+  .color-wheel .ax-shell-slot--footer {
+    grid-row: 3;
+  }
+
   .color-wheel .ax-shell-slot--topbar,
   .color-wheel .ax-shell-slot--canvas {
     padding-block-end: var(--spacing-300);
   }
 
   .color-wheel .ax-shell-slot--sidebar > sp-theme {
-  
     min-height: 0;
     display: block;
   }
@@ -493,7 +507,6 @@ color-wheel-express {
     min-height: 0;
     width: 100%;
     display: block;
-
   }
 
   .color-wheel-content {
@@ -566,26 +579,5 @@ color-wheel-express {
 
   .color-wheel .color-floating-toolbar-container .ax-swatch-strip {
     display: flex;
-  }
-}
-
-
-@media (min-width: 1200px) {
-  .color-wheel .ax-color-tool-layout {
-    grid-template-rows: auto minmax(0, 1fr) auto;
-    align-items: stretch;
-  }
-  .color-wheel .ax-shell-slot--sidebar {
-    grid-row: 1 / span 3;
-  }
-  .color-wheel .ax-shell-slot--topbar {
-    grid-row: 1;
-  }
-  .color-wheel .ax-shell-slot--canvas {
-    grid-row: 2;
-    min-height: 0;
-  }
-  .color-wheel .ax-shell-slot--footer {
-    grid-row: 3;
   }
 }

--- a/express/code/scripts/widgets/simple-carousel.js
+++ b/express/code/scripts/widgets/simple-carousel.js
@@ -67,26 +67,36 @@ function initializeSimpleCarousel(selector, parent, options = {}) {
     faderRight.classList.toggle('arrow-hidden', isAtEnd);
   };
 
-  let scrollTimeout;
-  const throttledUpdate = () => {
-    if (scrollTimeout) return;
-    scrollTimeout = setTimeout(() => {
+  let arrowUpdateFrame = null;
+  const scheduleArrowVisibilityUpdate = () => {
+    if (arrowUpdateFrame !== null) return;
+    arrowUpdateFrame = requestAnimationFrame(() => {
+      arrowUpdateFrame = null;
       updateArrowVisibility();
-      scrollTimeout = null;
-    }, 50);
+    });
   };
   faderLeft.append(arrowLeft);
   faderRight.append(arrowRight);
   parent.append(platform, faderLeft, faderRight);
 
-  platform.addEventListener('scroll', throttledUpdate, { passive: true });
-  window.addEventListener('resize', throttledUpdate, { passive: true });
+  platform.addEventListener('scroll', scheduleArrowVisibilityUpdate, { passive: true });
+  window.addEventListener('resize', scheduleArrowVisibilityUpdate, { passive: true });
 
-  requestAnimationFrame(() => {
-    setTimeout(() => {
-      updateArrowVisibility();
-    }, 150);
+  const resizeObserver = 'ResizeObserver' in window
+    ? new ResizeObserver(scheduleArrowVisibilityUpdate)
+    : null;
+  resizeObserver?.observe(parent);
+  resizeObserver?.observe(platform);
+  carouselContent.forEach((el) => resizeObserver?.observe(el));
+
+  const contentObserver = new MutationObserver(scheduleArrowVisibilityUpdate);
+  contentObserver.observe(platform, {
+    attributes: true,
+    childList: true,
+    subtree: true,
   });
+
+  scheduleArrowVisibilityUpdate();
 
   let isManualScroll = false;
 
@@ -205,8 +215,14 @@ function initializeSimpleCarousel(selector, parent, options = {}) {
   });
 
   const cleanup = () => {
-    platform.removeEventListener('scroll', throttledUpdate);
-    window.removeEventListener('resize', throttledUpdate);
+    platform.removeEventListener('scroll', scheduleArrowVisibilityUpdate);
+    window.removeEventListener('resize', scheduleArrowVisibilityUpdate);
+    resizeObserver?.disconnect();
+    contentObserver.disconnect();
+    if (arrowUpdateFrame !== null) {
+      cancelAnimationFrame(arrowUpdateFrame);
+      arrowUpdateFrame = null;
+    }
     if (centerActive && activeObserver) {
       activeObserver.disconnect();
     }
@@ -216,6 +232,7 @@ function initializeSimpleCarousel(selector, parent, options = {}) {
     platform,
     items: carouselContent,
     cleanup,
+    updateArrowVisibility: scheduleArrowVisibilityUpdate,
     scrollTo: (index) => {
       if (index >= 0 && index < carouselContent.length) {
         carouselContent[index].scrollIntoView({


### PR DESCRIPTION
## Summary

This PR fixes a **large-desktop (≥1200px) layout bug** on the Color Wheel where the **harmony selector** row was **visually clipped** (~bottom fourth of the controls). The main fix is in **`color-wheel.css`**: the tool shell grid now uses **three explicit rows** (topbar → canvas → footer) with **`minmax(0, 1fr)`** on the middle row, **`align-items: stretch`**, and the **sidebar spanning all three rows** so the left column (tabs + content, including the harmony carousel) can lay out with **correct height and overflow** instead of being squeezed by the grid.

Supporting updates:

- **Harmony carousel** faders and option buttons use **spacing tokens** (`--spacing-700`, etc.) and tokenized gaps/gradients so dimensions match intent and stay consistent.
- **`simple-carousel.js`** replaces a **timeout-based** scroll/resize throttle with **`requestAnimationFrame`**, adds **`ResizeObserver`** (parent, scroller, items) and a **`MutationObserver`** on the scroller so **arrow visibility** stays accurate when the carousel **resizes or its content changes**, with **cleanup** on disconnect.

---

## Jira Ticket

Resolves: [MWPW-194022](https://jira.corp.adobe.com/browse/MWPW-194022)

---

## Test URLs

| Env | URL |
|-----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/create/color-wheel |
| **After** | https://mwpwp-194022--da-express-milo--adobecom.aem.page/jp/express/create/color-wheel?martech=off |

*(Use your team’s real “before” baseline if `main` preview differs from production/stage; default remote branch here is `stage`.)*

---

## Verification Steps

1. Use a **viewport width &gt; 1200px** (desktop).
2. Open the **After** URL above (optional: add locale path/query if your preview mirrors `…/fr/create/color-wheel`).
3. In the sidebar, under the harmony section (e.g. “Harmonies de couleurs” in FR), confirm **all harmony selector buttons are fully visible** — **no clipping** at the bottom.
4. **Before:** reproduce the original issue — buttons **cut off** ~25% from the bottom on large desktop.
5. **After:** same viewport — buttons **fully visible**; **scroll/resize** the window and confirm **carousel fade arrows** still show/hide appropriately when content overflows.

---

## Potential Regressions

- **Color Wheel** sidebar + canvas **desktop grid** (≥1200px): spacing, scroll behavior, or **harmony carousel** alignment.
- **Any block using `simple-carousel`**: arrow visibility when **container size** or **list content** changes without a scroll/resize event.

Spot-check:  
https://mwpwp-194022--da-express-milo--adobecom.aem.live/express/create/color-wheel?martech=off  

---

## Additional Notes

- **Files touched:** `express/code/blocks/color-wheel/color-wheel.css`, `express/code/scripts/widgets/simple-carousel.js`.
- Attach the **required screenshot or recording** showing before/after on **&gt;1200px** for QA sign-off.

---