### PR TITLE
MWPW-193988 Ratings - use accent blue for keyboard focus ring (WCAG 1.4.11)

### DIFF
--- a/express/code/blocks/ratings/ratings.css
+++ b/express/code/blocks/ratings/ratings.css
@@ -348,7 +348,7 @@
   background-color: var(--color-gray-300);
   border-color: var(--color-gray-300);
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-info-accent);
+  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-gray-400);
 }
 
 .ratings form [type='submit']:focus:hover {
@@ -371,6 +371,11 @@
   color: #b9b9b9;
   cursor: default;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+.ratings form [type='submit']:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-info-accent);
 }
 
 /* Custom styling for the native range input, with cross-browser compatibility */

--- a/express/code/blocks/ratings/ratings.css
+++ b/express/code/blocks/ratings/ratings.css
@@ -348,7 +348,7 @@
   background-color: var(--color-gray-300);
   border-color: var(--color-gray-300);
   outline: none;
-  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-gray-400);
+  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-info-accent);
 }
 
 .ratings form [type='submit']:focus:hover {
@@ -371,12 +371,6 @@
   color: #b9b9b9;
   cursor: default;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-}
-
-.ratings form [type='submit']:focus-visible,
-.ratings form [type='submit'][aria-disabled='true']:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-white), 0 0 0 4px var(--color-gray-400);
 }
 
 /* Custom styling for the native range input, with cross-browser compatibility */


### PR DESCRIPTION
## Summary

Follow-up to PR #500 (merged to stage). The `:focus-visible` rule added in PR #500 used `--color-gray-400` (#b6b6b6) as the focus ring colour, giving only ~1.9:1 contrast against its adjacent white halo — failing WCAG 1.4.11 (non-text contrast, 3:1 minimum).

**Fix:** Replace `--color-gray-400` with `--color-info-accent` (#5c5ce0) in the `:focus-visible` rule only.

**Behaviour after fix:**
- Mouse click on Submit → subtle grey ring (`:focus`, `--color-gray-400`) — unchanged pre-existing behaviour
- Keyboard Tab to Submit → blue ring (`:focus-visible`, `--color-info-accent`) — 4.95:1 contrast ✅

---

## Jira Ticket

Resolves: [MWPW-193988](https://jira.corp.adobe.com/browse/MWPW-193988)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--da-express-milo--adobecom.aem.live/drafts/sircar/qr-code-generator?martech=off&nala=ratings |
| **After**   | https://mwpw-193988-darken-focus-indicator--da-express-milo--adobecom.aem.live/drafts/sircar/qr-code-generator?martech=off&nala=ratings |

---

## Verification Steps

1. Open the After URL
2. Rate 3 stars (feedback-required path — submit button goes grey with `aria-disabled="true"`)
3. **Mouse click** on Submit → grey ring (unchanged pre-existing behaviour)
4. **Keyboard Tab** to Submit → blue ring (`--color-info-accent`)
5. **Before:** Grey ring (~1.9:1 contrast, fails WCAG 1.4.11)
6. **After:** Blue ring (4.95:1 contrast ✅)
7. Rate 4/5 stars (enabled state), Tab to Submit → same blue ring ✅

---

## Potential Regressions

- https://mwpw-193988-darken-focus-indicator--da-express-milo--adobecom.aem.live/drafts/sircar/qr-code-generator?martech=off&nala=ratings

---

## Additional Notes

- CSS-only change — no JS touched
- Related PR: #500 (WCAG 2.4.7 fix, merged)
- `npm run lint` — clean
- Unit tests: 25/25 pass
- Nala: 3/3 pass, no accessibility violations