### PR TITLE
[MWPW-196252] add promo id for remove background focused control and challenger]

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -94,12 +94,9 @@ function frictionlessQAExperiment(
   appConfig.metaData.entryPoint = 'seo-quickaction-image-upload';
   switch (variant) {
     case 'qa-nba':
-      ccEverywhere.quickAction.removeBackground(docConfig, appConfig, exportConfig, contConfig);
-      break;
     case 'qa-in-product-control':
-      ccEverywhere.quickAction.removeBackground(docConfig, appConfig, exportConfig, contConfig);
-      break;
     case 'remove-background-fast-track-control':
+    case 'remove-background-focused-control':
       ccEverywhere.quickAction.removeBackground(docConfig, appConfig, exportConfig, contConfig);
       break;
     default:
@@ -543,7 +540,7 @@ export function buildSearchParamsForEditorUrl(pathname, assetId, quickAction, di
       routeSpecificParams = {
         locale: ietf,
         skipUploadStep: true,
-        ...(quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused && {
+        ...(quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocusedChallenger && {
           'edit-action': 'remove-bg',
           'l2-panel': 'backgrounds',
           'open-download': true,
@@ -743,7 +740,7 @@ export function setupFrictionlessTargetBaseUrl(quickAction) {
   const urlParams = new URLSearchParams(window.location.search);
   const urlVariant = urlParams.get('variant');
   const variant = urlVariant || quickAction;
-  if (variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocused) {
+  if (variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundFocusedChallenger) {
     const isStage = urlParams.get('hzenv') === 'stage';
     let stageFocusedUrl = `https://stage.projectx.corp.adobe.com${EXPRESS_ROUTE_PATHS.focusedEditor}`;
     const base = urlParams.get('base');

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -129,7 +129,6 @@ export const QA_CONFIGS = {
   'edit-image': { ...getBaseImgCfg(JPG, JPEG, PNG, WEBP) },
   'remove-background-fast-track-variant': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'remove-background-fast-track-control': { ...getBaseImgCfg(JPG, JPEG, PNG) },
-  'remove-background-focused': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'heic-to-jpg': {
     ...getBaseImgCfg(PNG, WEBP, HEIC),
     input_check: getHeicInputCheck(PNG, WEBP, HEIC),
@@ -148,6 +147,8 @@ export const EXPERIMENTAL_VARIANTS = [
   'qa-in-product-control',
   'remove-background-fast-track-variant',
   'remove-background-fast-track-control',
+  'remove-background-focused-control',
+  'remove-background-focused-challenger',
 ];
 
 export const EXPERIMENTAL_VARIANTS_PROMOID_MAP = {
@@ -157,6 +158,8 @@ export const EXPERIMENTAL_VARIANTS_PROMOID_MAP = {
   'qa-in-product-control': '91BF4LV6',
   'remove-background-fast-track-variant': '6DWQ762R',
   'remove-background-fast-track-control': '55KD8FF5',
+  'remove-background-focused-control': 'FZPQYL16',
+  'remove-background-focused-challenger': 'G4FRYG95',
 };
 
 // Quick actions allowed in frictionless upload feature
@@ -166,7 +169,7 @@ export const FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {
   removeBackgroundVariant1: 'qa-in-product-variant1',
   removeBackgroundVariant2: 'qa-in-product-variant2',
   removeBackgroundFasttrackVariant: 'remove-background-fast-track-variant',
-  removeBackgroundFocused: 'remove-background-focused',
+  removeBackgroundFocusedChallenger: 'remove-background-focused-challenger',
 };
 
 export const AUTH_FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {

--- a/test/blocks/frictionless-quick-action/frictionless-quick-action.test.js
+++ b/test/blocks/frictionless-quick-action/frictionless-quick-action.test.js
@@ -258,7 +258,7 @@ describe('Frictionless Quick Action - Utility Functions', () => {
   });
 });
 
-describe('remove-background-focused — URL setup and editor params', () => {
+describe('remove-background-focused-challenger — URL setup and editor params', () => {
   let originalSearch;
 
   before(() => {
@@ -272,36 +272,36 @@ describe('remove-background-focused — URL setup and editor params', () => {
 
   it('sets the prod editor URL when not in stage', () => {
     window.history.pushState({}, '', '?');
-    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    setupFrictionlessTargetBaseUrl('remove-background-focused-challenger');
     expect(getFrictionlessTargetBaseUrl()).to.equal('https://express.adobe.com/photo-editor/focused');
   });
 
   it('falls back to default stage URL when hzenv=stage but no base param', () => {
     window.history.pushState({}, '', '?hzenv=stage');
-    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    setupFrictionlessTargetBaseUrl('remove-background-focused-challenger');
     expect(getFrictionlessTargetBaseUrl()).to.equal('https://stage.projectx.corp.adobe.com/photo-editor/focused');
   });
 
   it('accepts a valid adobe.com base URL override', () => {
     window.history.pushState({}, '', '?hzenv=stage&base=https://custom.adobe.com/');
-    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    setupFrictionlessTargetBaseUrl('remove-background-focused-challenger');
     expect(getFrictionlessTargetBaseUrl()).to.equal('https://custom.adobe.com/photo-editor/focused');
   });
 
   it('rejects a non-adobe base URL and falls back to the default stage URL', () => {
     window.history.pushState({}, '', '?hzenv=stage&base=https://evil.notadobe.com/');
-    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    setupFrictionlessTargetBaseUrl('remove-background-focused-challenger');
     expect(getFrictionlessTargetBaseUrl()).to.equal('https://stage.projectx.corp.adobe.com/photo-editor/focused');
   });
 
   it('rejects a URL that ends with adobe.com but is not a subdomain (e.g. eviladobe.com)', () => {
     window.history.pushState({}, '', '?hzenv=stage&base=https://eviladobe.com/');
-    setupFrictionlessTargetBaseUrl('remove-background-focused');
+    setupFrictionlessTargetBaseUrl('remove-background-focused-challenger');
     expect(getFrictionlessTargetBaseUrl()).to.equal('https://stage.projectx.corp.adobe.com/photo-editor/focused');
   });
 
   it('appends the three focused-editor params in buildSearchParamsForEditorUrl', () => {
-    const params = buildSearchParamsForEditorUrl('/photo-editor/focused', 'asset-123', 'remove-background-focused', null);
+    const params = buildSearchParamsForEditorUrl('/photo-editor/focused', 'asset-123', 'remove-background-focused-challenger', null);
     expect(params['edit-action']).to.equal('remove-bg');
     expect(params['l2-panel']).to.equal('backgrounds');
     expect(params['open-download']).to.equal(true);


### PR DESCRIPTION
## Summary
Adds promo id for remove-background-focused experiment which opens focused image editor on express in challenger.

---

## Jira Ticket

Resolves: [MWPW-196252](https://jira.corp.adobe.com/browse/MWPW-196252)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/feature/image/remove-background |
| **After**   | https://remove-bg-fucused-promoid--da-express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off&hzenv=stage&variant=remove-background-focused-challenger |

---

## Verification Steps

- Click on Upload your photo
- Earlier the embed image editor was being opened,
- Now focused image editor https://stage.projectx.corp.adobe.com/photo-editor/focused will be opened.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
