### PR TITLE
MWPW-194531 Add HSB and Lab to Color Edit Component

### DIFF
--- a/express/code/scripts/color-shared/components/color-edit/index.js
+++ b/express/code/scripts/color-shared/components/color-edit/index.js
@@ -11,7 +11,7 @@ import { trapFocus, disableBackgroundScroll, restoreBackgroundScroll } from '../
 import { DEFAULT_PLACEHOLDERS as COLOR_EDIT_DEFAULTS } from '../../i18n/loadColorEditPlaceholders.js';
 import '../base-color/index.js';
 
-const COLOR_MODES = ['HEX', 'RGB'];
+const COLOR_MODES = ['HEX', 'RGB', 'HSB', 'Lab'];
 
 class ColorEdit extends LitElement {
   static get styles() {


### PR DESCRIPTION
## Summary

Add HSB and Lab options to the Color Edit component

---

## Jira Ticket

Resolves: [MWPW-194531](https://jira.corp.adobe.com/browse/MWPW-194531)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-wheel |
| **After**   | https://methomas-hsb-lab--express-color--adobecom.aem.live/create/color-wheel |
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-accessibility |
| **After**   | https://methomas-hsb-lab--express-color--adobecom.aem.live/create/color-accessibility |
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-contrast-analyzer |
| **After**   | https://methomas-hsb-lab--express-color--adobecom.aem.live/create/color-contrast-analyzer |

---

## Verification Steps

- For color wheel and color blindness, click on the Edit color button (hex code) in one of the color strips. For color contrast, click on the Foreground or Background hex code input.
- When the Edit color popover opens, click on the dropdown.
- You should see the two new options HSB and Lab. Click on the options to test.
- Before: Only HEX and RGB were available in the Color edit component.
- After HSB and Lab should also be available.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
