### PR TITLE
fix: MWPW-194823 restore flex centering for same-fcta CTA in ax-marquee-dynamic-hero

### DIFF
--- a/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.css
+++ b/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.css
@@ -130,6 +130,15 @@ main .ax-marquee-dynamic-hero p.button-container {
   text-align: left;
 }
 
+@media (min-width: 900px) {
+  .ax-marquee-dynamic-hero .button-container.free-plan-container a.button.same-fcta,
+  .ax-marquee-dynamic-hero .button-container.free-plan-container a.con-button.same-fcta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
 /* Media query for ax-columns-dynamic-hero on tablet */
 @media (min-width: 768px) and (max-width: 899px) {
   .ax-marquee-dynamic-hero {

--- a/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.css
+++ b/express/code/blocks/ax-marquee-dynamic-hero/ax-marquee-dynamic-hero.css
@@ -131,11 +131,8 @@ main .ax-marquee-dynamic-hero p.button-container {
 }
 
 @media (min-width: 900px) {
-  .ax-marquee-dynamic-hero .button-container.free-plan-container a.button.same-fcta,
-  .ax-marquee-dynamic-hero .button-container.free-plan-container a.con-button.same-fcta {
+  .ax-marquee-dynamic-hero .button-container.free-plan-container a.button.same-fcta {
     display: flex;
-    align-items: center;
-    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary

When `show-floating-cta: yes` is set in page metadata, the global CSS (`styles.css` L1336) re-shows the same-fcta CTA at ≥900px by forcing `display: inline-block`. This overrides the `display: flex` established by the free-plan-container button rule (L1324), stripping vertical centering inside the 183px-wide pill. On EN pages, single-line text renders fine. On FR/DE pages where the CTA text wraps to two lines, the text drops visually lower than the adjacent free-plan widget.

Fix: a block-scoped `@media (min-width: 900px)` override in `ax-marquee-dynamic-hero.css` that restores `display: flex` on `a.button.same-fcta`. This is the minimum-correct change — `align-items: center` and `justify-content: center` are already provided by the cascade (global L1324 and block L30-34 respectively) once `flex` is restored.

---

## Jira Ticket

Resolves: [MWPW-194823](https://jira.corp.adobe.com/browse/MWPW-194823)

---

## Test URLs

| Env | URL |
|---|---|
| **Before** | https://main--da-express-milo--adobecom.aem.live/fr/express/discover/wishes/easter |
| **After** | https://mwpw-194823-floating-issue-de-fr--da-express-milo--adobecom.aem.live/drafts/sircar/easter-fr |

---

## Verification Steps

1. Open the **After** URL at desktop widths: 900px, 1024px, 1440px.
2. Confirm the hero CTA text is vertically centered inside the pill and aligned with the free-plan widget on the right.
3. Repeat at <900px — CTA should be hidden (same as before, `display: none` via L1159).
4. Open the **Before** URL — visually unchanged from current.

---

## Potential Regressions

- Rule only fires when all four are true: viewport ≥900px + inside `.ax-marquee-dynamic-hero` + ancestor has `.free-plan-container` + element has `.button.same-fcta`. No other block is affected.
- https://mwpw-194823-floating-issue-de-fr--da-express-milo--adobecom.aem.live/drafts/sircar/easter-fr?martech=off

---

## Additional Notes

The global `display: inline-block` rule (styles.css L1336) is shared by all blocks — changing it globally risks regressions in `ax-marquee`, `ax-columns.marquee`, `fullscreen-marquee`, etc. The block-scoped override is the minimal, safe fix. The `con-button` selector is intentionally omitted because this block only ever produces `.button` CTAs.