### PR TITLE
Persist color space selection across the color experience

### DIFF
--- a/express/code/scripts/color-shared/adapters/README.md
+++ b/express/code/scripts/color-shared/adapters/README.md
@@ -14,7 +14,7 @@ Adapter for `<color-edit>`. Use from strips, color wheel, contrast checker, or m
 |------|------|---------|-------------|
 | `palette` | `string[]` | `[]` | Hex color array (up to 10 per Figma). |
 | `selectedIndex` | `number` | `0` | Selected palette index. |
-| `colorMode` | `string` | `'RGB'` | `'RGB'` \| `'HEX'`. |
+| `colorMode` | `string` | `'RGB'` | `'RGB'` \| `'HEX'`. Used as the fallback only — the adapter initializes from the persisted user preference (`express-color-mode` in localStorage) when one exists, and writes back to it on every mode change so other live pickers stay in sync. |
 | `showPalette` | `boolean` | `true` | Whether to show the palette row. |
 | `mobile` | `boolean` | `false` | When true, renders as bottom sheet. |
 
@@ -78,7 +78,7 @@ Adapter for `<base-color>`. Use when only the color picker (no palette) is neede
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `color` | `string` | `'#FF0000'` | Initial hex color. |
-| `colorMode` | `string` | `'HEX'` | `'HEX'` \| `'RGB'` \| `'HSB'` \| `'Lab'`. |
+| `colorMode` | `string` | `'HEX'` | `'HEX'` \| `'RGB'` \| `'HSB'` \| `'Lab'`. Used as the fallback only — the adapter initializes from the persisted user preference (`express-color-mode` in localStorage) when one exists, and writes back to it on every mode change so other live pickers stay in sync. |
 | `showHeader` | `boolean` | `true` | Show header row. |
 | `showBrightnessControl` | `boolean` | `true` | Show brightness slider. |
 

--- a/express/code/scripts/color-shared/adapters/createBaseColorAdapter.js
+++ b/express/code/scripts/color-shared/adapters/createBaseColorAdapter.js
@@ -1,3 +1,9 @@
+import {
+  getPreferredColorMode,
+  setPreferredColorMode,
+  subscribeColorMode,
+} from '../utils/colorModePreference.js';
+
 export default function createBaseColorAdapter(
   initialColor,
   colorMode,
@@ -8,7 +14,7 @@ export default function createBaseColorAdapter(
 
   const element = document.createElement('base-color');
   element.color = initialColor;
-  element.setAttribute('color-mode', colorMode);
+  element.setAttribute('color-mode', getPreferredColorMode(colorMode));
 
   if (callbacks.strings) {
     element.strings = callbacks.strings;
@@ -32,6 +38,7 @@ export default function createBaseColorAdapter(
   });
 
   element.addEventListener('mode-change', (e) => {
+    setPreferredColorMode(e.detail?.mode);
     callbacks.onModeChange?.(e.detail);
   });
 
@@ -41,6 +48,10 @@ export default function createBaseColorAdapter(
 
   element.addEventListener('color-change-end', (e) => {
     callbacks.onColorChangeEnd?.(e.detail);
+  });
+
+  const unsubscribe = subscribeColorMode((mode) => {
+    if (element.colorMode !== mode) element.colorMode = mode;
   });
 
   return {
@@ -54,6 +65,7 @@ export default function createBaseColorAdapter(
     getController: () => options.controller,
     destroy: () => {
       if (rafId !== null) cancelAnimationFrame(rafId);
+      unsubscribe();
       element.remove();
     },
   };

--- a/express/code/scripts/color-shared/adapters/litComponentAdapters.js
+++ b/express/code/scripts/color-shared/adapters/litComponentAdapters.js
@@ -1,6 +1,11 @@
 import { createGradientEditor } from '../components/gradients/gradient-editor.js';
 import { wrapInTheme } from '../spectrum/utils/theme.js';
 import { loadIconsRail } from '../spectrum/load-spectrum.js';
+import {
+  getPreferredColorMode,
+  setPreferredColorMode,
+  subscribeColorMode,
+} from '../utils/colorModePreference.js';
 
 const VERTICAL_STACKED_BREAKPOINT_PX = 1200;
 
@@ -266,7 +271,7 @@ export function createColorEditAdapter(options = {}, callbacks = {}) {
 
   element.palette = palette.slice(0, 10);
   element.selectedIndex = selectedIndex;
-  element.colorMode = colorMode;
+  element.colorMode = getPreferredColorMode(colorMode);
   element.showPalette = showPalette;
   element.mobile = mobile;
   if (strings) element.strings = strings;
@@ -282,10 +287,15 @@ export function createColorEditAdapter(options = {}, callbacks = {}) {
     callbacks.onSwatchSelect?.(e.detail);
   });
   element.addEventListener('mode-change', (e) => {
+    setPreferredColorMode(e.detail?.mode);
     callbacks.onModeChange?.(e.detail);
   });
   element.addEventListener('panel-close', () => {
     callbacks.onClose?.();
+  });
+
+  const unsubscribe = subscribeColorMode((mode) => {
+    if (element.colorMode !== mode) element.colorMode = mode;
   });
 
   return {
@@ -302,7 +312,10 @@ export function createColorEditAdapter(options = {}, callbacks = {}) {
       element.colorMode = mode;
     },
     getElement: () => element,
-    destroy: () => element.remove(),
+    destroy: () => {
+      unsubscribe();
+      element.remove();
+    },
   };
 }
 
@@ -385,7 +398,7 @@ export function createBaseColorAdapter(options = {}, callbacks = {}) {
   } = options;
 
   element.color = color;
-  element.colorMode = colorMode;
+  element.colorMode = getPreferredColorMode(colorMode);
   element.showHeader = showHeader;
   element.showBrightnessControl = showBrightnessControl;
   if (strings) element.strings = strings;
@@ -394,10 +407,15 @@ export function createBaseColorAdapter(options = {}, callbacks = {}) {
     callbacks.onColorChange?.(e.detail);
   });
   element.addEventListener('mode-change', (e) => {
+    setPreferredColorMode(e.detail?.mode);
     callbacks.onModeChange?.(e.detail);
   });
   element.addEventListener('lock-change', (e) => {
     callbacks.onLockChange?.(e.detail);
+  });
+
+  const unsubscribe = subscribeColorMode((mode) => {
+    if (element.colorMode !== mode) element.colorMode = mode;
   });
 
   return {
@@ -409,6 +427,9 @@ export function createBaseColorAdapter(options = {}, callbacks = {}) {
       element.colorMode = mode;
     },
     getElement: () => element,
-    destroy: () => element.remove(),
+    destroy: () => {
+      unsubscribe();
+      element.remove();
+    },
   };
 }

--- a/express/code/scripts/color-shared/components/base-color/README.md
+++ b/express/code/scripts/color-shared/components/base-color/README.md
@@ -73,6 +73,8 @@ Open / close programmatically via `el.show()` and `el.hide()`.
 
 ## Usage — Factory method
 
+> Note: when instantiated through `createBaseColorAdapter`, the `colorMode` you pass is treated as a fallback. The adapter initializes from the user's persisted preference (`express-color-mode` in localStorage) when one exists and writes back to it on every `mode-change`, keeping other live pickers in sync.
+
 ```js
 import { createBaseColorComponent } from 'path/to/color-shared/components/createBaseColorComponent.js';
 

--- a/express/code/scripts/color-shared/components/color-edit/README.md
+++ b/express/code/scripts/color-shared/components/color-edit/README.md
@@ -59,6 +59,8 @@ Open / close programmatically via `el.show()` and `el.hide()`.
 
 ## Usage — Factory method
 
+> Note: when instantiated through `createColorEditAdapter`, the `colorMode` you pass is treated as a fallback. The adapter initializes from the user's persisted preference (`express-color-mode` in localStorage) when one exists and writes back to it on every `mode-change`, keeping other live pickers in sync.
+
 ```js
 import { createColorEditComponent } from 'path/to/color-shared/components/createColorEditComponent.js';
 

--- a/express/code/scripts/color-shared/utils/colorModePreference.js
+++ b/express/code/scripts/color-shared/utils/colorModePreference.js
@@ -1,0 +1,46 @@
+export const VALID_COLOR_MODES = ['HEX', 'RGB', 'HSB', 'Lab'];
+
+const STORAGE_KEY = 'express-color-mode';
+const DEFAULT_MODE = 'HEX';
+
+const listeners = new Set();
+
+function readStored() {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStored(mode) {
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    /* storage disabled or quota exceeded — keep in-memory sync working */
+  }
+}
+
+export function getPreferredColorMode(fallback = DEFAULT_MODE) {
+  const stored = readStored();
+  if (stored && VALID_COLOR_MODES.includes(stored)) return stored;
+  return fallback;
+}
+
+export function setPreferredColorMode(mode) {
+  if (!VALID_COLOR_MODES.includes(mode)) return;
+  writeStored(mode);
+  listeners.forEach((listener) => {
+    try {
+      listener(mode);
+    } catch {
+      /* isolate subscriber failures */
+    }
+  });
+}
+
+export function subscribeColorMode(listener) {
+  if (typeof listener !== 'function') return () => {};
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/test/scripts/color-shared/utils/colorModePreference.test.js
+++ b/test/scripts/color-shared/utils/colorModePreference.test.js
@@ -1,0 +1,169 @@
+/* eslint-env mocha */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import {
+  VALID_COLOR_MODES,
+  getPreferredColorMode,
+  setPreferredColorMode,
+  subscribeColorMode,
+} from '../../../../express/code/scripts/color-shared/utils/colorModePreference.js';
+
+const STORAGE_KEY = 'express-color-mode';
+
+describe('colorModePreference', () => {
+  let unsubscribes;
+
+  beforeEach(() => {
+    unsubscribes = [];
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  afterEach(() => {
+    unsubscribes.forEach((fn) => {
+      try { fn(); } catch { /* ignore */ }
+    });
+    unsubscribes = [];
+    sinon.restore();
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  function track(unsub) {
+    unsubscribes.push(unsub);
+    return unsub;
+  }
+
+  describe('VALID_COLOR_MODES', () => {
+    it('exports exactly HEX, RGB, HSB, Lab', () => {
+      expect(VALID_COLOR_MODES).to.deep.equal(['HEX', 'RGB', 'HSB', 'Lab']);
+    });
+  });
+
+  describe('getPreferredColorMode', () => {
+    it('returns default fallback "HEX" when nothing is stored', () => {
+      expect(getPreferredColorMode()).to.equal('HEX');
+    });
+
+    it('returns the explicit fallback when nothing is stored', () => {
+      expect(getPreferredColorMode('RGB')).to.equal('RGB');
+    });
+
+    ['HEX', 'RGB', 'HSB', 'Lab'].forEach((mode) => {
+      it(`returns the stored value when it is the valid mode "${mode}"`, () => {
+        localStorage.setItem(STORAGE_KEY, mode);
+        expect(getPreferredColorMode()).to.equal(mode);
+      });
+    });
+
+    it('returns the fallback when the stored value is not in VALID_COLOR_MODES', () => {
+      localStorage.setItem(STORAGE_KEY, 'xyz');
+      expect(getPreferredColorMode()).to.equal('HEX');
+    });
+
+    it('returns the fallback when the stored value is an empty string', () => {
+      localStorage.setItem(STORAGE_KEY, '');
+      expect(getPreferredColorMode()).to.equal('HEX');
+    });
+
+    it('returns the fallback when the stored value differs only by case (e.g. "rgb")', () => {
+      localStorage.setItem(STORAGE_KEY, 'rgb');
+      expect(getPreferredColorMode()).to.equal('HEX');
+    });
+
+    it('returns the fallback (without throwing) when localStorage.getItem throws', () => {
+      sinon.stub(Storage.prototype, 'getItem').throws(new Error('storage disabled'));
+      expect(() => getPreferredColorMode('RGB')).to.not.throw();
+      expect(getPreferredColorMode('RGB')).to.equal('RGB');
+    });
+  });
+
+  describe('setPreferredColorMode', () => {
+    it('writes a valid mode to localStorage', () => {
+      setPreferredColorMode('RGB');
+      expect(localStorage.getItem(STORAGE_KEY)).to.equal('RGB');
+    });
+
+    it('ignores invalid modes — no write, no listener invocation', () => {
+      const spy = sinon.spy();
+      track(subscribeColorMode(spy));
+
+      setPreferredColorMode('xyz');
+
+      expect(localStorage.getItem(STORAGE_KEY)).to.be.null;
+      expect(spy.called).to.be.false;
+    });
+
+    it('still notifies subscribers when localStorage.setItem throws', () => {
+      sinon.stub(Storage.prototype, 'setItem').throws(new Error('quota exceeded'));
+      const spy = sinon.spy();
+      track(subscribeColorMode(spy));
+
+      expect(() => setPreferredColorMode('RGB')).to.not.throw();
+      expect(spy.calledOnceWithExactly('RGB')).to.be.true;
+    });
+
+    it('isolates listener exceptions — a throwing listener does not block others', () => {
+      const thrower = sinon.stub().throws(new Error('listener boom'));
+      const spy = sinon.spy();
+      track(subscribeColorMode(thrower));
+      track(subscribeColorMode(spy));
+
+      expect(() => setPreferredColorMode('HSB')).to.not.throw();
+      expect(thrower.calledOnce).to.be.true;
+      expect(spy.calledOnceWithExactly('HSB')).to.be.true;
+    });
+  });
+
+  describe('subscribeColorMode', () => {
+    it('invokes the listener with the new mode on each setPreferredColorMode call', () => {
+      const spy = sinon.spy();
+      track(subscribeColorMode(spy));
+
+      setPreferredColorMode('RGB');
+      setPreferredColorMode('Lab');
+
+      expect(spy.callCount).to.equal(2);
+      expect(spy.firstCall.args).to.deep.equal(['RGB']);
+      expect(spy.secondCall.args).to.deep.equal(['Lab']);
+    });
+
+    it('notifies multiple subscribers', () => {
+      const a = sinon.spy();
+      const b = sinon.spy();
+      track(subscribeColorMode(a));
+      track(subscribeColorMode(b));
+
+      setPreferredColorMode('HSB');
+
+      expect(a.calledOnceWithExactly('HSB')).to.be.true;
+      expect(b.calledOnceWithExactly('HSB')).to.be.true;
+    });
+
+    it('returned unsubscribe stops further notifications', () => {
+      const spy = sinon.spy();
+      const unsubscribe = subscribeColorMode(spy);
+
+      setPreferredColorMode('RGB');
+      unsubscribe();
+      setPreferredColorMode('Lab');
+
+      expect(spy.calledOnceWithExactly('RGB')).to.be.true;
+    });
+
+    it('returns a no-op function when the listener is not a function and never throws', () => {
+      const unsubNull = subscribeColorMode(null);
+      const unsubUndefined = subscribeColorMode(undefined);
+      const unsubNumber = subscribeColorMode(42);
+
+      expect(unsubNull).to.be.a('function');
+      expect(unsubUndefined).to.be.a('function');
+      expect(unsubNumber).to.be.a('function');
+
+      expect(() => setPreferredColorMode('RGB')).to.not.throw();
+      expect(() => {
+        unsubNull();
+        unsubUndefined();
+        unsubNumber();
+      }).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The active color mode (HEX / RGB / HSB / Lab) in `base-color` and `color-edit` now persists in `localStorage` (key: `express-color-mode`) and syncs across every live picker on the page. Users no longer have to re-select their preferred color space on each component or after navigating between color blocks.

Implementation lives entirely at the adapter layer — no block-level changes:
- New utility: `express/code/scripts/color-shared/utils/colorModePreference.js` exposes `getPreferredColorMode` / `setPreferredColorMode` / `subscribeColorMode`, backed by `localStorage` with try/catch on every access so storage-disabled browsers (Safari private mode, etc.) degrade gracefully to in-memory sync.
- `createBaseColorAdapter.js` and both adapters in `litComponentAdapters.js` (`createColorEditAdapter`, `createBaseColorAdapter`) now: initialize `colorMode` from the persisted preference (the caller's value is used as a fallback), write back on every `mode-change`, and subscribe so all live pickers stay in sync.

---

## Jira Ticket

n/a

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-wheel |
| **After**   | https://persistent-color-space--express-color--adobecom.aem.page/create/color-wheel |

---

## Verification Steps

1. Open the **After** URL (color-wheel).
2. In the primary picker, change the color mode from `HEX` to `RGB`.
3. Click a swatch to open its color-edit panel — it should also open in `RGB` (same-page sync). **Before:** the swatch panel opens in `HEX` regardless of the primary picker's mode.
4. Reload the page — the primary picker should stay in `RGB`. **Before:** it resets to `HEX`.
5. Navigate to `/create/color-contrast-analyzer` on the same branch — the color input should open in `RGB`. **Before:** opens in `HEX` (or whatever the component default is).
6. Change to `Lab` on contrast-analyzer, then navigate back to `/create/color-wheel`. The picker should be in `Lab`.
7. DevTools → Application → Local Storage → confirm `express-color-mode` holds the current value.
8. Edge case: in the DevTools console run `localStorage.setItem('express-color-mode','xyz')` and reload — the picker should fall back to `HEX` (invalid values are rejected).
9. Edge case: open the page in a Safari private window and exercise step 2 — mode changes should still sync within the page even though persistence is unavailable; no console errors.

---

## Potential Regressions

- https://persistent-color-space--express-color--adobecom.aem.live/create/color-wheel
- https://persistent-color-space--express-color--adobecom.aem.live/create/color-contrast-analyzer
- https://persistent-color-space--express-color--adobecom.aem.live/create/color-accessibility

Watch list:
- The positional `colorMode` argument on `createBaseColorAdapter(initialColor, colorMode, …)` is now treated as a fallback rather than an authoritative initial value. All current call sites pass `'HEX'` (the default) so behavior is unchanged when no preference is stored — but any future caller that needs to force a specific mode should be aware.
- `subscribeColorMode` listeners are unsubscribed in each adapter's `destroy()`. Any caller that fails to call `destroy()` would leak a closure holding the element — confirmed all current callers do (e.g. color-wheel tracks `primaryColorAdapter`).

---

## Additional Notes

- Cross-tab sync (via the `storage` event) intentionally not implemented — the primary use case is sequential navigation in one tab, and the added complexity isn't justified yet.
- Stored value contains no PII; it's one of four short strings (`HEX`, `RGB`, `HSB`, `Lab`). Falls under the same "functional UI preference" category as the existing `localStorage` usage in `app-banner`, `ax-marquee`, and `ratings`.