### PR TITLE
MWPW-195777: add center-content variant

### DIFF
--- a/express/code/blocks/cta-carousel/cta-carousel.css
+++ b/express/code/blocks/cta-carousel/cta-carousel.css
@@ -193,6 +193,10 @@
     margin-left: auto;
 }
 
+.cta-carousel.center-content .carousel-container .carousel-platform {
+    margin-inline: auto;
+}
+
 .cta-carousel.quick-action .card.gen-ai-action .card-sleeve .gen-ai-input-form .gen-ai-submit {
     left: 56px;
     bottom: 24px;


### PR DESCRIPTION
## Summary

Adds an opt-in `.center-content` variant to the `cta-carousel` block that horizontally centers the cards row within its container. This is a purely additive CSS change — the existing left-aligned default is completely unchanged, so there is zero regression risk for any currently authored page.

The variant pairs with the existing `.center-heading` variant:
- `center-heading` — centers the heading section (h2 + subheading).
- `center-content` — centers the carousel cards row.

Authors who want everything centered combine both: `cta-carousel (center-heading, center-content)` in the document.

**Behavior with many cards:** when the total card width fills or exceeds the container, `margin-inline: auto` is a no-op and the carousel scrolls exactly as today.

---

## Jira Ticket

Resolves: [MWPW-195777](https://jira.corp.adobe.com/browse/MWPW-195777)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.live/drafts/sircar/cta-carousel |
| **After**   | https://mwpw-195777-cta-center--express-color--adobecom.aem.live/drafts/sircar/cta-carousel |

---

## Verification Steps

1. Open the **Before** URL — confirm existing layout is left-aligned (baseline).
2. Open the **After** URL — confirm pages without `.center-content` look identical to Before (no regression).
3. In DevTools, add `center-content` to a `.cta-carousel` with **few cards** → cards row should visibly center within the container.
4. In DevTools, add `center-content` to a `.cta-carousel` with **many cards** (overflow) → cards should still fill the container width and the carousel should scroll normally.
5. Combine `center-heading center-content` → both heading and cards row should be centered.

---

## Potential Regressions

- https://mwpw-195777-cta-center--express-color--adobecom.aem.live/drafts/sircar/cta-carousel

---

## Additional Notes

- Change is CSS-only (4 lines added). No JS or markup changes.
- Vertical spacing is intentionally out of scope — authors use section-metadata spacing classes (`l-spacing`, `xl-spacing`, etc.) for vertical balance, same convention as every other block on the site.
- The doc page at `/docs/library/blocks/cta-carousel` should be updated to list `center-content` as a new variant — separate content-authoring follow-up.