### PR TITLE
MWPW-194124 Explore missing modal CTA translation

### DIFF
--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -696,6 +696,8 @@ export default async function decorate(block) {
               {
                 verticalMaxPerRow: config.swatchVerticalMaxPerRow,
                 onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
+                modalStrings: await colorModalStringsPromise,
+                colorSwatchRailStrings: await colorSwatchRailStringsPromise,
               },
             );
           });
@@ -711,6 +713,8 @@ export default async function decorate(block) {
               {
                 verticalMaxPerRow: config.swatchVerticalMaxPerRow,
                 onLikeToggle: async ({ id, liked }) => activeDataService.toggleLike({ id, liked }),
+                modalStrings: await colorModalStringsPromise,
+                colorSwatchRailStrings: await colorSwatchRailStringsPromise,
               },
             );
           });
@@ -778,6 +782,8 @@ export default async function decorate(block) {
                   onLikeToggle: async ({ id, liked }) => (
                     activeDataService.toggleLike({ id, liked })
                   ),
+                  modalStrings: await colorModalStringsPromise,
+                  colorSwatchRailStrings: await colorSwatchRailStringsPromise,
                   initialFocusSelector: () => null,
                 });
               }


### PR DESCRIPTION
## Summary

Fix bug where the CTA in palette modal on the explore page was showing in English on ROW pages

---

## Jira Ticket

Resolves: [MWPW-194124](https://jira.corp.adobe.com/browse/MWPW-194124)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/fr/explore |
| **After**   | https://methomas-cta-translation--express-color--adobecom.aem.live/fr/explore |

---

## Verification Steps

- Load the explore page in a non-English language
- Click on a color palette to open the modal
- Observe the blue CTA button
- Before: Text was in English: "Create with color palette"
- After: Text should be translated

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
