### PR TITLE
[COLOR] CTA Redirect to Product Refactor

### DIFF
--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -432,11 +432,14 @@ async function buildSimplifiedSusi(el, locale, imsClientId, noRedirect) {
   const isColor = el.classList.contains('color');
 
   let redirectUrl;
+  let consumeSusiColorRedirect;
   if (isColor) {
-    const { consumeSusiColorRedirect } = await import(
+    ({ consumeSusiColorRedirect } = await import(
       '../../scripts/color-shared/utils/susiRedirect.js'
-    );
-    redirectUrl = consumeSusiColorRedirect() || window.location.href;
+    ));
+    // Use the current page URL as redirect_uri so IMS always gets a valid whitelisted URI.
+    // The actual Express destination is read lazily at sign-in success time.
+    redirectUrl = window.location.href;
   } else {
     redirectUrl = rows[0]?.textContent?.trim();
   }
@@ -456,7 +459,10 @@ async function buildSimplifiedSusi(el, locale, imsClientId, noRedirect) {
   const titleDiv = createTag('div', { class: 'title' }, title);
   const susiWrapper = createTag('div', { class: 'susi-wrapper' }, createSUSIComponent({
     ...params,
-    onSuccessfulToken: () => window.location.assign(destURL.toString()),
+    onSuccessfulToken: () => {
+      const target = (isColor && consumeSusiColorRedirect?.()) || destURL.toString();
+      window.location.assign(target);
+    },
   }));
   const layout = createTag('div', { class: 'susi-layout' }, [createLogo(), titleDiv, susiWrapper]);
   return layout;

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -3,12 +3,22 @@ import { createColorPaletteParamApi } from './utilities.js';
 const KEY = '__susiColorRedirect';
 
 export function setSusiColorRedirect(url) {
-  window[KEY] = url;
+  try {
+    sessionStorage.setItem(KEY, url);
+  } catch {
+    window[KEY] = url;
+  }
 }
 
 export function consumeSusiColorRedirect() {
-  const url = window[KEY];
-  delete window[KEY];
+  let url;
+  try {
+    url = sessionStorage.getItem(KEY);
+    if (url) sessionStorage.removeItem(KEY);
+  } catch {
+    url = window[KEY];
+    delete window[KEY];
+  }
   return url || null;
 }
 


### PR DESCRIPTION
## Summary

Persist the Express URL in sessionStorage instead of window property so it survives full OAuth page reloads. Read the redirect URL lazily inside onSuccessfulToken rather than at modal decoration time, so a pre-decorated (cached) modal still picks up the correct Express URL when the user signs in.

---

## Jira Ticket

Resolves: [MWPW-194451](https://jira.corp.adobe.com/browse/MWPW-194451)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://redirect-cta--express-color--adobecom.aem.page/create/color-wheel?martech=off|

---

## Verification Steps

- Spoof stage locally 
- Test login flow from CTA
- Should redirect to product

---