### PR TITLE
Color Wheel Misalignment Fix

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -571,16 +571,3 @@ color-wheel-express {
 }
 
 
-.color-wheel sp-tab-panel[selected] {
-  display: block;
-  min-width: 0;
-}
-.color-wheel sp-tab-panel[selected] .color-wheel-content {
-  width: 100%;
-  max-width: 370px;
-  min-width: 0;
-}
-.color-wheel-harmony-carousel-host {
-  width: 100%;
-  min-width: 0;
-}

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -40,7 +40,19 @@
 }
 
 .color-wheel sp-tabs {
+  display: flex;
+  flex-direction: column;
   gap: var(--spacing-300);
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.color-wheel sp-tab-panel {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .color-wheel-content {
@@ -237,6 +249,8 @@
 /* Color wheel panel */
 
 color-wheel-express {
+  box-sizing: border-box;
+  width: 100%;
   max-width: 400px;
   padding: var(--spacing-300);
 }
@@ -505,8 +519,6 @@ color-wheel-express {
   .color-wheel sp-tabs {
     flex: 1 1 0;
     min-height: 0;
-    width: 100%;
-    display: block;
   }
 
   .color-wheel-content {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -266,7 +266,7 @@ color-wheel-express {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: var(--spacing-50);
+  gap: 2px;
   margin-bottom: 0.75rem;
 }
 
@@ -311,7 +311,7 @@ color-wheel-express {
 .color-wheel-harmony-carousel-host .simple-carousel-fader-right {
   display: flex;
   width: 88px;
-  height: var(--spacing-700);
+  height: 48px;
   align-items: center;
   gap: 10px;
 }
@@ -330,8 +330,8 @@ color-wheel-express {
 
 .color-wheel-harmony-option {
   box-sizing: border-box;
-  width: var(--spacing-700);
-  height: var(--spacing-700);
+  width: 48px;
+  height: 48px;
   padding: 0;
   margin: 0;
   border-radius: var(--Radius-corner-radius-75);
@@ -359,8 +359,8 @@ color-wheel-express {
 }
 
 .color-wheel .icon.simple-carousel-arrow-icon {
-  height: var(--spacing-325);
-  width: var(--spacing-325);
+  height: 18px;
+  width: 18px;
 }
 
 .mobile-container {
@@ -523,7 +523,6 @@ color-wheel-express {
 
   .color-wheel-content {
     gap: var(--spacing-100);
-    max-width: 370px;
   }
 
   .color-wheel .action-menu-controls-only {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -499,6 +499,7 @@ color-wheel-express {
 
   .color-wheel-content {
     gap: var(--spacing-100);
+    max-width: 370px;
   }
 
   .color-wheel .action-menu-controls-only {
@@ -568,3 +569,5 @@ color-wheel-express {
     display: flex;
   }
 }
+
+

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -493,6 +493,8 @@ color-wheel-express {
     flex: 1 1 0;
     min-height: 0;
     width: 100%;
+    display: block;
+
   }
 
   .color-wheel-content {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -571,3 +571,16 @@ color-wheel-express {
 }
 
 
+.color-wheel sp-tab-panel[selected] {
+  display: block;
+  min-width: 0;
+}
+.color-wheel sp-tab-panel[selected] .color-wheel-content {
+  width: 100%;
+  max-width: 370px;
+  min-width: 0;
+}
+.color-wheel-harmony-carousel-host {
+  width: 100%;
+  min-width: 0;
+}

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -252,7 +252,7 @@ color-wheel-express {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 2px;
+  gap: var(--spacing-50);
   margin-bottom: 0.75rem;
 }
 
@@ -297,27 +297,27 @@ color-wheel-express {
 .color-wheel-harmony-carousel-host .simple-carousel-fader-right {
   display: flex;
   width: 88px;
-  height: 48px;
+  height: var(--spacing-700);
   align-items: center;
   gap: 10px;
 }
 
 .color-wheel-harmony-carousel-host .simple-carousel-fader-left {
-  background: linear-gradient(90deg, #FFFFFF 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
+  background: linear-gradient(90deg, var(--color-white) 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
   padding-inline-start: var(--spacing-100);
   justify-content: flex-start;
 }
 
 .color-wheel-harmony-carousel-host .simple-carousel-fader-right {
-  background: linear-gradient(270deg, #FFFFFF 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
+  background: linear-gradient(270deg, var(--color-white) 14.5%, rgba(255, 255, 255, 0.38) 84%, rgba(255, 255, 255, 0.00) 100%);
   padding-inline-end: var(--spacing-100);
   justify-content: flex-end;
 }
 
 .color-wheel-harmony-option {
   box-sizing: border-box;
-  width: 48px;
-  height: 48px;
+  width: var(--spacing-700);
+  height: var(--spacing-700);
   padding: 0;
   margin: 0;
   border-radius: var(--Radius-corner-radius-75);
@@ -345,8 +345,8 @@ color-wheel-express {
 }
 
 .color-wheel .icon.simple-carousel-arrow-icon {
-  height: 18px;
-  width: 18px;
+  height: var(--spacing-325);
+  width: var(--spacing-325);
 }
 
 .mobile-container {
@@ -570,3 +570,22 @@ color-wheel-express {
 }
 
 
+@media (min-width: 1200px) {
+  .color-wheel .ax-color-tool-layout {
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    align-items: stretch;
+  }
+  .color-wheel .ax-shell-slot--sidebar {
+    grid-row: 1 / span 3;
+  }
+  .color-wheel .ax-shell-slot--topbar {
+    grid-row: 1;
+  }
+  .color-wheel .ax-shell-slot--canvas {
+    grid-row: 2;
+    min-height: 0;
+  }
+  .color-wheel .ax-shell-slot--footer {
+    grid-row: 3;
+  }
+}

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -483,10 +483,9 @@ color-wheel-express {
   }
 
   .color-wheel .ax-shell-slot--sidebar > sp-theme {
-    flex: 1 1 0;
+  
     min-height: 0;
-    display: flex;
-    flex-direction: column;
+    display: block;
   }
 
   .color-wheel sp-tabs {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -455,8 +455,9 @@ color-wheel-express {
 @media (min-width: 1200px) {
   .color-wheel .ax-color-tool-layout {
     padding: var(--spacing-600);
-    grid-template-rows: auto;
+    grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-columns: minmax(0, var(--cw-sidebar-fr, 4fr)) minmax(0, 8fr);
+    align-items: stretch;
     transition: grid-template-columns 0.35s ease, column-gap 0.35s ease;
   }
 
@@ -469,6 +470,7 @@ color-wheel-express {
     align-self: stretch;
     min-height: 0;
     grid-column: 1;
+    grid-row: 1 / span 3;
   }
 
   .color-wheel .ax-shell-slot--topbar,
@@ -477,13 +479,25 @@ color-wheel-express {
     grid-column: 2;
   }
 
+  .color-wheel .ax-shell-slot--topbar {
+    grid-row: 1;
+  }
+
+  .color-wheel .ax-shell-slot--canvas {
+    grid-row: 2;
+    min-height: 0;
+  }
+
+  .color-wheel .ax-shell-slot--footer {
+    grid-row: 3;
+  }
+
   .color-wheel .ax-shell-slot--topbar,
   .color-wheel .ax-shell-slot--canvas {
     padding-block-end: var(--spacing-300);
   }
 
   .color-wheel .ax-shell-slot--sidebar > sp-theme {
-  
     min-height: 0;
     display: block;
   }
@@ -493,7 +507,6 @@ color-wheel-express {
     min-height: 0;
     width: 100%;
     display: block;
-
   }
 
   .color-wheel-content {
@@ -566,26 +579,5 @@ color-wheel-express {
 
   .color-wheel .color-floating-toolbar-container .ax-swatch-strip {
     display: flex;
-  }
-}
-
-
-@media (min-width: 1200px) {
-  .color-wheel .ax-color-tool-layout {
-    grid-template-rows: auto minmax(0, 1fr) auto;
-    align-items: stretch;
-  }
-  .color-wheel .ax-shell-slot--sidebar {
-    grid-row: 1 / span 3;
-  }
-  .color-wheel .ax-shell-slot--topbar {
-    grid-row: 1;
-  }
-  .color-wheel .ax-shell-slot--canvas {
-    grid-row: 2;
-    min-height: 0;
-  }
-  .color-wheel .ax-shell-slot--footer {
-    grid-row: 3;
   }
 }

--- a/express/code/scripts/widgets/simple-carousel.js
+++ b/express/code/scripts/widgets/simple-carousel.js
@@ -67,26 +67,36 @@ function initializeSimpleCarousel(selector, parent, options = {}) {
     faderRight.classList.toggle('arrow-hidden', isAtEnd);
   };
 
-  let scrollTimeout;
-  const throttledUpdate = () => {
-    if (scrollTimeout) return;
-    scrollTimeout = setTimeout(() => {
+  let arrowUpdateFrame = null;
+  const scheduleArrowVisibilityUpdate = () => {
+    if (arrowUpdateFrame !== null) return;
+    arrowUpdateFrame = requestAnimationFrame(() => {
+      arrowUpdateFrame = null;
       updateArrowVisibility();
-      scrollTimeout = null;
-    }, 50);
+    });
   };
   faderLeft.append(arrowLeft);
   faderRight.append(arrowRight);
   parent.append(platform, faderLeft, faderRight);
 
-  platform.addEventListener('scroll', throttledUpdate, { passive: true });
-  window.addEventListener('resize', throttledUpdate, { passive: true });
+  platform.addEventListener('scroll', scheduleArrowVisibilityUpdate, { passive: true });
+  window.addEventListener('resize', scheduleArrowVisibilityUpdate, { passive: true });
 
-  requestAnimationFrame(() => {
-    setTimeout(() => {
-      updateArrowVisibility();
-    }, 150);
+  const resizeObserver = 'ResizeObserver' in window
+    ? new ResizeObserver(scheduleArrowVisibilityUpdate)
+    : null;
+  resizeObserver?.observe(parent);
+  resizeObserver?.observe(platform);
+  carouselContent.forEach((el) => resizeObserver?.observe(el));
+
+  const contentObserver = new MutationObserver(scheduleArrowVisibilityUpdate);
+  contentObserver.observe(platform, {
+    attributes: true,
+    childList: true,
+    subtree: true,
   });
+
+  scheduleArrowVisibilityUpdate();
 
   let isManualScroll = false;
 
@@ -205,8 +215,14 @@ function initializeSimpleCarousel(selector, parent, options = {}) {
   });
 
   const cleanup = () => {
-    platform.removeEventListener('scroll', throttledUpdate);
-    window.removeEventListener('resize', throttledUpdate);
+    platform.removeEventListener('scroll', scheduleArrowVisibilityUpdate);
+    window.removeEventListener('resize', scheduleArrowVisibilityUpdate);
+    resizeObserver?.disconnect();
+    contentObserver.disconnect();
+    if (arrowUpdateFrame !== null) {
+      cancelAnimationFrame(arrowUpdateFrame);
+      arrowUpdateFrame = null;
+    }
     if (centerActive && activeObserver) {
       activeObserver.disconnect();
     }
@@ -216,6 +232,7 @@ function initializeSimpleCarousel(selector, parent, options = {}) {
     platform,
     items: carouselContent,
     cleanup,
+    updateArrowVisibility: scheduleArrowVisibilityUpdate,
     scrollTo: (index) => {
       if (index >= 0 && index < carouselContent.length) {
         carouselContent[index].scrollIntoView({


### PR DESCRIPTION
## Summary

Fixes the Color Wheel **color harmony** controls being visually clipped on **localized** pages (e.g. FR, JP) where section copy is longer and the layout was not constraining Spectrum tabs/panels correctly. Updates `color-wheel.css` so `sp-tabs` and `sp-tab-panel` use a column flex layout with full width, `min-width: 0`, and consistent box sizing so the harmony selector buttons stay fully visible on large desktop viewports.

---

## Jira Ticket

Resolves: [MWPW-194022](https://jira.corp.adobe.com/browse/MWPW-194022)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After** | https://mwpwp-194022--express-color--adobecom.aem.page/drafts/echen/color-wheel-alignment |
| **After** |  https://mwpwp-194022--express-color--adobecom.aem.page/fr/create/color-wheel |

---

## Verification Steps

1. On a **large desktop** window (**&gt; 1200px** width), open a Color Wheel page that includes this block (mirror Jira: localized surface with long harmony section labels, e.g. FR — `https://color.stage.adobe.com/fr/create/color-wheel` or JP as in live reports).
2. Scroll to the **color harmonies** area (e.g. “Harmonies de couleurs” on FR).
3. **Before:** The bottom of the harmony selector controls is **cut off** (~bottom quarter clipped).
4. **After:** Harmony selector buttons/cards are **fully visible**; tabs/panels no longer clip due to overflow from the flex layout.

---

## Potential Regressions

- https://mwpwp-194022--express-color--adobecom.aem.page/fr/create/color-wheel
- Spot-check: **English** short copy still aligns; **narrow / responsive** breakpoints where `sp-tabs` uses `flex: 1 1 0` and `min-height: 0`; other **Spectrum tabs** on the same block still scroll and resize as expected.
