### PR TITLE
MWPW-183928 fix logo-row heading typography to be tag-agnostic for a11y

### DIFF
--- a/express/code/blocks/logo-row/logo-row.css
+++ b/express/code/blocks/logo-row/logo-row.css
@@ -16,7 +16,7 @@ main .logo-row .block-layout {
     font-family: Arial, sans-serif;
 }
 
-main .logo-row .text-column :where(h1, h2, h3, h4, h5, h6, p) {
+main .logo-row .text-column :where(h1, h2, h3, h4, h5, h6) {
     font-size: var(--heading-font-size-s);
     font-style: normal;
 }

--- a/express/code/blocks/logo-row/logo-row.css
+++ b/express/code/blocks/logo-row/logo-row.css
@@ -16,10 +16,8 @@ main .logo-row .block-layout {
     font-family: Arial, sans-serif;
 }
 
-main .logo-row.block-layout .text-column {
-    font-size: 22px;
-    font-style: normal;
-    font-weight: 900;
+main .logo-row .text-column :where(h1, h2, h3, h4, h5, h6, p) {
+    font-size: var(--heading-font-size-s);
 }
 
 main .logo-row .block-row {

--- a/express/code/blocks/logo-row/logo-row.css
+++ b/express/code/blocks/logo-row/logo-row.css
@@ -18,6 +18,7 @@ main .logo-row .block-layout {
 
 main .logo-row .text-column :where(h1, h2, h3, h4, h5, h6, p) {
     font-size: var(--heading-font-size-s);
+    font-style: normal;
 }
 
 main .logo-row .block-row {


### PR DESCRIPTION
## Summary

Make the `logo-row` block's text column render all heading levels (`h1`–`h6`) with identical typography. Authors can now choose a semantically correct heading level (e.g. `h2` after the page `h1`) without any visual change, eliminating the axe DevTools "Ensure the order of headings is semantically correct" violation.

**Root cause:** The old CSS targeted the `.text-column` container, but the global per-level `font-size` rules in `styles.css` had higher specificity on the heading elements themselves, so `h1`–`h3` still rendered at their default large sizes. Authors were forced to use `h5` to get the intended visual, breaking heading hierarchy.

**Fix:** Use `:where(h1, h2, h3, h4, h5, h6, p)` inside `.text-column` to set a uniform `--heading-font-size-s`. `font-weight` and `line-height` are intentionally left to the global `main h1–h6` rule in `styles.css` (`--heading-font-weight`, `--heading-line-height`) — those are already consistent across all heading levels so no override is needed. `:where()` contributes zero specificity, ensuring the existing tablet `> *` rule still wins via source order with no tablet regression.

---

## Jira Ticket

Resolves: [MWPW-183928](https://jira.corp.adobe.com/browse/MWPW-183928)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.live/drafts/sircar/why-choose-express |
| **After**   | https://mwpw-183928-why-axe-dev-issue--da-express-milo--adobecom.aem.live/drafts/sircar/why-choose-express |

---

## Verification Steps

1. Open the **After** URL at mobile (390px), tablet (900px), and desktop (1440px).
2. The logo-row text should look visually identical to the **Before** URL at all breakpoints.
3. In DevTools, confirm the heading tag is `h2` (or whichever semantic level the author chose) — not `h5`.
4. Run axe DevTools on the After URL — "Ensure the order of headings is semantically correct" should no longer appear for the logo-row.

**Before:** Author had to use `h5` (skipping h2–h4) to match the visual design → axe violation.
**After:** Author can use `h2` and the block renders identically → no axe violation.

---

## Potential Regressions

- https://mwpw-183928-why-axe-dev-issue--da-express-milo--adobecom.aem.live/drafts/sircar/why-choose-express

---

## Additional Notes

Pixel-level regression check (Playwright + pixelmatch) confirmed 0 differing pixels between branch and prod at all three breakpoints.