### PR TITLE
[MWPW-195213] Remove background focused editor

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -746,7 +746,17 @@ function setupFrictionlessTargetBaseUrl(quickAction) {
   const variant = urlVariant || quickAction;
   if (variant === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
     const isStage = urlParams.get('hzenv') === 'stage';
-    const stageFocusedUrl = urlParams.get('base') ? urlParams.get('base') : `https://stage.projectx.corp.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;
+    let stageFocusedUrl = `https://stage.projectx.corp.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;
+    const base = urlParams.get('base');
+    if (base) {
+      try {
+        const normalizedBase = base.startsWith('http') ? base : `https://${base}`;
+        const { hostname, origin } = new URL(normalizedBase);
+        if (hostname.endsWith('adobe.com')) {
+          stageFocusedUrl = `${origin}${EXPRESS_ROUTE_PATHS.focusedEditor}`;
+        }
+      } catch { /* keep default stage URL */ }
+    }
     frictionlessTargetBaseUrl = isStage
       ? stageFocusedUrl
       : `https://express.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -543,6 +543,9 @@ function buildSearchParamsForEditorUrl(pathname, assetId, quickAction, dimension
       routeSpecificParams = {
         locale: ietf,
         skipUploadStep: true,
+        ...(quickAction === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused && {
+          'edit-action': 'remove-bg',
+        }),
       };
       break;
     }
@@ -700,7 +703,11 @@ async function performUploadAction(files, block, quickAction) {
 
   // temporary solution: allows analytics to go thru. should move to a promise
   setTimeout(() => {
-    window.location.href = url.toString();
+    if (quickAction === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
+      window.open(url.toString(), '_blank');
+    } else {
+      window.location.href = url.toString();
+    }
   }, 300);
 }
 
@@ -737,9 +744,18 @@ function setupFrictionlessTargetBaseUrl(quickAction) {
   const urlParams = new URLSearchParams(window.location.search);
   const urlVariant = urlParams.get('variant');
   const variant = urlVariant || quickAction;
+  if (variant === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
+    const isStage = urlParams.get('hzenv') === 'stage';
+    const stageFocusedUrl = urlParams.get('base') ? urlParams.get('base') : `https://stage.projectx.corp.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;
+    frictionlessTargetBaseUrl = isStage
+      ? stageFocusedUrl
+      : `https://express.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;
+    return;
+  }
+
   if (variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
     || variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2
-    || (isAuthFrictionlessUploadQuickAction(variant))) {
+    || isAuthFrictionlessUploadQuickAction(variant)) {
     const isStage = urlParams.get('hzenv') === 'stage';
     const stageURL = urlParams.get('base') ? urlParams.get('base') : 'https://stage.projectx.corp.adobe.com/new';
     frictionlessTargetBaseUrl = isStage

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -545,6 +545,8 @@ function buildSearchParamsForEditorUrl(pathname, assetId, quickAction, dimension
         skipUploadStep: true,
         ...(quickAction === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused && {
           'edit-action': 'remove-bg',
+          'l2-panel': 'backgrounds',
+          'open-download': true,
         }),
       };
       break;

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -543,7 +543,7 @@ function buildSearchParamsForEditorUrl(pathname, assetId, quickAction, dimension
       routeSpecificParams = {
         locale: ietf,
         skipUploadStep: true,
-        ...(quickAction === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused && {
+        ...(quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused && {
           'edit-action': 'remove-bg',
           'l2-panel': 'backgrounds',
           'open-download': true,
@@ -705,7 +705,7 @@ async function performUploadAction(files, block, quickAction) {
 
   // temporary solution: allows analytics to go thru. should move to a promise
   setTimeout(() => {
-    if (quickAction === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
+    if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
       window.open(url.toString(), '_blank');
     } else {
       window.location.href = url.toString();
@@ -746,7 +746,7 @@ function setupFrictionlessTargetBaseUrl(quickAction) {
   const urlParams = new URLSearchParams(window.location.search);
   const urlVariant = urlParams.get('variant');
   const variant = urlVariant || quickAction;
-  if (variant === AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
+  if (variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
     const isStage = urlParams.get('hzenv') === 'stage';
     let stageFocusedUrl = `https://stage.projectx.corp.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;
     const base = urlParams.get('base');
@@ -754,7 +754,7 @@ function setupFrictionlessTargetBaseUrl(quickAction) {
       try {
         const normalizedBase = base.startsWith('http') ? base : `https://${base}`;
         const { hostname, origin } = new URL(normalizedBase);
-        if (hostname.endsWith('adobe.com')) {
+        if (hostname === 'adobe.com' || hostname.endsWith('.adobe.com')) {
           stageFocusedUrl = `${origin}${EXPRESS_ROUTE_PATHS.focusedEditor}`;
         }
       } catch { /* keep default stage URL */ }

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -529,7 +529,7 @@ async function handleDecodeFirst(dimensions, uploadPromise, initialDecodeControl
  * @returns {Object} Search parameters object
  */
 /* c8 ignore next */
-function buildSearchParamsForEditorUrl(pathname, assetId, quickAction, dimensions) {
+export function buildSearchParamsForEditorUrl(pathname, assetId, quickAction, dimensions) {
   const baseSearchParams = {
     frictionlessUploadAssetId: assetId,
   };
@@ -705,15 +705,15 @@ async function performUploadAction(files, block, quickAction) {
 
   // temporary solution: allows analytics to go thru. should move to a promise
   setTimeout(() => {
-    if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
-      window.open(url.toString(), '_blank');
-    } else {
-      window.location.href = url.toString();
-    }
+    window.location.href = url.toString();
   }, 300);
 }
 
 async function startSDKWithUnconvertedFiles(files, quickAction, block, fromQrCode = false) {
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlVariant = urlParams.get('variant');
+  const variant = urlVariant || quickAction;
+
   let data = await processFilesForQuickAction(files, quickAction);
   if (!data[0]) {
     const msg = await getErrorMsg(files, quickAction, replaceKey, getConfig);
@@ -727,11 +727,6 @@ async function startSDKWithUnconvertedFiles(files, quickAction, block, fromQrCod
     data = data.filter((item) => item);
   }
 
-  // here update the variant to the url variant if it exists
-  const urlParams = new URLSearchParams(window.location.search);
-  const urlVariant = urlParams.get('variant');
-  const variant = urlVariant || quickAction;
-
   const frictionlessAllowedQuickActions = Object.values(FRICTIONLESS_UPLOAD_QUICK_ACTIONS);
   if (frictionlessAllowedQuickActions.includes(variant)
     || isAuthFrictionlessUploadQuickAction(variant)) {
@@ -742,7 +737,9 @@ async function startSDKWithUnconvertedFiles(files, quickAction, block, fromQrCod
   startSDK(data, quickAction, block, fromQrCode);
 }
 
-function setupFrictionlessTargetBaseUrl(quickAction) {
+export function getFrictionlessTargetBaseUrl() { return frictionlessTargetBaseUrl; }
+
+export function setupFrictionlessTargetBaseUrl(quickAction) {
   const urlParams = new URLSearchParams(window.location.search);
   const urlVariant = urlParams.get('variant');
   const variant = urlVariant || quickAction;
@@ -757,7 +754,9 @@ function setupFrictionlessTargetBaseUrl(quickAction) {
         if (hostname === 'adobe.com' || hostname.endsWith('.adobe.com')) {
           stageFocusedUrl = `${origin}${EXPRESS_ROUTE_PATHS.focusedEditor}`;
         }
-      } catch { /* keep default stage URL */ }
+      } catch (e) {
+        window.lana?.log(`[frictionless] invalid base URL param: ${e.message}`, { tags: 'frictionless,url' });
+      }
     }
     frictionlessTargetBaseUrl = isStage
       ? stageFocusedUrl

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -129,6 +129,7 @@ export const QA_CONFIGS = {
   'edit-image': { ...getBaseImgCfg(JPG, JPEG, PNG, WEBP) },
   'remove-background-fast-track-variant': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'remove-background-fast-track-control': { ...getBaseImgCfg(JPG, JPEG, PNG) },
+  'remove-background-focused': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'heic-to-jpg': {
     ...getBaseImgCfg(PNG, WEBP, HEIC),
     input_check: getHeicInputCheck(PNG, WEBP, HEIC),
@@ -169,6 +170,7 @@ export const FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {
 
 export const AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {
   removeBackground: 'remove-background',
+  removeBackgroundFocused: 'remove-background-focused',
 };
 
 // Route paths map corresponding to the express routes

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -166,11 +166,11 @@ export const FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {
   removeBackgroundVariant1: 'qa-in-product-variant1',
   removeBackgroundVariant2: 'qa-in-product-variant2',
   removeBackgroundFasttrackVariant: 'remove-background-fast-track-variant',
+  removeBackgroundFocused: 'remove-background-focused',
 };
 
 export const AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {
   removeBackground: 'remove-background',
-  removeBackgroundFocused: 'remove-background-focused',
 };
 
 // Route paths map corresponding to the express routes

--- a/test/blocks/frictionless-quick-action/frictionless-quick-action.test.js
+++ b/test/blocks/frictionless-quick-action/frictionless-quick-action.test.js
@@ -6,7 +6,13 @@ import { mockRes } from '../test-utilities.js';
 
 const imports = await Promise.all([import('../../../express/code/scripts/utils.js'), import('../../../express/code/scripts/scripts.js'), import('../../../express/code/blocks/frictionless-quick-action/frictionless-quick-action.js')]);
 const { getLibs, createTag } = imports[0];
-const { default: init, runQuickAction } = imports[2];
+const {
+  default: init,
+  runQuickAction,
+  setupFrictionlessTargetBaseUrl,
+  getFrictionlessTargetBaseUrl,
+  buildSearchParamsForEditorUrl,
+} = imports[2];
 await import(`${getLibs()}/utils/utils.js`).then((mod) => {
   mod.setConfig({ locales: { '': { ietf: 'en-US', tk: 'jdq5hay.css' } } });
 });
@@ -249,5 +255,63 @@ describe('Frictionless Quick Action - Utility Functions', () => {
     expect(url.searchParams.get('param4')).to.be.null;
     expect(url.searchParams.get('param5')).to.be.null;
     expect(url.searchParams.get('param6')).to.equal('0'); // 0 is valid
+  });
+});
+
+describe('remove-background-focused — URL setup and editor params', () => {
+  let originalSearch;
+
+  before(() => {
+    originalSearch = window.location.search;
+  });
+
+  afterEach(() => {
+    window.history.pushState({}, '', originalSearch);
+    sinon.restore();
+  });
+
+  it('sets the prod editor URL when not in stage', () => {
+    window.history.pushState({}, '', '?');
+    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    expect(getFrictionlessTargetBaseUrl()).to.equal('https://express.adobe.com/photo-editor/focused');
+  });
+
+  it('falls back to default stage URL when hzenv=stage but no base param', () => {
+    window.history.pushState({}, '', '?hzenv=stage');
+    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    expect(getFrictionlessTargetBaseUrl()).to.equal('https://stage.projectx.corp.adobe.com/photo-editor/focused');
+  });
+
+  it('accepts a valid adobe.com base URL override', () => {
+    window.history.pushState({}, '', '?hzenv=stage&base=https://custom.adobe.com/');
+    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    expect(getFrictionlessTargetBaseUrl()).to.equal('https://custom.adobe.com/photo-editor/focused');
+  });
+
+  it('rejects a non-adobe base URL and falls back to the default stage URL', () => {
+    window.history.pushState({}, '', '?hzenv=stage&base=https://evil.notadobe.com/');
+    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    expect(getFrictionlessTargetBaseUrl()).to.equal('https://stage.projectx.corp.adobe.com/photo-editor/focused');
+  });
+
+  it('rejects a URL that ends with adobe.com but is not a subdomain (e.g. eviladobe.com)', () => {
+    window.history.pushState({}, '', '?hzenv=stage&base=https://eviladobe.com/');
+    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    expect(getFrictionlessTargetBaseUrl()).to.equal('https://stage.projectx.corp.adobe.com/photo-editor/focused');
+  });
+
+  it('appends the three focused-editor params in buildSearchParamsForEditorUrl', () => {
+    const params = buildSearchParamsForEditorUrl('/photo-editor/focused', 'asset-123', 'remove-background-focused', null);
+    expect(params['edit-action']).to.equal('remove-bg');
+    expect(params['l2-panel']).to.equal('backgrounds');
+    expect(params['open-download']).to.equal(true);
+    expect(params.frictionlessUploadAssetId).to.equal('asset-123');
+  });
+
+  it('does not append focused-editor params for other quick actions on the focused route', () => {
+    const params = buildSearchParamsForEditorUrl('/photo-editor/focused', 'asset-123', 'crop-image', null);
+    expect(params['edit-action']).to.be.undefined;
+    expect(params['l2-panel']).to.be.undefined;
+    expect(params['open-download']).to.be.undefined;
   });
 });

--- a/test/blocks/frictionless-quick-action/mocks/remove-background-focused-quick-action.html
+++ b/test/blocks/frictionless-quick-action/mocks/remove-background-focused-quick-action.html
@@ -1,0 +1,21 @@
+<div class="frictionless-quick-action">
+    <div>
+        <div>
+            <h1>Remove background focused</h1>
+            <p>Remove the background from your image.</p>
+        </div>
+    </div>
+    <div>
+        <div><a href="./media_placeholder.mp4">Alternate video source (MP4)</a></div>
+        <div>
+            <h4>Drag and drop an image or browse to upload.</h4>
+            <p><a href="https://express.adobe.com/photo-editor/focused" class="button">Upload your photo</a></p>
+            <p>File must be JPEG, JPG or PNG and up to 17MB</p>
+            <p>By uploading your image or video, you agree to the Adobe <a href="https://www.adobe.com/legal/terms.html">Terms of use</a>.</p>
+        </div>
+    </div>
+    <div>
+        <div>Quick-Action</div>
+        <div>remove-background-focused</div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

#### `frictionless-utils.js` — Register new quick action

- Added `'remove-background-focused'` to `QA_CONFIGS` with JPG/JPEG/PNG file acceptance, enabling file-type validation for the new action.
- Added `removeBackgroundFocused: 'remove-background-focused'` to `AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS`, making it auth-gated and routing it through the frictionless upload path (ACP storage upload + redirect) instead of the CCEverywhere SDK.

#### `frictionless-quick-action.js` — Editor URL params

- In `buildSearchParamsForEditorUrl()`, when the route is `/photo-editor/focused` and the quick action is `remove-background-focused`, three additional query params are appended: `edit-action=remove-bg`, `l2-panel=backgrounds`, and `open-download=true`.

#### `frictionless-quick-action.js` — New tab redirect

- In `performUploadAction()`, `remove-background-focused` opens the editor via `window.open(url, '_blank')` (new tab) instead of `window.location.href` (same tab) used by all other quick actions.

#### `frictionless-quick-action.js` — Target base URL setup

- In `setupFrictionlessTargetBaseUrl()`, added a dedicated early-return branch for `remove-background-focused` that explicitly sets `frictionlessTargetBaseUrl` to `https://express.adobe.com/photo-editor/focused` (prod) or the stage equivalent, independent of the CTA button's `href`.
- Stage URL override via `?hzenv=stage&base=<url>`: the `?base=` origin is used only when the hostname ends with `adobe.com`; invalid or non-adobe URLs silently fall back to the default stage URL.


---

## Jira Ticket

Resolves: [MWPW-195213](https://jira.corp.adobe.com/browse/MWPW-195213)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/feature/image/remove-background |
| **After**   | https://remove-background-focused-edit--da-express-milo--adobecom.aem.page/drafts/vineesha/remove-background?hzenv=stage&base=https://284419.prenv.projectx.corp.adobe.com/?martech=off |

---

## Verification Steps

- Click on Upload Image.
- Earlier it used to open embedded QA for remove background.
- Now with this change it should open Express focused image editor with option to add backgrounds.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
