### PR TITLE
MWPW-194374 Color - Fix Safari input zoom

### DIFF
--- a/express/code/scripts/color-shared/components/color-edit/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-edit/styles.css.js
@@ -233,6 +233,7 @@ export const style = css`
         --mod-textfield-border-color: var(--color-gray-300-variant);
         --mod-textfield-background-color: var(--color-white);
         --mod-textfield-border-color-hover: var(--color-gray-400-variant);
+        --mod-textfield-placeholder-font-size: var(--body-font-size-m);
     }
 
     .ce-sr-only {


### PR DESCRIPTION
## Summary

Fix iOS bug where clicking into the hex code input field in the Edit color tray causes the page to zoom in and cut off content

---

## Jira Ticket

Resolves: [MWPW-194374](https://jira.corp.adobe.com/browse/MWPW-194374)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-wheel |
| **After**   | https://methomas-zoom--express-color--adobecom.aem.live/create/color-wheel |

---

## Verification Steps

- On an iPhone or simulated iPhone, click on the hex code button of a palette color
- When the Edit color tray pops up, click on the hex code field
- Before: The page zooms in and cuts off content
- After: Page does not zoom

---

## Potential Regressions

- https://methomas-zoom--express-color--adobecom.aem.page/create/color-accessibility

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
