### PR TITLE
Remove express styles.css for Doodlebug

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -22,7 +22,7 @@ import {
 } from './utils.js';
 
 // Add project-wide style path here.
-const STYLES = ['/express/code/styles/styles.css'];
+const STYLES = [];
 
 // Use 'https://milo.adobe.com/libs' if you cannot map '/libs' to milo's origin.
 const LIBS = '/libs';
@@ -360,6 +360,9 @@ function preloadLCPImage(img) {
 
 (function loadStyles() {
   const paths = [`${miloLibs}/styles/styles.css`];
+  if (getMetadata('theme') !== 'doodlebug') {
+    paths.push('/express/code/styles/styles.css');
+  }
   if (STYLES) { paths.push(STYLES); }
   paths.forEach((path) => {
     const link = document.createElement('link');


### PR DESCRIPTION
## Summary

Prevents Express' custom styles (styles.css) from loading when the metadata "theme" is set to "doodlebug"

---

## Jira Ticket

Resolves: No ticket

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/methomas/doodlebug |
| **After**   | https://methomas-styles--da-express-milo--adobecom.aem.page/drafts/methomas/doodlebug |

---

## Verification Steps

- Open the test page and notice the styling differences in the milo blocks compared to the main page
- Heading font weight is less bold
- Button colors are different
- Spacing is different in some places
- These differences are because the custom express styles have been removed

---

## Potential Regressions

- Theme is assigned to something other than doodlebug: https://methomas-styles--da-express-milo--adobecom.aem.page/express/
- Theme is not assigned: https://methomas-styles--da-express-milo--adobecom.aem.live/express/create/print/t-shirt

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
