### PR TITLE
MWPW-194002: Persistent support for image updloaded after sign in

### DIFF
--- a/express/code/blocks/color-extract/color-extract.js
+++ b/express/code/blocks/color-extract/color-extract.js
@@ -878,6 +878,7 @@ function renderColorVariant(block, rows, config, strings = {}) {
       window.history.pushState({ colorExtract: 'results' }, '');
     }
     currentSrc = src;
+    try { sessionStorage.setItem('color-extract-image-src', src); } catch { /* quota exceeded — image won't be restored after sign-in */ }
     edit.setBackground(src);
     history.clear();
 
@@ -1045,7 +1046,21 @@ function renderColorVariant(block, rows, config, strings = {}) {
     const paletteName = getResolvedPaletteName();
     controller.setState({ swatches: colors.map((hex) => ({ hex })), baseColorIndex: 0 });
     if (paletteName) controller.setMetadata({ name: paletteName });
-    edit.bgWrapper.replaceWith(dropzone.container);
+
+    const storedSrc = sessionStorage.getItem('color-extract-image-src');
+    sessionStorage.removeItem('color-extract-image-src');
+    if (storedSrc) {
+      const img = new Image();
+      img.onload = async () => {
+        currentSrc = storedSrc;
+        edit.setBackground(storedSrc);
+        currentCanvas = drawImageToCanvas(img);
+        await setupMarkers(currentCanvas);
+      };
+      img.src = storedSrc;
+    } else {
+      edit.bgWrapper.replaceWith(dropzone.container);
+    }
     block.classList.add('has-image');
     window.history.replaceState({ colorExtract: 'results' }, '');
     floatingToolbar.mount();
@@ -1327,6 +1342,7 @@ async function renderGradientVariant(block, rows, config, strings = {}) {
       window.history.pushState({ colorExtract: 'results' }, '');
     }
     currentSrc = src;
+    try { sessionStorage.setItem('color-extract-image-src', src); } catch { /* quota exceeded — image won't be restored after sign-in */ }
     edit.setBackground(src);
     history.clear();
 
@@ -1510,7 +1526,21 @@ async function renderGradientVariant(block, rows, config, strings = {}) {
     const gradientData = { type: 'linear', angle: 90, colorStops };
     gradientEditor.setGradient(gradientData);
     syncSwatchesFromGradient(gradientData);
-    edit.bgWrapper.replaceWith(dropzone.container);
+
+    const storedSrc = sessionStorage.getItem('color-extract-image-src');
+    sessionStorage.removeItem('color-extract-image-src');
+    if (storedSrc) {
+      const img = new Image();
+      img.onload = async () => {
+        currentSrc = storedSrc;
+        edit.setBackground(storedSrc);
+        currentCanvas = drawImageToCanvas(img);
+        await setupMarkers(currentCanvas);
+      };
+      img.src = storedSrc;
+    } else {
+      edit.bgWrapper.replaceWith(dropzone.container);
+    }
     block.classList.add('has-image');
     window.history.replaceState({ colorExtract: 'results' }, '');
     floatingToolbar.mount();

--- a/test/blocks/color-extract/color-extract.test.js
+++ b/test/blocks/color-extract/color-extract.test.js
@@ -149,3 +149,68 @@ describe('Color Extract — gradient variant', () => {
     });
   });
 });
+
+describe('Color Extract — sign-in image restoration', () => {
+  const IMAGE_SRC_KEY = 'color-extract-image-src';
+  // Use a URL that triggers onerror (not onload) so the async setupMarkers
+  // dynamic import is never reached in the test environment.
+  const FAKE_SRC = './nonexistent-test-image.png';
+  const PARAM_NAME = 'color-palette';
+
+  before(() => {
+    window.isTestEnv = true;
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem(IMAGE_SRC_KEY);
+    window.history.replaceState({}, '', window.location.pathname);
+  });
+
+  it('palette: keeps bgWrapper in DOM when image src is stored and color-palette param present', async () => {
+    sessionStorage.setItem(IMAGE_SRC_KEY, FAKE_SRC);
+    window.history.replaceState({}, '', `${window.location.pathname}?${PARAM_NAME}=FF0000,00FF00`);
+    document.body.innerHTML = basic;
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+
+    expect(sessionStorage.getItem(IMAGE_SRC_KEY)).to.be.null;
+    expect(block.classList.contains('has-image')).to.be.true;
+    // bgWrapper should remain in the DOM (not replaced by the dropzone)
+    expect(block.querySelector('.color-extract-edit-bg')).to.exist;
+  });
+
+  it('palette: replaces bgWrapper with dropzone when no image stored and color-palette param present', async () => {
+    sessionStorage.removeItem(IMAGE_SRC_KEY);
+    window.history.replaceState({}, '', `${window.location.pathname}?${PARAM_NAME}=FF0000,00FF00`);
+    document.body.innerHTML = basic;
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+
+    expect(block.classList.contains('has-image')).to.be.true;
+    // bgWrapper replaced by dropzone — edit-bg should be gone
+    expect(block.querySelector('.color-extract-edit-bg')).to.not.exist;
+  });
+
+  it('gradient: keeps bgWrapper in DOM when image src is stored and color-palette param present', async () => {
+    sessionStorage.setItem(IMAGE_SRC_KEY, FAKE_SRC);
+    window.history.replaceState({}, '', `${window.location.pathname}?${PARAM_NAME}=FF0000,00FF00`);
+    document.body.innerHTML = gradient;
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+
+    expect(sessionStorage.getItem(IMAGE_SRC_KEY)).to.be.null;
+    expect(block.classList.contains('has-image')).to.be.true;
+    expect(block.querySelector('.color-extract-edit-bg')).to.exist;
+  });
+
+  it('gradient: replaces bgWrapper with dropzone when no image stored and color-palette param present', async () => {
+    sessionStorage.removeItem(IMAGE_SRC_KEY);
+    window.history.replaceState({}, '', `${window.location.pathname}?${PARAM_NAME}=FF0000,00FF00`);
+    document.body.innerHTML = gradient;
+    const block = document.querySelector('.color-extract');
+    await decorate(block);
+
+    expect(block.classList.contains('has-image')).to.be.true;
+    expect(block.querySelector('.color-extract-edit-bg')).to.not.exist;
+  });
+});


### PR DESCRIPTION
## Summary

On extract pages users can now upload an image, modify the palette, sign in, and not lose their image as long as it's under 5mb.

Note: This is a re-attempt at #430 which was reverted.

---

## Jira Ticket

Resolves: [MWPW-194002](https://jira.corp.adobe.com/browse/MWPW-194002)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/image |
| **After**   | https://mwpw-194002--express-color--adobecom.aem.live/create/image |
| **Before**  | https://main--express-color--adobecom.aem.live/create/image-gradient |
| **After**   | https://mwpw-194002--express-color--adobecom.aem.live/create/image-gradient |

---

## Verification Steps

- Test on stage or spoofed stage
- Log out
- Upload an image less than 5mb or click on one of the suggested images
- In the toolbar, click on "Save to library"
- In the popup, click on "Sign in to save" and go through the sign in workflow
- When sign-in is complete, observe the page you're on
- Before: The image was lost and in its place was the "Upload your image" dropzone"
- After: The image is retained and the page looks just like it did prior to signing in
- Note: For images over 5mb, users will still see the "Upload your image" dropzone

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
