### PR TITLE
Extract Image Stacking On Mobile

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -76,7 +76,6 @@
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding: 32px 16px;
 }
 
 body:has(.color-headline.extract) .color-extract .color-extract-landing {


### PR DESCRIPTION
## Summary

- Fixes the **Extract Palette / Gradient** landing layout on **mobile Safari (iOS)** when **no image** is uploaded: the upload widget no longer gets squeezed into a vertical stack because of extra horizontal padding on the landing container.
- Removes **`padding: 32px 16px`** from `.color-extract .color-extract-landing` so outer spacing matches the intended **16px** gutter from surrounding layout instead of double-counting padding.

---

## Jira Ticket

Resolves: [MWPW-194379](https://jira.corp.adobe.com/browse/MWPW-194379)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://MWPW-194379--express-color--adobecom.aem.live/create/image |

---

## Verification Steps

1. On **iPhone Safari**, open the **create/image** flow (Extract Palette & Gradient), **without** uploading an image.
2. **Before:** The image/upload widget tends to **stack vertically** and the area around the drop zone feels **too padded** (wider than the expected ~16px edge spacing).
3. **After:** The empty-state upload UI stays in a **single-row width** where appropriate, with **tighter, correct side spacing** consistent with the page’s 16px gutter.

---

## Potential Regressions

- https://MWPW-194379--da-express-milo--adobecom.aem.live/express/?martech=off  
- Other **`color-extract`** landing states (with/without headline marquee, first paint on narrow viewports).

---

## Additional Notes

- **Reporter:** Julia  
- **Original URL / context:** https://color.adobe.com/create/image — filed during **color.adobe.com live launch (May 4, 2026)**.  
- **Implementation:** One-line CSS change in `express/code/blocks/color-extract/color-extract.css` (landing container padding removal). 