### PR TITLE
Color Wheel Primary Color Slider Performance

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -505,7 +505,6 @@ function buildPrimaryColorContent(controller, strings = {}) {
     pendingBaseColorHex = null;
   };
 
-  // Coalesce drag updates to one per frame to keep Safari responsive.
   const queueBaseColorUpdate = (hex) => {
     if (!hex) return;
     pendingBaseColorHex = hex;

--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -495,6 +495,24 @@ function buildPrimaryColorContent(controller, strings = {}) {
   const state = controller.getState();
   const baseColorIndex = state.baseColorIndex ?? 0;
   const baseColor = state.swatches?.[baseColorIndex]?.hex || '#FF0000';
+  let pendingBaseColorHex = null;
+  let pendingBaseColorRaf = null;
+
+  const flushPendingBaseColor = () => {
+    pendingBaseColorRaf = null;
+    if (!pendingBaseColorHex) return;
+    controller.setBaseColor(pendingBaseColorHex);
+    pendingBaseColorHex = null;
+  };
+
+  // Coalesce drag updates to one per frame to keep Safari responsive.
+  const queueBaseColorUpdate = (hex) => {
+    if (!hex) return;
+    pendingBaseColorHex = hex;
+    if (pendingBaseColorRaf != null) return;
+    pendingBaseColorRaf = requestAnimationFrame(flushPendingBaseColor);
+  };
+
   const adapter = createBaseColorAdapter(
     baseColor,
     'HEX',
@@ -502,9 +520,13 @@ function buildPrimaryColorContent(controller, strings = {}) {
       strings: strings.baseColorStrings,
       onColorChange: (detail) => {
         if (!detail?.hex) return;
-        controller.setBaseColor(detail.hex);
+        queueBaseColorUpdate(detail.hex);
       },
       onColorChangeEnd: () => {
+        if (pendingBaseColorRaf != null) {
+          cancelAnimationFrame(pendingBaseColorRaf);
+          flushPendingBaseColor();
+        }
         // eslint-disable-next-line no-underscore-dangle
         adapter.element._setLocked?.(true);
       },


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Uses `requestAnimationFrame` to queue changes to the base color to the next browser render frame instead of on every mouse move tick, reducing the number of calls needed and improving performance

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-194370

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://safari-color-wheel-lag--express-color--adobecom.aem.page/create/color |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page, switch to the `Primary Color` tab
- Use the slider at the bottom of the widget to change the shade of the primary color, notice that the performance is better on Safari and Chrome

---

## Potential Regressions

- https://safari-color-wheel-lag--express-color--adobecom.aem.page/create/color

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
