### PR TITLE
improved the focus handling of the color wheel overlays

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -567,6 +567,7 @@ async function buildTabs(controller, suggestionsRow, { onSelectionChange, string
       selected: 'color-wheel',
       size: 'm',
       quiet: true,
+      enterPanelOnTab: ['color-wheel'],
       tabs: [
         { label: strings.tabPrimaryColor || 'Primary color', value: 'primary-color', iconSlotHtml: PRIMARY_COLOR_ICON },
         { label: strings.tabImage || 'Image', value: 'image', spIcon: 'sp-icon-image' },

--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -567,7 +567,6 @@ async function buildTabs(controller, suggestionsRow, { onSelectionChange, string
       selected: 'color-wheel',
       size: 'm',
       quiet: true,
-      enterPanelOnTab: ['color-wheel'],
       tabs: [
         { label: strings.tabPrimaryColor || 'Primary color', value: 'primary-color', iconSlotHtml: PRIMARY_COLOR_ICON },
         { label: strings.tabImage || 'Image', value: 'image', spIcon: 'sp-icon-image' },

--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -103,6 +103,15 @@ export class ColorWheelExpress extends ColorWheel {
     this._resizeObserver.observe(this.container);
 
     this.addEventListener('keydown', (e) => {
+      if (e.key === 'Tab' && !e.shiftKey && !this.shadowRoot?.activeElement) {
+        const firstMarker = this.shadowRoot?.querySelector('.wheel-marker-overlay[data-index="0"]');
+        if (firstMarker) {
+          e.preventDefault();
+          this._kbFocusIndex = 0;
+          firstMarker.focus({ preventScroll: true });
+        }
+        return;
+      }
       if (e.key === 'Enter' && this._kbFocusIndex < 0) {
         e.preventDefault();
         const firstMarker = this.shadowRoot?.querySelector('.wheel-marker-overlay[data-index="0"]');
@@ -222,7 +231,7 @@ export class ColorWheelExpress extends ColorWheel {
     marker.style.transform = 'translate(-50%, -50%)';
     marker.dataset.index = index;
     marker.setAttribute('role', 'button');
-    marker.setAttribute('tabindex', '-1');
+    marker.setAttribute('tabindex', '0');
 
     // Visible marker is 33px; below Apple HIG's 44px minimum tap target.
     // Users on iOS overshoot the dot and land on the canvas instead, which
@@ -350,17 +359,6 @@ export class ColorWheelExpress extends ColorWheel {
       case 'ArrowLeft': e.preventDefault(); this._moveMarkerByKey(index, -step, 0); break;
       case 'ArrowUp': e.preventDefault(); this._moveMarkerByKey(index, 0, step); break;
       case 'ArrowDown': e.preventDefault(); this._moveMarkerByKey(index, 0, -step); break;
-      case 'Tab': {
-        e.preventDefault();
-        const count = this.swatches.length;
-        const next = e.shiftKey ? (index - 1 + count) % count : (index + 1) % count;
-        const nextMarker = this.shadowRoot?.querySelector(`.wheel-marker-overlay[data-index="${next}"]`);
-        if (nextMarker) {
-          this._kbFocusIndex = next;
-          nextMarker.focus({ preventScroll: true });
-        }
-        break;
-      }
       case 'Escape':
         e.preventDefault();
         this._kbFocusIndex = -1;
@@ -614,6 +612,7 @@ export class ColorWheelExpress extends ColorWheel {
     event.stopPropagation();
 
     if (isRightMouseButtonClicked(event)) return;
+    event.currentTarget?.focus?.({ preventScroll: true });
 
     // Paint the active ring optimistically — the controller fan-out (deep
     // clone state + Lit re-render across ~6 subscribers) can take many ms

--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -103,15 +103,6 @@ export class ColorWheelExpress extends ColorWheel {
     this._resizeObserver.observe(this.container);
 
     this.addEventListener('keydown', (e) => {
-      if (e.key === 'Tab' && !e.shiftKey && !this.shadowRoot?.activeElement) {
-        const firstMarker = this.shadowRoot?.querySelector('.wheel-marker-overlay[data-index="0"]');
-        if (firstMarker) {
-          e.preventDefault();
-          this._kbFocusIndex = 0;
-          firstMarker.focus({ preventScroll: true });
-        }
-        return;
-      }
       if (e.key === 'Enter' && this._kbFocusIndex < 0) {
         e.preventDefault();
         const firstMarker = this.shadowRoot?.querySelector('.wheel-marker-overlay[data-index="0"]');
@@ -253,7 +244,6 @@ export class ColorWheelExpress extends ColorWheel {
       this._handleMarkerKeydown(e, Number(marker.dataset.index));
     });
     marker.addEventListener('focus', () => {
-      this.classList.add('wheel-marker-focus-entered');
       this._kbFocusIndex = Number(marker.dataset.index);
       marker.classList.add('wheel-marker-overlay--kb-focused');
     });

--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -253,6 +253,7 @@ export class ColorWheelExpress extends ColorWheel {
       this._handleMarkerKeydown(e, Number(marker.dataset.index));
     });
     marker.addEventListener('focus', () => {
+      this.classList.add('wheel-marker-focus-entered');
       this._kbFocusIndex = Number(marker.dataset.index);
       marker.classList.add('wheel-marker-overlay--kb-focused');
     });

--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -222,7 +222,7 @@ export class ColorWheelExpress extends ColorWheel {
     marker.style.transform = 'translate(-50%, -50%)';
     marker.dataset.index = index;
     marker.setAttribute('role', 'button');
-    marker.setAttribute('tabindex', '0');
+    marker.setAttribute('tabindex', '-1');
 
     // Visible marker is 33px; below Apple HIG's 44px minimum tap target.
     // Users on iOS overshoot the dot and land on the canvas instead, which
@@ -355,6 +355,19 @@ export class ColorWheelExpress extends ColorWheel {
         this._kbFocusIndex = -1;
         this.focus({ preventScroll: true });
         break;
+      case 'Tab': {
+        e.preventDefault();
+        const allMarkers = Array.from(
+          this.shadowRoot.querySelectorAll('.wheel-marker-overlay[data-index]'),
+        );
+        if (!allMarkers.length) break;
+        const cur = allMarkers.findIndex((m) => Number(m.dataset.index) === index);
+        const next = e.shiftKey
+          ? (cur - 1 + allMarkers.length) % allMarkers.length
+          : (cur + 1) % allMarkers.length;
+        allMarkers[next].focus({ preventScroll: true });
+        break;
+      }
       default: break;
     }
   }

--- a/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
@@ -120,6 +120,7 @@ export const style = css`
         cursor: not-allowed;
     }
 
+    :host(:not(.wheel-marker-focus-entered)) .wheel-marker-overlay--active,
     .wheel-marker-overlay:focus,
     .wheel-marker-overlay--kb-focused {
         outline: 2px solid var(--Alias-content-semantic-accent-key-focus);

--- a/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
@@ -121,8 +121,7 @@ export const style = css`
     }
 
     .wheel-marker-overlay:focus,
-    .wheel-marker-overlay--kb-focused,
-    .wheel-marker-overlay--active {
+    .wheel-marker-overlay--kb-focused {
         outline: 2px solid var(--Alias-content-semantic-accent-key-focus);
         outline-offset: 2px;
         z-index: 20;

--- a/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
@@ -120,7 +120,6 @@ export const style = css`
         cursor: not-allowed;
     }
 
-    :host(:not(.wheel-marker-focus-entered)) .wheel-marker-overlay--active,
     .wheel-marker-overlay:focus,
     .wheel-marker-overlay--kb-focused {
         outline: 2px solid var(--Alias-content-semantic-accent-key-focus);

--- a/express/code/scripts/color-shared/spectrum/components/express-tabs.js
+++ b/express/code/scripts/color-shared/spectrum/components/express-tabs.js
@@ -63,6 +63,8 @@ function getTabbableAdjacentTo(el, reverse = false) {
  * @param {'auto'|'compact'} [config.direction='auto']
  * @param {Array<{label: string, value: string, disabled?: boolean, spIcon?: string, iconSlotHtml?: string}>} [config.tabs=[]]
  * @param {Function} [config.onSelectionChange] — ({ selected }) when tab changes
+ * @param {boolean|string[]} [config.enterPanelOnTab=false] — move forward Tab from
+ * selected tabs into the panel
  * @returns {Promise<{
  *   element: HTMLElement,
  *   tabsEl: HTMLElement,
@@ -82,6 +84,7 @@ export async function createExpressTabs(config = {}) {
     direction = 'auto',
     tabs: tabConfigs = [],
     onSelectionChange,
+    enterPanelOnTab = false,
   } = config;
 
   await loadTabs();
@@ -117,6 +120,22 @@ export async function createExpressTabs(config = {}) {
 
   const panelEntryFocusMap = new Map();
 
+  function shouldEnterPanelOnTab(selectedValue) {
+    if (enterPanelOnTab === true) return true;
+    return Array.isArray(enterPanelOnTab) && enterPanelOnTab.includes(selectedValue);
+  }
+
+  function focusSelectedPanelEntry() {
+    const { selected: selectedValue } = tabsEl;
+    const customFn = panelEntryFocusMap.get(selectedValue);
+    if (customFn) {
+      customFn();
+      return;
+    }
+    const panel = tabsEl.querySelector(`sp-tab-panel[value="${selectedValue}"]`);
+    getFirstTabbable(panel)?.focus();
+  }
+
   const controller = new AbortController();
   const { signal } = controller;
 
@@ -126,7 +145,7 @@ export async function createExpressTabs(config = {}) {
     }, { signal });
   }
 
-  // Tab skips the panel; Enter enters the panel.
+  // Tab skips the panel by default; selected tabs can opt into panel entry.
   theme.addEventListener('keydown', (e) => {
     const path = e.composedPath();
     const isOnTab = path.some((node) => node.tagName === 'SP-TAB');
@@ -135,18 +154,13 @@ export async function createExpressTabs(config = {}) {
 
     if (e.key === 'Tab') {
       e.preventDefault();
+      if (!e.shiftKey && shouldEnterPanelOnTab(tabsEl.selected)) {
+        requestAnimationFrame(focusSelectedPanelEntry);
+        return;
+      }
       getTabbableAdjacentTo(theme, e.shiftKey)?.focus();
     } else if (e.key === 'Enter') {
-      requestAnimationFrame(() => {
-        const { selected } = tabsEl;
-        const customFn = panelEntryFocusMap.get(selected);
-        if (customFn) {
-          customFn();
-          return;
-        }
-        const panel = tabsEl.querySelector(`sp-tab-panel[value="${selected}"]`);
-        getFirstTabbable(panel)?.focus();
-      });
+      requestAnimationFrame(focusSelectedPanelEntry);
     }
   }, { capture: true, signal });
 


### PR DESCRIPTION
## Summary

Corrects color wheel handle **focus vs selection** so one swatch is not stuck in a permanent “focused” look, **Tab** no longer shows two handles with focus rings, and **clicking empty wheel area** does not retarget keyboard focus the way dragging a handle does. 

Styling now ties the accent ring to real `:focus` / keyboard focus (`.wheel-marker-overlay--kb-focused`) only, not the active swatch. 

Markers are in the tab order (`tabindex="0"`), first forward **Tab** lands on the first handle when focus is on the wheel host, pointer activation focuses the dragged handle, and the Color wheel tab opts into **Tab** entering the panel via the new `enterPanelOnTab` option on Express tabs.

---

## Jira Ticket

Resolves: [MWPW-194721](https://jira.corp.adobe.com/browse/MWPW-194721)

---

## Test URLs

| Env | URL |
|----|-----|
| **Before** | https://main--express-color--adobecom.aem.live/create/color-wheel|
| **After** | https://color-wheel-focus--express-color--adobecom.aem.live/create/color-wheel |

---

## Verification Steps

1. Open the color wheel block (Milo preview **After** URL, or production URL above for parity).
2. **Keyboard:** Use **Tab** to reach the wheel / tabs; confirm only one handle shows the focus ring at a time, and there is no persistent “always focused” handle before you **Tab** into markers.
3. **Click:** Click empty areas of the wheel (not on a handle). **Expected:** active color updates per product rules, but **focus** should not jump so that a second handle looks focused; behavior should match “only handle interaction drives focus confusion,” and should align with dragging handles for color edits.
4. **Tab from tabs:** On the “Color wheel” tab, forward **Tab** from the tab list should move into the panel where configured (`enterPanelOnTab: ['color-wheel']`); **Shift+Tab** still leaves the tab list as before

**Expected (after fix):** No stuck default focus styling; no double focus rings while tabbing; focus and selection stay coherent with pointer and keyboard.

---

## Potential Regressions

- https://color-wheel-focus--express-color--adobecom.aem.live/create/color-wheel 
- **Keyboard:** Marker **Tab** order and **Enter**-to-panel behavior on other tabs (only `color-wheel` opts into **Tab**-into-panel).
- **Visual:** Active swatch no longer uses the key-focus ring from `.wheel-marker-overlay--active` in CSS—confirm selected state is still clear.

---

## Additional Notes

**Files touched**

- `express/code/scripts/color-shared/components/color-wheel-express/index.js` — `tabindex="0"` on overlays; **Tab** handling when shadow root has no active element; focus on pointer down; removed custom **Tab** cycling between markers.
- `express/code/scripts/color-shared/components/color-wheel-express/styles.css.js` — focus ring only for `:focus` and `--kb-focused`, not `--active`.
- `express/code/scripts/color-shared/spectrum/components/express-tabs.js` — `enterPanelOnTab` (boolean or allowlist); forward **Tab** from tab can call `focusSelectedPanelEntry`; **Enter** refactored to shared helper.
- `express/code/blocks/color-wheel/color-wheel.js` — `enterPanelOnTab: ['color-wheel']` on tab config.

---
