### PR TITLE
MWPW-192903: Added link to my library in the toast message

### DIFF
--- a/express/code/scripts/color-shared/spectrum/components/express-toast.js
+++ b/express/code/scripts/color-shared/spectrum/components/express-toast.js
@@ -14,7 +14,7 @@
  *   });
  */
 
-import { loadToast } from '../load-spectrum.js';
+import { loadToast, loadButton } from '../load-spectrum.js';
 import { createThemeWrapper } from '../utils/theme.js';
 import { announceToScreenReader } from '../utils/a11y.js';
 import { loadOverrideStyles } from './style-loader.js';
@@ -53,6 +53,8 @@ function updateStack() {
  * @param {'positive'|'negative'|'info'|'neutral'} [config.variant='info']
  * @param {number} [config.timeout=4000] — auto-dismiss in ms (0 = manual close)
  * @param {Function} [config.onClose]    — called when the toast is dismissed
+ * @param {{label: string, href?: string, onClick?: Function}} [config.action]
+ *        — optional inline action button
  * @returns {Promise<{close: ()=>void}>}
  */
 export async function showExpressToast(config) {
@@ -61,11 +63,17 @@ export async function showExpressToast(config) {
     variant = 'info',
     timeout = 4000,
     onClose,
+    action,
   } = config;
 
   await loadToast();
   await loadOverrideStyles('toast', STYLES_PATH);
   await customElements.whenDefined('sp-toast');
+
+  if (action?.label && (action.href || action.onClick)) {
+    await loadButton();
+    await customElements.whenDefined('sp-button');
+  }
 
   const container = ensureContainer();
   const theme = createThemeWrapper();
@@ -82,6 +90,25 @@ export async function showExpressToast(config) {
   if (spVariant) toast.setAttribute('variant', spVariant);
   toast.setAttribute('open', '');
   toast.textContent = message;
+
+  if (action?.label && (action.href || action.onClick)) {
+    const button = document.createElement('sp-button');
+    button.slot = 'action';
+    button.setAttribute('variant', 'secondary');
+    button.setAttribute('treatment', 'outline');
+    button.setAttribute('static-color', 'white');
+    button.setAttribute('size', 's');
+    button.textContent = action.label;
+    if (action.href) {
+      button.setAttribute('href', action.href);
+      button.setAttribute('target', '_blank');
+      button.setAttribute('rel', 'noopener noreferrer');
+    }
+    if (action.onClick) {
+      button.addEventListener('click', action.onClick);
+    }
+    toast.appendChild(button);
+  }
 
   theme.appendChild(toast);
   container.appendChild(theme);

--- a/express/code/scripts/color-shared/spectrum/styles/toast.css
+++ b/express/code/scripts/color-shared/spectrum/styles/toast.css
@@ -31,8 +31,26 @@ sp-toast {
   font-size: 14px;
   line-height: 20px;
   min-width: 280px;
-  max-width: 400px;
+  max-width: 560px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+/* ── Inline action button ─────────────────────────────────────────── */
+
+sp-toast sp-button[slot="action"] {
+  --spectrum-button-text-color-default: var(--color-white);
+  --spectrum-button-text-color-hover: var(--color-black);
+  --spectrum-button-text-color-down: var(--color-black);
+  --spectrum-button-text-color-focus: var(--color-black);
+  color: var(--color-white);
+  align-self: center;
+  transform: translateY(2px);
+}
+
+sp-toast sp-button[slot="action"]:hover,
+sp-toast sp-button[slot="action"]:focus,
+sp-toast sp-button[slot="action"]:active {
+  color: var(--color-black);
 }
 
 /* ── Variants ─────────────────────────────────────────────────────── */

--- a/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
+++ b/express/code/scripts/color-shared/toolbar/createDrawerComponent.js
@@ -69,6 +69,7 @@ const DRAWER_DEFAULTS = {
   tagRemoveAriaLabel: 'Remove {{tag}}',
   libraryCreatedToast: "Library '{{name}}' created",
   createLibraryFailedToast: 'Something went wrong. Try again.',
+  viewInLibrary: 'View in Library',
 };
 
 const DRAWER_CSS_PATH = 'scripts/color-shared/toolbar/drawer.css';
@@ -847,6 +848,11 @@ export async function createDrawer(options) {
           label,
           libraryName: formData.library?.name ?? t.yourLibrary,
         }),
+        timeout: 6000,
+        action: {
+          label: t.viewInLibrary,
+          href: 'https://new.express.adobe.com/libraries',
+        },
       });
       await onSave?.(formData);
     } catch (err) {

--- a/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
+++ b/express/code/scripts/color-shared/toolbar/createFloatingToolbar.js
@@ -66,6 +66,7 @@ const DRAWER_I18N_MAP = {
   tagRemoveAriaLabel: 'color-drawer-tag-remove-aria-label',
   libraryCreatedToast: 'color-drawer-library-created-toast',
   createLibraryFailedToast: 'color-drawer-create-library-failed-toast',
+  viewInLibrary: 'color-drawer-view-in-library',
 };
 
 async function loadI18nStrings() {


### PR DESCRIPTION
## Summary

Adds link to my library in toast message upon successful save of color palette.

Note: This is a re-attempt at #448 which was reverted

---

## Jira Ticket

Resolves: [MWPW-192903](https://jira.corp.adobe.com/browse/MWPW-192903)

---

## Test URLs
(All color pages with save capability in toolbar)

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-wheel |
| **After**   | https://mwpw-192903--express-color--adobecom.aem.live/create/color-wheel |

---

## Verification Steps

- Test via stage or spoofed stage
- Sign in
- Click "Save to library" in the toolbar
- Click "Save to library" in the drawer
- Observe the toast message that appears upon saving
- Before: The toast only had a success message
- After: The toast also includes a "View in library" button.
- Click the button and it should take you to your Libraries page in Express. Note, since this button goes to Express Prod, it won't contain the palette you just saved with your Stage login.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
