### PR TITLE
MWPW-192565, MWPW-192554: Enable upload screen for upload component a…

### DIFF
--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -330,6 +330,21 @@ function createColorExtractDropzone(block, config, onImageReady, strings = {}) {
     });
   }
 
+  // The file input's change event calls the internal handleFile directly (bypassing the
+  // wrapped dz.handleFile), so block.is-loading is never set via that path. This covers
+  // both "Upload your image" click and the toolbar's "Replace image" button, both of
+  // which trigger the OS file picker via dz.input.click().
+  // Capture phase on the container fires before the input's own listener, which does
+  // input.value = '' — clearing input.files before any later same-element handlers see it.
+  dz.container.addEventListener('change', (e) => {
+    if (e.target !== dz.input) return;
+    const file = e.target.files?.[0];
+    if (file?.type?.startsWith('image/')) {
+      block.classList.add('is-loading');
+      emitBlockEvent(block, EVENTS.IMAGE_UPLOAD, { file });
+    }
+  }, { capture: true });
+
   return dz;
 }
 
@@ -877,8 +892,7 @@ function renderColorVariant(block, rows, config, strings = {}) {
   }
 
   function handleSuggestionClick(imgEl, src) {
-    block.classList.add('has-image');
-    onImageReady(imgEl, src);
+    dropzone.handleUrl(src);
   }
 
   const suggestions = resolvedConfig.enableUrlInput
@@ -1341,8 +1355,7 @@ async function renderGradientVariant(block, rows, config, strings = {}) {
   }
 
   function handleSuggestionClick(imgEl, src) {
-    block.classList.add('has-image');
-    onImageReady(imgEl, src);
+    dropzone.handleUrl(src);
   }
 
   const suggestions = resolvedConfig.enableUrlInput


### PR DESCRIPTION
## Summary

Enable upload screen for upload component and second upload in results view

---

## Jira Ticket

Resolves: [MWPW-192565](https://jira.corp.adobe.com/browse/MWPW-192565)
Resolves: [MWPW-192554](https://jira.corp.adobe.com/browse/MWPW-192554)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-192565--express-color--adobecom.aem.page/create/image?martech=off |

---

## Verification Steps

- Visit URL and upload image using the upload image component
- Observe full screen loading 
- Visit URL and upload image using the pre-selected image
- Observe full screen loading
- Visit URL, trigger results, and then upload a new image with the "Replace Image" icon
- Observe full screen loading 

---
