### PR TITLE
Force Likes To Appear Positive For Color Palettes 

### DIFF
--- a/express/code/scripts/color-shared/modal/createPaletteModalContent.js
+++ b/express/code/scripts/color-shared/modal/createPaletteModalContent.js
@@ -248,7 +248,6 @@ function createPaletteMetaSection(palette = {}, options = {}) {
       });
     });
   });
-  
   const likesText = createTag('p', { class: 'modal-likes-count' });
   likesText.textContent = String(likesCount);
   likesWrap.appendChild(likeBtn);

--- a/express/code/scripts/color-shared/modal/createPaletteModalContent.js
+++ b/express/code/scripts/color-shared/modal/createPaletteModalContent.js
@@ -39,7 +39,7 @@ function getPaletteColors(palette = {}) {
 
 function normalizeLikesCount(rawValue) {
   if (rawValue == null) return '0';
-  const value = typeof rawValue === 'string' ? Math.abs(rawValue.trim()) : rawValue;
+  const value = typeof rawValue === 'string' ? rawValue.trim() : rawValue;
   if (value === '') return '0';
   return String(Math.abs(value));
 }

--- a/express/code/scripts/color-shared/modal/createPaletteModalContent.js
+++ b/express/code/scripts/color-shared/modal/createPaletteModalContent.js
@@ -39,9 +39,9 @@ function getPaletteColors(palette = {}) {
 
 function normalizeLikesCount(rawValue) {
   if (rawValue == null) return '0';
-  const value = typeof rawValue === 'string' ? rawValue.trim() : rawValue;
+  const value = typeof rawValue === 'string' ? Math.abs(rawValue.trim()) : rawValue;
   if (value === '') return '0';
-  return String(value);
+  return String(Math.abs(value));
 }
 
 function normalizeCreatorName(rawValue) {
@@ -248,6 +248,7 @@ function createPaletteMetaSection(palette = {}, options = {}) {
       });
     });
   });
+  
   const likesText = createTag('p', { class: 'modal-likes-count' });
   likesText.textContent = String(likesCount);
   likesWrap.appendChild(likeBtn);


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Patches the like value to always be positive

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-194285

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://like-value-abs--express-color--adobecom.aem.page/explore |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change. 
- Visit the page and check if there are still negative numbers for likes for the palettes
---

## Potential Regressions

- https://like-value-abs--express-color--adobecom.aem.page/explore 

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
