### PR TITLE
MWPW-193629: Filter out unicode vals from theme names

### DIFF
--- a/express/code/libs/services/providers/transforms.js
+++ b/express/code/libs/services/providers/transforms.js
@@ -99,7 +99,7 @@ export function themeToGradient(theme) {
 
   return {
     id: theme.id,
-    name: theme.name || 'Unnamed Theme',
+    name: (theme.name || 'Unnamed Theme').replace(/\\u([0-9A-Fa-f]{4})/gi, (_, hex) => String.fromCharCode(parseInt(hex, 16))),
     type: 'linear',
     angle: 90,
     colorStops,


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: [MWPW-193629](https://jira.corp.adobe.com/browse/MWPW-193629)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://MWPW-193629--express-color--adobecom.aem.page/explore/|
| **After**   | https://MWPW-193629--express-color--adobecom.aem.page/explore/?martech=off |

---

## Verification Steps

- Visit URL 
- Should see no theme names with unicode values like `\\u00`
