### PR TITLE
MWPW-192104: Aria label addition

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -457,6 +457,12 @@ export default async function decorate(block) {
         } else if (aTag.classList.contains('light')) {
           aTag.classList.replace('accent', 'primary');
         }
+        if (!aTag.getAttribute('aria-label')) {
+          const header = cell.querySelector('h1, h2, h3, h4, h5, h6');
+          if (header) {
+            aTag.setAttribute('aria-label', `${aTag.textContent.trim()} ${header.textContent.trim()}`);
+          }
+        }
       }
 
       // handle history events


### PR DESCRIPTION
## Summary

Adds aria label to cta 

---

## Jira Ticket

Resolves: [MWPW-192104:](https://jira.corp.adobe.com/browse/MWPW-192104:)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://MWPW-192104:--express-color--adobecom.aem.page/ |
| **After**   | https://main--express-color--adobecom.aem.page/?martech=off |

---

## Verification Steps

- Open After URL
- Inspect black CTA under carousel (See ticket) "Create a color palette now"
- Observe aria-label

---
