### PR TITLE
Add keyboard shortcuts to color palette generator

### DIFF
--- a/express/code/blocks/color-wheel/color-wheel.js
+++ b/express/code/blocks/color-wheel/color-wheel.js
@@ -243,6 +243,11 @@ async function buildDefaultActionMenuConfig(strings) {
 const THEME_NAME = '';
 const HISTORY_EVENT = `${ACTION_MENU_ID}:history-index-changed`;
 const HISTORY_SKIP_SOURCES = new Set(['active-index', 'metadata', 'base-index']);
+const KB_INTERACTIVE_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A']);
+const KB_INTERACTIVE_ROLES = new Set([
+  'button', 'link', 'checkbox', 'menuitem', 'option',
+  'radio', 'tab', 'slider', 'spinbutton', 'textbox', 'combobox',
+]);
 let harmonyCarouselCleanup = null;
 let harmonyStateUnsubscribe = null;
 let layoutInstance = null;
@@ -257,6 +262,7 @@ let primaryColorAdapter = null;
 let sidebarNaturalWidth = 0;
 let sidebarTransitionCleanup = null;
 let historyCleanup = null;
+let keyboardCleanup = null;
 let currentInitToken = 0;
 
 function swatchHexListFromState(state) {
@@ -817,6 +823,8 @@ function cleanup() {
   sidebarNaturalWidth = 0;
   historyCleanup?.();
   historyCleanup = null;
+  keyboardCleanup?.();
+  keyboardCleanup = null;
 }
 
 export default async function decorate(block) {
@@ -1055,6 +1063,28 @@ export default async function decorate(block) {
         document.removeEventListener(HISTORY_EVENT, onHistoryChange);
         clearTimeout(historyDebounceTimer);
       };
+
+      const onKeyDown = (e) => {
+        const el = document.activeElement;
+        if (el && el !== document.body && el !== document.documentElement) {
+          if (KB_INTERACTIVE_TAGS.has(el.tagName)) return;
+          if (el.isContentEditable) return;
+          if (parseInt(el.getAttribute('tabindex') ?? '-1', 10) >= 0) return;
+          if (KB_INTERACTIVE_ROLES.has(el.getAttribute('role'))) return;
+        }
+        if (e.key === ' ') {
+          e.preventDefault();
+          actionMenuApi?.generateRandom?.();
+        } else if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          actionMenuApi?.undo?.();
+        } else if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          actionMenuApi?.redo?.();
+        }
+      };
+      document.addEventListener('keydown', onKeyDown);
+      keyboardCleanup = () => document.removeEventListener('keydown', onKeyDown);
 
       tabs.setPanelEntryFocus('primary-color', () => {
         primaryColorAdapter?.element?.shadowRoot?.querySelector('.bc-mode-trigger')?.focus();

--- a/express/code/scripts/color-shared/components/createActionMenuComponent.js
+++ b/express/code/scripts/color-shared/components/createActionMenuComponent.js
@@ -385,6 +385,7 @@ export async function createActionMenuComponent(options = {}) {
     getCurrentPalette: getCurrentPaletteFn,
     undo: handleUndoState,
     redo: handleRedoState,
+    generateRandom: handleGenerateRandom,
     destroy() {
       document.removeEventListener(eventName, handleHistoryIndexChanged);
       container.remove();


### PR DESCRIPTION
## Summary
- **Space** generates a random palette (equivalent to clicking "Generate random")
- **← / →** navigate back and forward through palette history (equivalent to undo/redo)
- Shortcuts are suppressed when any interactive element has keyboard focus — form fields, buttons, links, color wheel markers (tabindex ≥ 0), harmony carousel items, and ARIA role widgets — so keyboard-only users are unaffected

## Changes
- `createActionMenuComponent.js` — expose `generateRandom` on the returned API so the full generate-random sequence (color reset + history push) can be triggered without a button click
- `color-wheel.js` — add a `keydown` listener on `document` wired to `actionMenuApi.generateRandom`, `actionMenuApi.undo`, and `actionMenuApi.redo`; listener is cleaned up on block re-init (breakpoint change)

## Test plan
- [ ] Click the page background (no element focused) → press **Space** → palette refreshes
- [ ] Press **←** / **→** → palette steps back and forward through history
- [ ] Tab to "Generate random" button → press **Space** → button activates normally, no double-fire
- [ ] Tab into the color wheel (press **Enter**) → use **← →** to adjust hue → history navigation does NOT fire
- [ ] Tab to a hex input → type → no shortcut interference
- [ ] Resize to mobile → Space / arrows still work when no element is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)