### PR TITLE
MWPW-192500: aligned placeholder text and adjusted height to match spec

### DIFF
--- a/express/code/scripts/color-shared/toolbar/drawer.css
+++ b/express/code/scripts/color-shared/toolbar/drawer.css
@@ -52,7 +52,7 @@
   --ax-drawer-focus-ring-width: 2px;
   --ax-drawer-focus-ring-offset: 2px;
   --ax-drawer-tag-icon-size-mobile: 14px;
-  --ax-tag-field-min-height: 56px;
+  --ax-tag-field-min-height: 80px;
   --ax-tag-field-gap: 6px;
   --ax-tag-pill-max-width: 224px;
   --ax-tag-pill-min-width: 27px;
@@ -236,7 +236,7 @@
 .ax-tag-field {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--ax-tag-field-gap);
   min-block-size: var(--ax-tag-field-min-height);
   padding: var(--spacing-200);


### PR DESCRIPTION
## Summary

Aligns placeholder text top left instead of center, and modifies height of box to match Figma 

---

## Jira Ticket

Resolves: [MWPW-192500](https://jira.corp.adobe.com/browse/MWPW-192500)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/image/create/?martech=off |
| **After**   | https://MWPW-192500--express-color--adobecom.aem.live/image/create/?martech=off |

---

## Verification Steps

- Open After URL or any page with save to library toolbar 
- Click save to library
- Observe described changes. 

