### PR TITLE
MWPW-194001: Added auto save after sign in

### DIFF
--- a/express/code/libs/services/middlewares/auth.middleware.js
+++ b/express/code/libs/services/middlewares/auth.middleware.js
@@ -114,6 +114,38 @@ export function ensureIms(timeoutMs = DEFAULT_IMS_TIMEOUT_MS) {
 }
 
 /**
+ * Wait until `adobeIMS.isSignedInUser()` returns true.
+ *
+ * After a sign-in redirect, `ensureIms()` resolves as soon as the IMS object
+ * exists, but IMS still needs time to process the OAuth callback and restore
+ * the session. This helper polls until the session is ready or times out.
+ *
+ * @param {number} [timeoutMs=5000] - Max ms to wait for session restoration
+ * @param {number} [intervalMs=100] - Polling interval in ms
+ * @returns {Promise<Object>} Resolves with the `window.adobeIMS` instance
+ * @throws {AuthenticationError} If IMS times out before session is restored
+ */
+export async function waitForSignedInUser(timeoutMs = 5000, intervalMs = 100) {
+  const ims = await ensureIms();
+  if (ims.isSignedInUser()) return ims;
+
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const interval = setInterval(() => {
+      if (ims.isSignedInUser()) {
+        clearInterval(interval);
+        resolve(ims);
+      } else if (Date.now() >= deadline) {
+        clearInterval(interval);
+        reject(new AuthenticationError('Timed out waiting for IMS session after redirect', {
+          code: 'IMS_SIGNIN_TIMEOUT',
+        }));
+      }
+    }, intervalMs);
+  });
+}
+
+/**
  * Check if a token is expiring within the buffer window.
  * @param {number} expireTimestamp - Token expiry time (ms since epoch)
  * @param {number} [bufferMs=300000] - Buffer window in milliseconds

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -763,6 +763,7 @@ export async function createDrawer(options) {
     libraries: userLibraries,
     ccLibraryProvider,
     onLibraryCreated,
+    autoSave = false,
     i18n = {},
     deps = {},
   } = options;
@@ -928,6 +929,10 @@ export async function createDrawer(options) {
     isOpen = true;
 
     announceToScreenReader(t.title);
+
+    if (autoSave && isSignedIn) {
+      await save();
+    }
   }
 
   function destroy() {

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -893,7 +893,7 @@ export async function createDrawer(options) {
             '../utils/susiRedirect.js'
           );
           const colors = paletteData?.colors || [];
-          const paletteName = paletteData?.name || '';
+          const paletteName = nameInput?.value?.trim() || paletteData?.name || '';
           setSusiColorRedirect(buildColorSignInRedirectUrl(colors, paletteName, paletteData?.id));
           return triggerSignInFlow();
         },

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -9,7 +9,7 @@ import { loadButton, loadActionButton, loadTooltip } from '../spectrum/load-spec
 import { createThemeWrapper } from '../spectrum/utils/theme.js';
 import { paletteToThemeData } from '../../../libs/services/providers/transforms.js';
 import { serviceManager } from '../../../libs/services/core/ServiceManager.js';
-import { triggerSignInFlow, ensureIms } from '../../../libs/services/middlewares/auth.middleware.js';
+import { triggerSignInFlow, ensureIms, waitForSignedInUser } from '../../../libs/services/middlewares/auth.middleware.js';
 
 function interpolate(tpl, vars) {
   return Object.entries(vars).reduce((s, [k, v]) => s.replaceAll(`{${k}}`, v), tpl);
@@ -602,7 +602,7 @@ export function createToolbar(options) {
 
     (async () => {
       try {
-        await ensureIms();
+        await waitForSignedInUser();
         if (!getLibraryContext) return;
         const ctx = await getLibraryContext();
         if (!ctx?.provider) return;

--- a/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createToolbarComponent.js
@@ -202,6 +202,7 @@ async function handleSave(
   ccLibraryProvider,
   libCtxCache,
   drawerI18n,
+  { autoSave = false } = {},
 ) {
   try {
     if (activeDrawer?.isOpen) {
@@ -221,6 +222,7 @@ async function handleSave(
       onLibraryCreated: (newLib) => {
         if (libCtxCache) libCtxCache.libraries.push(newLib);
       },
+      autoSave,
       i18n: drawerI18n,
     };
     if (libraries?.length) drawerOpts.libraries = libraries;
@@ -447,7 +449,11 @@ export function createToolbar(options) {
 
   let libCtxCache = null;
   async function fetchLibCtxOnce() {
-    if (!libCtxCache && getLibraryContext) libCtxCache = await getLibraryContext();
+    if (!libCtxCache && getLibraryContext) {
+      const ctx = await getLibraryContext();
+      if (ctx?.provider) libCtxCache = ctx;
+      return ctx ?? { libraries: [], provider: null };
+    }
     return libCtxCache ?? { libraries: [], provider: null };
   }
 
@@ -588,6 +594,37 @@ export function createToolbar(options) {
   const mql = window.matchMedia('(max-width: 599px)');
   const mqlHandler = () => { ctaBtn.textContent = getCTAText(); };
   mql.addEventListener('change', mqlHandler);
+
+  if (new URLSearchParams(window.location.search).get('pendingSave') === '1') {
+    const cleanUrl = new URL(window.location.href);
+    cleanUrl.searchParams.delete('pendingSave');
+    window.history.replaceState({}, '', cleanUrl.toString());
+
+    (async () => {
+      try {
+        await ensureIms();
+        if (!getLibraryContext) return;
+        const ctx = await getLibraryContext();
+        if (!ctx?.provider) return;
+        libCtxCache = ctx;
+        await handleSave(
+          getPaletteWithName(),
+          type,
+          ccLibBtn,
+          ctx.libraries,
+          ctx.provider,
+          libCtxCache,
+          drawerI18n,
+          { autoSave: true },
+        );
+      } catch (err) {
+        window.lana?.log(`Auto-save after sign-in failed: ${err.message}`, {
+          tags: 'color-floating-toolbar,auto-save',
+          severity: 'error',
+        });
+      }
+    })();
+  }
 
   const api = {
     element: theme,

--- a/express/code/scripts/color-shared/utils/susiRedirect.js
+++ b/express/code/scripts/color-shared/utils/susiRedirect.js
@@ -22,10 +22,12 @@ export function buildColorSignInRedirectUrl(colors, name, id = null) {
   if (pageHasBlock('color-explore')) {
     const url = new URL(window.location.href);
     if (id) url.searchParams.set('id', id);
+    url.searchParams.set('pendingSave', '1');
     return url.toString();
   }
 
   const url = new URL(window.location.href);
   setOnUrl(url, colors, { name });
+  url.searchParams.set('pendingSave', '1');
   return url.toString();
 }


### PR DESCRIPTION
## Summary

Make sign-in to save a single action

Note: This is a re-attempt at #431 which was reverted


---

## Jira Ticket

Resolves: [MWPW-194001](https://jira.corp.adobe.com/browse/MWPW-194001)

---

## Test URLs
(All color pages with toolbar)

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-wheel |
| **After**   | https://methomas-auto-save--express-color--adobecom.aem.live/create/color-wheel |

---

## Verification Steps

- Pull down locally and spoof color.stage.adobe.com or test after merged to stage
- Make sure you're not logged in
- Click on the "Save to library" button in the toolbar
- Customize the palette name
- Click "Sign in to save button"
- Sign in with SUSI modal
- Before: Page refreshed with the user signed in but the palette was not saved. Would need to open the "Save to library" again to save.
- After: When page refreshes, you might see the drawer briefly flash open before closing again. A toast message should appear confirming that the palette saved. 
- Confirm the palette exists in your library in the Stage Express product using the profile that you signed in with: https://stage.projectx.corp.adobe.com/your-stuff/libraries

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
