### PR TITLE
MWPW-195419: color-wheel: enforce lock state on wheel handles

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -1064,6 +1064,14 @@ export default async function decorate(block) {
       });
       layoutInstance.slots.sidebar.appendChild(tabs.element);
 
+      const wheelEl = tabs.getPanel('color-wheel')?.querySelector('color-wheel-express');
+      if (wheelEl) {
+        wheelEl.lockedByIndex = swatchRailController.getState().lockedByIndex;
+        swatchRailController.subscribe((state) => {
+          wheelEl.lockedByIndex = state.lockedByIndex;
+        });
+      }
+
       if (!isDesktop) {
         const { createActionMenuComponent } = await import('../../scripts/color-shared/components/createActionMenuComponent.js');
 

--- a/express/code/scripts/color-shared/components/color-wheel-express/index.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/index.js
@@ -258,6 +258,28 @@ export class ColorWheelExpress extends ColorWheel {
     return marker;
   }
 
+  set lockedByIndex(val) {
+    this._lockedByIndex = val instanceof Set ? val : new Set();
+    this.updateMarkers();
+  }
+
+  _showLockedTip(index) {
+    const layer = this.shadowRoot?.querySelector('.marker-layer');
+    const marker = layer?.querySelector(`.wheel-marker-overlay[data-index="${index}"]`);
+    if (!marker || !layer) return;
+
+    layer.querySelector(`.wheel-locked-tip[data-tip-index="${index}"]`)?.remove();
+
+    const tip = document.createElement('div');
+    tip.className = 'wheel-locked-tip';
+    tip.dataset.tipIndex = index;
+    tip.textContent = this.lockedTipText || 'Unlock to change value';
+    tip.style.left = marker.style.left;
+    tip.style.top = marker.style.top;
+    layer.appendChild(tip);
+    tip.addEventListener('animationend', () => tip.remove());
+  }
+
   updateMarkers() {
     const markerLayer = this.shadowRoot.querySelector('.marker-layer');
     if (!markerLayer || !this.swatches.length) return;
@@ -328,6 +350,7 @@ export class ColorWheelExpress extends ColorWheel {
       const isBase = index === this.baseColorIndex && this.harmonyRule !== 'CUSTOM';
       marker.classList.toggle('wheel-marker-overlay--base', isBase);
       marker.classList.toggle('wheel-marker-overlay--active', index === this.activeSwatchIndex);
+      marker.classList.toggle('wheel-marker-overlay--locked', this._lockedByIndex?.has(index) ?? false);
     });
 
     for (let i = existingSpokes.length - 1; i >= spokeCursor; i -= 1) {
@@ -346,6 +369,13 @@ export class ColorWheelExpress extends ColorWheel {
   }
 
   _handleMarkerKeydown(e, index) {
+    if (this._lockedByIndex?.has(index)) {
+      if (['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        e.preventDefault();
+        this._showLockedTip(index);
+      }
+      return;
+    }
     const step = 3;
     switch (e.key) {
       case 'ArrowRight': e.preventDefault(); this._moveMarkerByKey(index, step, 0); break;
@@ -575,6 +605,12 @@ export class ColorWheelExpress extends ColorWheel {
     event.stopPropagation();
 
     if (isRightMouseButtonClicked(event)) return;
+
+    if (event.target === this.canvas && this._lockedByIndex?.has(this.activeSwatchIndex)) {
+      this._showLockedTip(this.activeSwatchIndex);
+      return;
+    }
+
     this.getCanvasPosition();
 
     if (event.target === this.canvas) {
@@ -684,6 +720,12 @@ export class ColorWheelExpress extends ColorWheel {
     }
 
     this.getCanvasPosition();
+
+    if (this._lockedByIndex?.has(index)) {
+      this._showLockedTip(index);
+      return;
+    }
+
     this._dragIndex = index;
 
     const rawV = this.swatches[index]?.hsv?.v != null

--- a/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
+++ b/express/code/scripts/color-shared/components/color-wheel-express/styles.css.js
@@ -118,6 +118,7 @@ export const style = css`
     .wheel-marker-overlay--locked,
     .wheel-marker-overlay--locked:active {
         cursor: not-allowed;
+        opacity: 0.65;
     }
 
     .wheel-marker-overlay:focus,
@@ -151,6 +152,26 @@ export const style = css`
         border-radius: 50%;
         pointer-events: none;
         z-index: 3;
+    }
+
+    /* Transient tooltip shown when a user attempts to move a locked handle */
+    .wheel-locked-tip {
+        position: absolute;
+        background: var(--spectrum-global-color-gray-800, #2c2c2c);
+        color: #fff;
+        font-size: 11px;
+        line-height: 1.4;
+        border-radius: 4px;
+        padding: 4px 8px;
+        pointer-events: none;
+        white-space: nowrap;
+        z-index: 200;
+        transform: translate(-50%, calc(-100% - 10px));
+        animation: wheel-tip-fade 2s forwards;
+    }
+    @keyframes wheel-tip-fade {
+        0%, 70% { opacity: 1; }
+        100% { opacity: 0; }
     }
 
     /* Spoke lines */


### PR DESCRIPTION
## Summary
- Locked color handles on the wheel now render at `opacity: 0.65` with `cursor: not-allowed` to visually indicate they cannot be moved
- Drag attempts (pointer and canvas click) on locked handles are blocked; a transient "Unlock to change value" tooltip appears near the handle and fades out after 2s
- Keyboard arrow movement on locked handles is blocked with the same tooltip; Tab/Escape still work for navigation and focus
- Lock state (`lockedByIndex`) is wired from `swatchRailControllerBridge` to the `color-wheel-express` element via a subscription added after tab setup

## Test plan
- [ ] Lock a swatch in the palette strip → its wheel handle dims to 0.65 opacity
- [ ] Try dragging a locked handle → handle doesn't move, tooltip appears and fades
- [ ] Try clicking the canvas while the locked swatch is active → blocked with tooltip
- [ ] Tab to a locked handle, press arrow keys → movement blocked, tooltip appears; Tab still cycles handles
- [ ] Unlock the swatch → handle fully interactive again, tooltip no longer appears
- [ ] Switch harmony rule from custom → verify `lockedByIndex` clears and handles return to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)