### PR TITLE
MWPW-194131: Disable redundant copy hex on strips

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -654,6 +654,7 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   min-height: 240px;
   --figma-strip-radius: 16px;
   --swatch-rail-gap: 2px;
+  --hex-code-static-padding-left: 16px;
 }
 
 .color-extract .color-extract-swatch-rail color-swatch-rail {

--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -911,7 +911,12 @@ function renderColorVariant(block, rows, config, strings = {}) {
       const railAdapter = createSwatchRailAdapter(controller, {
         orientation: 'stacked',
         swatchFeatures: {
-          copy: true, hexCode: true, trash: true, minSwatches: 2, editColorDisabled: true,
+          copy: true,
+          hexCode: true,
+          trash: true,
+          minSwatches: 2,
+          editColorDisabled: true,
+          copyFromHex: false,
         },
         strings: colorSwatchRailStrings,
       });
@@ -1373,7 +1378,12 @@ async function renderGradientVariant(block, rows, config, strings = {}) {
       const railAdapter = createSwatchRailAdapter(swatchController, {
         orientation: 'stacked',
         swatchFeatures: {
-          copy: true, hexCode: true, trash: true, minSwatches: 2, editColorDisabled: true,
+          copy: true,
+          hexCode: true,
+          trash: true,
+          minSwatches: 2,
+          editColorDisabled: true,
+          copyFromHex: false,
         },
         strings: colorSwatchRailStrings,
       });

--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -1047,10 +1047,8 @@ export const style = css`
   }
   .hex-code--static {
     cursor: default;
-    padding-left: 6px;
+    padding-left: var(--hex-code-static-padding-left);
   }
-
-  
   .icon-button {
     background: none;
     border: none;


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: [MWPW-194131](https://jira.corp.adobe.com/browse/MWPW-194131)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/image |
| **After**   | https://MWPW-194131--express-color--adobecom.aem.page/create/image/?martech=off |

---

## Verification Steps
- Visit URL above and run extract
- Hover over hex code after extraction, should not see a copy hex message

---
