### PR TITLE
MWPW-193949 | New Mobile Fork Button capability for iOS/Android split

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # Run CSS variable linting
-# npm run lint:css-vars 
+npm run lint:css-vars 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # Run CSS variable linting
-npm run lint:css-vars 
+# npm run lint:css-vars 

--- a/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.css
+++ b/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.css
@@ -72,7 +72,7 @@ main .mobile-fork-button-os-split .floating-button a.button:any-link {
 }
 
 main .mobile-fork-button-os-split .floating-button a.button:any-link.accent {
-  color: var(--color-var(--color-white));
+  color: var(--color-white);
   background-color: var(--color-info-accent);
   border-color: var(--color-info-accent);
 }

--- a/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.css
+++ b/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.css
@@ -1,0 +1,88 @@
+main  .floating-button-wrapper.mobile-fork-button-os-split, main .mobile-fork-button-os-split {
+  z-index: 10;
+  --mfb-font-size: var(--body-font-size-m);
+}
+
+.feds-localnav--active ~ main .floating-button-wrapper.mobile-fork-button-os-split {
+  z-index: 8;
+}
+
+main .mobile-fork-button-os-split.long-text {
+  --mfb-font-size: var(--body-font-size-m);
+}
+
+main .mobile-gating-text {
+  height: fit-content;
+  margin: auto;
+  text-align: left;
+  flex-grow: 1;
+  font-weight: 400;
+  font-size: var(--mfb-font-size);
+}
+main .mobile-fork-button-os-split .floating-button .mobile-gating-row .mobile-gating-icon-empty,
+main .mobile-gating-text, main .mobile-fork-button-os-split .floating-button .mobile-gating-row .icon{
+  width: 22px;
+  height: 22px;
+  margin: auto;
+}
+
+main .mobile-fork-button-os-split  .mobile-gating-header-row .mobile-gating-exit {
+  border-radius: 24px;
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  font-size: var(--body-font-size-xs);
+  background: var(--Palette-sx-gray-100, var(--color-gray-200));
+}
+
+main  .mobile-fork-button-os-split .floating-button.block {
+  background-color: var(--color-white);
+  border-radius: 28px;
+  box-shadow: 0px 0px 12px 0px #00000029;
+  padding: var(--spacing-300);
+  width: calc(100% - 16px);
+  margin: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-100);
+}
+
+main .mobile-gating-row {
+  display: flex;
+  gap: 10px;
+  min-height: 40px;
+}
+
+main .mobile-gating-header {
+  font-size: var(--type-heading-xxs-lh);
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: var(--spacing-100);
+}
+
+main .mobile-fork-button-os-split .floating-button a.button:any-link {
+  border-radius: 20px;
+  font-size: var(--mfb-font-size);
+  min-width: 150px;
+  margin: auto;
+  width: 50%;
+  color: var(--color-white);
+  background-color: var(--color-info-accent);
+  border-color: var(--color-info-accent);
+}
+
+main .mobile-fork-button-os-split .floating-button a.button:any-link.accent {
+  color: var(--color-var(--color-white));
+  background-color: var(--color-info-accent);
+  border-color: var(--color-info-accent);
+}
+
+main .mobile-fork-button-os-split .floating-button a.button:any-link.outline {
+  background-color: var(--color-white);
+  border: 2px solid var(--Border-Extra-subdued-default, var(--color-gray-200));
+  color: var(--color-black);
+}
+
+main .mobile-fork-button-os-split.floating-button--hidden .floating-button.block {
+  margin-bottom: -10px
+}

--- a/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.js
+++ b/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.js
@@ -1,0 +1,53 @@
+import {
+  createTag,
+  getMobileOperatingSystem,
+  getIconElementDeprecated,
+  addTempWrapperDeprecated,
+} from '../../scripts/utils.js';
+import { createFloatingButton } from '../../scripts/widgets/floating-cta.js';
+import {
+  createMultiFunctionButton,
+  collectOsSplitFloatingButtonData,
+} from '../../scripts/utils/mobile-fork-button-utils.js';
+
+const OS_METADATA_PREFIXES = {
+  Android: 'android',
+  iOS: 'ios',
+};
+
+export default async function decorate(block) {
+  const metadataPrefix = OS_METADATA_PREFIXES[getMobileOperatingSystem()];
+  if (!metadataPrefix) {
+    const { default: decorateNormal } = await import('../floating-button/floating-button.js');
+    await decorateNormal(block);
+    return;
+  }
+
+  addTempWrapperDeprecated(block, 'multifunction-button');
+  if (!block.classList.contains('meta-powered')) return;
+
+  const audience = block.querySelector(':scope > div').textContent.trim();
+  if (audience === 'mobile') {
+    block.closest('.section')?.remove();
+  }
+
+  const data = collectOsSplitFloatingButtonData(
+    createTag,
+    getIconElementDeprecated,
+    metadataPrefix,
+  );
+  const blockWrapper = await createMultiFunctionButton(
+    createTag,
+    createFloatingButton,
+    block,
+    data,
+    audience,
+    'mobile-fork-button-os-split',
+  );
+  const blockLinks = blockWrapper.querySelectorAll('a');
+  if (blockLinks && blockLinks.length > 0) {
+    const linksPopulated = new CustomEvent('linkspopulated', { detail: blockLinks });
+    document.dispatchEvent(linksPopulated);
+  }
+  if (data.longText) blockWrapper.classList.add('long-text');
+}

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -609,7 +609,7 @@ export function buildAutoBlocks() {
     const lastDiv = document.querySelector('main > div:last-of-type');
     const newDiv = document.createElement('div');
     lastDiv.insertAdjacentElement('afterend', newDiv);
-    const validButtonVersion = ['floating-button', 'multifunction-button', 'mobile-fork-button', 'mobile-fork-button-frictionless', 'mobile-fork-button-dismissable'];
+    const validButtonVersion = ['floating-button', 'multifunction-button', 'mobile-fork-button', 'mobile-fork-button-frictionless', 'mobile-fork-button-dismissable', 'mobile-fork-button-os-split'];
     const device = document.body.dataset?.device;
     const blockName = getMetadata(`${device}-floating-cta`);
 

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -69,6 +69,7 @@ export function androidCheck(getMetadata, getMobileOperatingSystem) {
  * @param {number} index - CTA index (1 or 2)
  * @param {boolean} useFrictionless - Whether to use frictionless metadata with fallback
  * @param {string} metadataPrefix - Optional metadata prefix for platform-specific fields
+ * @param {boolean} enableMobileFqaUpload - Whether the upload hash should click the upload button
  * @returns {Object} Tool data with icon, iconText, and anchor
  */
 export function createToolData(
@@ -78,6 +79,7 @@ export function createToolData(
   index,
   useFrictionless = false,
   metadataPrefix = '',
+  enableMobileFqaUpload = useFrictionless,
 ) {
   const prefix = `${metadataPrefix}fork-cta-${index}`;
 
@@ -98,7 +100,7 @@ export function createToolData(
   const aTag = createTag('a', { title: textMetadata, href: hrefMetadata });
 
   // Special handler for frictionless upload
-  if (useFrictionless && hrefMetadata.toLowerCase().trim() === '#mobile-fqa-upload') {
+  if (enableMobileFqaUpload && hrefMetadata.toLowerCase().trim() === '#mobile-fqa-upload') {
     aTag.addEventListener('click', (e) => {
       e.preventDefault();
       document.getElementById('mobile-fqa-upload').click();
@@ -216,6 +218,7 @@ export function collectOsSplitFloatingButtonData(
       i,
       false,
       metadataPrefix,
+      true,
     );
     if (toolData) {
       data.tools.push(toolData);

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -189,6 +189,9 @@ export function collectOsSplitFloatingButtonData(
   const metadataMap = createMetadataMap();
   const getMetadataLocal = (key) => metadataMap[key];
   const metadataPrefix = `${platform}-`;
+  const getOsOrDefaultForkMetadata = (osKey, defaultKey) => (
+    getMetadataLocal(osKey) ?? getMetadataLocal(defaultKey)
+  );
 
   const data = {
     scrollState: 'withLottie',
@@ -207,14 +210,25 @@ export function collectOsSplitFloatingButtonData(
     },
     bubbleSheet: getMetadataLocal('floating-cta-bubble-sheet'),
     live: getMetadataLocal('floating-cta-live'),
-    forkButtonHeader: getMetadataLocal(`${metadataPrefix}fork-button-header`),
+    forkButtonHeader: getOsOrDefaultForkMetadata(
+      `${metadataPrefix}fork-button-header`,
+      'fork-button-header',
+    ),
   };
 
   for (let i = 1; i < 3; i += 1) {
+    const metadataWithForkFallback = { ...metadataMap };
+    ['icon', 'icon-text', 'link', 'text'].forEach((field) => {
+      const osKey = `${metadataPrefix}fork-cta-${i}-${field}`;
+      const defaultKey = `fork-cta-${i}-${field}`;
+      if (metadataWithForkFallback[osKey] === undefined && metadataWithForkFallback[defaultKey] !== undefined) {
+        metadataWithForkFallback[osKey] = metadataWithForkFallback[defaultKey];
+      }
+    });
     const toolData = createToolData(
       createTag,
       getIconElementDeprecated,
-      metadataMap,
+      metadataWithForkFallback,
       i,
       false,
       metadataPrefix,

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -82,7 +82,6 @@ export function createToolData(
   enableMobileFqaUpload = useFrictionless,
 ) {
   const prefix = `${metadataPrefix}fork-cta-${index}`;
-
   // Metadata lookup with optional frictionless fallback
   const iconMetadata = (useFrictionless && metadataMap[`${prefix}-icon-frictionless`])
     || metadataMap[`${prefix}-icon`];
@@ -221,7 +220,8 @@ export function collectOsSplitFloatingButtonData(
     ['icon', 'icon-text', 'link', 'text'].forEach((field) => {
       const osKey = `${metadataPrefix}fork-cta-${i}-${field}`;
       const defaultKey = `fork-cta-${i}-${field}`;
-      if (metadataWithForkFallback[osKey] === undefined && metadataWithForkFallback[defaultKey] !== undefined) {
+      if (metadataWithForkFallback[osKey] === undefined
+        && metadataWithForkFallback[defaultKey] !== undefined) {
         metadataWithForkFallback[osKey] = metadataWithForkFallback[defaultKey];
       }
     });

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -68,6 +68,7 @@ export function androidCheck(getMetadata, getMobileOperatingSystem) {
  * @param {Object} metadataMap - Map of metadata
  * @param {number} index - CTA index (1 or 2)
  * @param {boolean} useFrictionless - Whether to use frictionless metadata with fallback
+ * @param {string} metadataPrefix - Optional metadata prefix for platform-specific fields
  * @returns {Object} Tool data with icon, iconText, and anchor
  */
 export function createToolData(
@@ -76,8 +77,9 @@ export function createToolData(
   metadataMap,
   index,
   useFrictionless = false,
+  metadataPrefix = '',
 ) {
-  const prefix = `fork-cta-${index}`;
+  const prefix = `${metadataPrefix}fork-cta-${index}`;
 
   // Metadata lookup with optional frictionless fallback
   const iconMetadata = (useFrictionless && metadataMap[`${prefix}-icon-frictionless`])
@@ -156,6 +158,64 @@ export function collectFloatingButtonData(
       metadataMap,
       i,
       useFrictionless,
+    );
+    if (toolData) {
+      data.tools.push(toolData);
+      if (getTextWidth(toolData.anchor.textContent, 16) > LONG_TEXT_CUTOFF) {
+        data.longText = true;
+      }
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Collects floating button data from platform-prefixed fork metadata.
+ * @param {Function} createTag - Function to create DOM elements
+ * @param {Function} getIconElementDeprecated - Function to get icon elements
+ * @param {string} platform - Platform metadata prefix ('android' or 'ios')
+ * @param {Object} extraMainCtaProps - Extra properties to add to mainCta (optional)
+ * @returns {Object} Floating button data
+ */
+export function collectOsSplitFloatingButtonData(
+  createTag,
+  getIconElementDeprecated,
+  platform,
+  extraMainCtaProps = {},
+) {
+  const metadataMap = createMetadataMap();
+  const getMetadataLocal = (key) => metadataMap[key];
+  const metadataPrefix = `${platform}-`;
+
+  const data = {
+    scrollState: 'withLottie',
+    showAppStoreBadge: ['on'].includes(getMetadataLocal('show-floating-cta-app-store-badge')?.toLowerCase()),
+    toolsToStash: getMetadataLocal('ctas-above-divider'),
+    delay: getMetadataLocal('floating-cta-drawer-delay') || 0,
+    tools: [],
+    mainCta: {
+      desktopHref: getMetadataLocal('desktop-floating-cta-link'),
+      desktopText: getMetadataLocal('desktop-floating-cta-text'),
+      mobileHref: getMetadataLocal('mobile-floating-cta-link'),
+      mobileText: getMetadataLocal('mobile-floating-cta-text'),
+      href: getMetadataLocal('main-cta-link'),
+      text: getMetadataLocal('main-cta-text'),
+      ...extraMainCtaProps,
+    },
+    bubbleSheet: getMetadataLocal('floating-cta-bubble-sheet'),
+    live: getMetadataLocal('floating-cta-live'),
+    forkButtonHeader: getMetadataLocal(`${metadataPrefix}fork-button-header`),
+  };
+
+  for (let i = 1; i < 3; i += 1) {
+    const toolData = createToolData(
+      createTag,
+      getIconElementDeprecated,
+      metadataMap,
+      i,
+      false,
+      metadataPrefix,
     );
     if (toolData) {
       data.tools.push(toolData);

--- a/test/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.test.js
+++ b/test/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.test.js
@@ -1,0 +1,146 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { buildAutoBlocks, setLibs } from '../../../express/code/scripts/utils.js';
+
+setLibs('/test/mocks/libs', { hostname: 'example.com', search: '' });
+
+const { default: decorate } = await import('../../../express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.js');
+
+const ANDROID_USER_AGENT = 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36';
+const IOS_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+function setDocumentMetadata() {
+  const metadata = {
+    'floating-cta-live': 'Y',
+    'show-floating-cta': 'yes',
+    'mobile-floating-cta': 'mobile-fork-button-os-split',
+    'desktop-floating-cta': 'floating-button',
+    'main-cta-link': 'https://www.adobe.com/express/create',
+    'main-cta-text': 'Get the full experience in the app.',
+    'floating-cta-device-and-ram-check': 'no',
+    'fallback-text': '((mobile-gating-fallback-text))',
+    'android-fork-button-header': 'Android header',
+    'android-fork-cta-1-icon': 'cc-express',
+    'android-fork-cta-1-link': 'https://www.google.com?os=android-app',
+    'android-fork-cta-1-text': 'Get Android App',
+    'android-fork-cta-1-icon-text': 'Android Express',
+    'android-fork-cta-2-icon': 'cc-express',
+    'android-fork-cta-2-link': 'https://www.google.com?os=android-web',
+    'android-fork-cta-2-text': 'Android Web',
+    'android-fork-cta-2-icon-text': 'Android Browser',
+    'ios-fork-button-header': 'iOS header',
+    'ios-fork-cta-1-icon': 'cc-express',
+    'ios-fork-cta-1-link': 'https://www.google.com?os=ios-app',
+    'ios-fork-cta-1-text': 'Get iOS App',
+    'ios-fork-cta-1-icon-text': 'iOS Express',
+    'ios-fork-cta-2-icon': 'cc-express',
+    'ios-fork-cta-2-link': 'https://www.google.com?os=ios-web',
+    'ios-fork-cta-2-text': 'iOS Web',
+    'ios-fork-cta-2-icon-text': 'iOS Browser',
+  };
+
+  Object.entries(metadata).forEach(([name, content]) => {
+    const meta = document.createElement('meta');
+    meta.name = name;
+    meta.content = content;
+    document.head.appendChild(meta);
+  });
+}
+
+async function render(userAgent) {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: userAgent,
+    configurable: true,
+  });
+  setDocumentMetadata();
+  const block = document.createElement('div');
+  block.className = 'floating-button meta-powered';
+  block.innerHTML = '<div>mobile</div>';
+  document.querySelector('main .section').append(block);
+  await decorate(block);
+}
+
+describe('Mobile Fork Button OS Split', () => {
+  beforeEach(async () => {
+    window.isTestEnv = true;
+    window.hlx = {};
+    window.floatingCta = [
+      {
+        path: 'default',
+        live: 'Y',
+      },
+    ];
+    window.placeholders = { 'see-more': 'See More' };
+    document.head.innerHTML = '';
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+    document.body.dataset.device = 'mobile';
+  });
+
+  afterEach(() => {
+    window.placeholders = undefined;
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('creates the auto block from mobile-floating-cta metadata', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: ANDROID_USER_AGENT,
+      configurable: true,
+    });
+    setDocumentMetadata();
+
+    await buildAutoBlocks();
+
+    const block = document.querySelector('.mobile-fork-button-os-split');
+    expect(block).to.exist;
+    expect(block.classList.contains('meta-powered')).to.be.true;
+  });
+
+  it('renders Android-prefixed fork metadata for Android', async () => {
+    await render(ANDROID_USER_AGENT);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(blockWrapper.querySelector('.mobile-gating-header').textContent).to.equal('Android header');
+    expect(rows.length).to.equal(2);
+    expect(rows[0].querySelector('a').textContent).to.equal('Get Android App');
+    expect(rows[0].querySelector('a').href).to.equal('https://www.google.com/?os=android-app');
+    expect(rows[0].querySelector('.mobile-gating-text').textContent).to.equal('Android Express');
+    expect(rows[1].querySelector('a').textContent).to.equal('Android Web');
+    expect(rows[1].querySelector('a').href).to.equal('https://www.google.com/?os=android-web');
+    expect(rows[1].querySelector('.mobile-gating-text').textContent).to.equal('Android Browser');
+  });
+
+  it('renders iOS-prefixed fork metadata for iOS', async () => {
+    await render(IOS_USER_AGENT);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(blockWrapper.querySelector('.mobile-gating-header').textContent).to.equal('iOS header');
+    expect(rows.length).to.equal(2);
+    expect(rows[0].querySelector('a').textContent).to.equal('Get iOS App');
+    expect(rows[0].querySelector('a').href).to.equal('https://www.google.com/?os=ios-app');
+    expect(rows[0].querySelector('.mobile-gating-text').textContent).to.equal('iOS Express');
+    expect(rows[1].querySelector('a').textContent).to.equal('iOS Web');
+    expect(rows[1].querySelector('a').href).to.equal('https://www.google.com/?os=ios-web');
+    expect(rows[1].querySelector('.mobile-gating-text').textContent).to.equal('iOS Browser');
+  });
+
+  it('dispatches linkspopulated after rendering links', async () => {
+    const linksPopulated = new Promise((resolve) => {
+      document.addEventListener('linkspopulated', (event) => {
+        if (event.detail.length === 2) resolve(event.detail);
+      });
+    });
+
+    await render(ANDROID_USER_AGENT);
+
+    const links = await linksPopulated;
+    expect(links.length).to.equal(2);
+    expect(links[0].textContent).to.equal('Get Android App');
+    expect(links[1].textContent).to.equal('Android Web');
+  });
+});

--- a/test/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.test.js
+++ b/test/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.test.js
@@ -12,7 +12,7 @@ const { default: decorate } = await import('../../../express/code/blocks/mobile-
 const ANDROID_USER_AGENT = 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36';
 const IOS_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
 
-function setDocumentMetadata() {
+function setDocumentMetadata(overrides = {}) {
   const metadata = {
     'floating-cta-live': 'Y',
     'show-floating-cta': 'yes',
@@ -40,6 +40,7 @@ function setDocumentMetadata() {
     'ios-fork-cta-2-link': 'https://www.google.com?os=ios-web',
     'ios-fork-cta-2-text': 'iOS Web',
     'ios-fork-cta-2-icon-text': 'iOS Browser',
+    ...overrides,
   };
 
   Object.entries(metadata).forEach(([name, content]) => {
@@ -50,12 +51,12 @@ function setDocumentMetadata() {
   });
 }
 
-async function render(userAgent) {
+async function render(userAgent, metadataOverrides = {}) {
   Object.defineProperty(navigator, 'userAgent', {
     value: userAgent,
     configurable: true,
   });
-  setDocumentMetadata();
+  setDocumentMetadata(metadataOverrides);
   const block = document.createElement('div');
   block.className = 'floating-button meta-powered';
   block.innerHTML = '<div>mobile</div>';
@@ -142,5 +143,33 @@ describe('Mobile Fork Button OS Split', () => {
     expect(links.length).to.equal(2);
     expect(links[0].textContent).to.equal('Get Android App');
     expect(links[1].textContent).to.equal('Android Web');
+  });
+
+  it('opens the mobile FQA upload target from Android CTA 2 metadata', async () => {
+    let uploadClicks = 0;
+    const uploadButton = document.createElement('button');
+    uploadButton.id = 'mobile-fqa-upload';
+    uploadButton.addEventListener('click', () => { uploadClicks += 1; });
+    document.body.append(uploadButton);
+
+    await render(ANDROID_USER_AGENT, { 'android-fork-cta-2-link': '#mobile-fqa-upload' });
+
+    document.querySelectorAll('.mobile-gating-row')[1].querySelector('a').click();
+
+    expect(uploadClicks).to.equal(1);
+  });
+
+  it('opens the mobile FQA upload target from iOS CTA 2 metadata', async () => {
+    let uploadClicks = 0;
+    const uploadButton = document.createElement('button');
+    uploadButton.id = 'mobile-fqa-upload';
+    uploadButton.addEventListener('click', () => { uploadClicks += 1; });
+    document.body.append(uploadButton);
+
+    await render(IOS_USER_AGENT, { 'ios-fork-cta-2-link': '#mobile-fqa-upload' });
+
+    document.querySelectorAll('.mobile-gating-row')[1].querySelector('a').click();
+
+    expect(uploadClicks).to.equal(1);
   });
 });

--- a/test/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.test.js
+++ b/test/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.test.js
@@ -172,4 +172,43 @@ describe('Mobile Fork Button OS Split', () => {
 
     expect(uploadClicks).to.equal(1);
   });
+
+  it('falls back to default fork metadata when Android metadata is missing', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: ANDROID_USER_AGENT,
+      configurable: true,
+    });
+    setDocumentMetadata({
+      'fork-button-header': 'Default header',
+      'fork-cta-1-text': 'Default CTA 1 Text',
+      'fork-cta-1-link': 'https://www.google.com?os=default-app',
+      'fork-cta-1-icon-text': 'Default CTA 1 Label',
+      'fork-cta-2-text': 'Default CTA 2 Text',
+      'fork-cta-2-link': 'https://www.google.com?os=default-web',
+      'fork-cta-2-icon-text': 'Default CTA 2 Label',
+    });
+    document.head.querySelector('meta[name="android-fork-button-header"]')?.remove();
+    document.head.querySelector('meta[name="android-fork-cta-1-text"]')?.remove();
+    document.head.querySelector('meta[name="android-fork-cta-1-link"]')?.remove();
+    document.head.querySelector('meta[name="android-fork-cta-1-icon-text"]')?.remove();
+    document.head.querySelector('meta[name="android-fork-cta-2-text"]')?.remove();
+    document.head.querySelector('meta[name="android-fork-cta-2-link"]')?.remove();
+    document.head.querySelector('meta[name="android-fork-cta-2-icon-text"]')?.remove();
+    const block = document.createElement('div');
+    block.className = 'floating-button meta-powered';
+    block.innerHTML = '<div>mobile</div>';
+    document.querySelector('main .section').append(block);
+
+    await decorate(block);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(blockWrapper.querySelector('.mobile-gating-header').textContent).to.equal('Default header');
+    expect(rows[0].querySelector('a').textContent).to.equal('Default CTA 1 Text');
+    expect(rows[0].querySelector('a').href).to.equal('https://www.google.com/?os=default-app');
+    expect(rows[0].querySelector('.mobile-gating-text').textContent).to.equal('Default CTA 1 Label');
+    expect(rows[1].querySelector('a').textContent).to.equal('Default CTA 2 Text');
+    expect(rows[1].querySelector('a').href).to.equal('https://www.google.com/?os=default-web');
+    expect(rows[1].querySelector('.mobile-gating-text').textContent).to.equal('Default CTA 2 Label');
+  });
 });

--- a/test/blocks/mobile-fork-button-os-split/mocks/body.html
+++ b/test/blocks/mobile-fork-button-os-split/mocks/body.html
@@ -1,0 +1,3 @@
+<main>
+  <div class="section"></div>
+</main>

--- a/test/mocks/libs/utils/utils.js
+++ b/test/mocks/libs/utils/utils.js
@@ -46,3 +46,7 @@ export function createTag(tag, attributes = {}, html = '') {
   }
   return el;
 }
+
+export function decorateLinks() {
+  // no-op in tests
+}


### PR DESCRIPTION
## Summary

Adds a new `mobile-fork-button-os-split` block that supports different routing logic for iOS and Android. Currently the mobile fork button only supports Android-only gating or a shared CTA across both devices. This enhancement introduces a new variant where `fork-cta-2` can be overridden with an os link and copy (eg `ios-fork-cta-2-link` / `ios-fork-cta-2-text`)

---

## Jira Ticket

Resolves: [MWPW-193949](https://jira.corp.adobe.com/browse/MWPW-193949)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/feature/video/editor |
| **After**   | https://mobile-fork-button-ios--da-express-milo--adobecom.aem.page/drafts/echen/mobile-fork-button-os-split |

https://mobile-fork-button-ios--da-express-milo--adobecom.aem.page/drafts/echen/mobile-fork-os-split-fb

---


## Verification Steps

1. Open the **After** URL on an **iOS** device or use Chrome DevTools to emulate an iOS device.
   - Verify the iOS-specific CTA (`fork-cta-2`) appears with the correct link and copy.
2. Open the **After** URL on an **Android** device or emulate Android in DevTools.
   - Verify Android retains its existing CTA behavior, including frictionless `#mobile-fqa-upload` support.
3. Test with no iOS override values authored — verify fallback logic shows the default CTA correctly.

---

## Potential Regressions

- https://mobile-fork-button-ios--da-express-milo--adobecom.aem.live/express/feature/video/editor
- https://mobile-fork-button-ios--da-express-milo--adobecom.aem.live/express/create/video
