### PR TITLE
MWPW-195465 Fix Color Tools Tablet Spacing

### DIFF
--- a/express/code/blocks/color-blindness/color-blindness.css
+++ b/express/code/blocks/color-blindness/color-blindness.css
@@ -3,8 +3,10 @@
 .color-blindness .ax-color-tool-layout {
   --ax-layout-inline-size: auto;
   --ax-text-content-gap: var(--spacing-100);
-  --ax-padding-sidebar-mobile: 0;
-  --ax-padding-canvas-mobile: 0;
+  --ax-padding-topbar-mobile: 0 0 var(--spacing-400);
+  --ax-padding-sidebar-mobile: 0 0 var(--spacing-300);
+  --ax-padding-canvas-mobile: 0 0 var(--spacing-300);
+  --ax-padding-sidebar-desktop: var(--spacing-100) 0 0;
 }
 
 .color-blindness .ax-shell-slot--sidebar {
@@ -81,7 +83,6 @@
 
   .color-blindness .ax-color-tool-layout {
     grid-template-rows: auto 1fr auto;
-    --ax-padding-sidebar-desktop: var(--spacing-100) 0 0;
     --ax-footer-margin-top: 0;
   }
 

--- a/express/code/blocks/color-contrast-checker/color-contrast-checker.css
+++ b/express/code/blocks/color-contrast-checker/color-contrast-checker.css
@@ -143,14 +143,16 @@
 }
 
 .color-contrast-checker .ax-color-tool-layout {
-  --ax-layout-inline-size: auto;
+  --ax-padding-sidebar-desktop: var(--spacing-100) 0 0;
+  --ax-padding-topbar-mobile: 0 0 var(--spacing-400);
+  --ax-padding-sidebar-mobile: 0 0 var(--spacing-300);
 }
 
 
 .color-contrast-checker-layout {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-400);
+  gap: var(--spacing-300);
   margin-block-start: var(--spacing-300);
 }
 
@@ -604,7 +606,6 @@
 
 .cc-tabs sp-tab-panel {
   padding-block-start: var(--spacing-200);
-  min-height: var(--cc-preview-cta-width-mobile);
 }
 
 .cc-summary-content {
@@ -1331,6 +1332,12 @@
   }
 }
 
+@media (min-width: 600px) and (max-width: 887px) {
+  .color-contrast-checker .ax-color-tool-layout {
+    --ax-padding-sidebar-mobile: 0 0 var(--spacing-400);
+    --ax-padding-canvas-mobile: 0 0 var(--spacing-200);
+  }
+}
 
 @media (min-width: 888px) {
   .cc-slider-container {

--- a/express/code/blocks/color-headline/color-headline.css
+++ b/express/code/blocks/color-headline/color-headline.css
@@ -90,12 +90,13 @@ body:has(.color-extract.has-image) .color-headline.extract {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-100);
+  box-sizing: border-box;
 }
 
 .color-headline.tools:not([data-adopted="true"]) {
   max-width: var(--block-wd-max-width);
-  padding: var(--action-menu-buffer) var(--spacing-300) 0;
-  margin-inline: auto;
+  padding: var(--action-menu-buffer) var(--spacing-300) var(--spacing-300);
+  margin: 0 auto;
 }
 
 .color-headline.tools .express-logo {
@@ -135,6 +136,7 @@ body:has(.color-extract.has-image) .color-headline.extract {
 
   .color-headline.tools:not([data-adopted="true"]) {
     padding-inline: var(--spacing-500);
+    padding-block-end: var(--spacing-400);
   }
 }
 
@@ -150,7 +152,7 @@ body:has(.color-extract.has-image) .color-headline.extract {
   }
 
   .color-headline.tools:not([data-adopted="true"]) {
-    padding-inline: var(--spacing-600);
+    padding: var(--spacing-600);
   }
 
   .color-headline.tools:not([data-adopted="true"]) > div {

--- a/express/code/blocks/color-wheel/color-wheel.css
+++ b/express/code/blocks/color-wheel/color-wheel.css
@@ -20,15 +20,12 @@ body {
 }
 
 .color-wheel .ax-color-tool-layout {
-  box-sizing: border-box;
-  max-width: var(--block-wd-max-width);
-  margin: 0 auto;
-  padding: 0 var(--spacing-300) var(--spacing-300);
-  row-gap: 0;
-}
+  --ax-padding-topbar-desktop: 0 0 var(--spacing-400);
+  --ax-padding-topbar-mobile: 0 0 var(--spacing-400);
+  --ax-padding-sidebar-mobile: 0 0 var(--spacing-300);
+  --ax-padding-canvas-mobile: 0 0 var(--spacing-300);
 
-.color-wheel .ax-shell-slot--topbar {
-  padding-block-end: var(--spacing-400);
+  row-gap: 0;
 }
 
 .color-wheel .ax-shell-slot--sidebar {
@@ -36,12 +33,10 @@ body {
   flex-direction: column;
   gap: var(--spacing-300);
   overflow: visible;
-  padding-block-end: var(--spacing-300);
   isolation: isolate;
 }
 
 .color-wheel .ax-shell-slot--canvas {
-  padding-block-end: var(--spacing-300);
   box-sizing: border-box;
   overflow-y: visible;
 }
@@ -448,23 +443,13 @@ color-wheel-express {
 
 @media (min-width: 600px) {
   .color-wheel .ax-color-tool-layout {
-    padding: var(--spacing-400) var(--spacing-500);
-    row-gap: 0;
-  }
-
-  .color-wheel .ax-shell-slot--topbar,
-  .color-wheel .ax-shell-slot--sidebar {
-    padding-block-end: var(--spacing-400);
+    --ax-padding-sidebar-mobile: 0 0 var(--spacing-400);
   }
 }
 
 /* Large Tablet */
 
 @media (min-width: 888px) {
-  .color-wheel .ax-shell-slot--sidebar {
-    padding-block-end: 0;
-  }
-
   .color-wheel .ax-shell-slot--canvas {
     padding-block-end: var(--spacing-200);
   }
@@ -508,7 +493,6 @@ color-wheel-express {
   }
 
   .color-wheel .ax-color-tool-layout {
-    padding: var(--spacing-600);
     grid-template-rows: auto minmax(0, 1fr) auto;
     grid-template-columns: minmax(0, var(--cw-sidebar-fr, 4fr)) minmax(0, 8fr);
     align-items: stretch;

--- a/express/code/scripts/color-shared/shell/layouts/styles/color-tool-layout.css
+++ b/express/code/scripts/color-shared/shell/layouts/styles/color-tool-layout.css
@@ -1,16 +1,12 @@
 .ax-color-tool-layout {
   /* Layout configuration */
   --ax-layout-gap: var(--spacing-300);
-  --ax-layout-row-gap: var(--ax-layout-gap);
+  --ax-layout-row-gap: 0;
   --ax-layout-column-gap: var(--ax-layout-gap);
   --ax-color-tool-presentation-max-width: var(--block-wd-max-width);
-  --ax-layout-outer-margin-inline: var(--spacing-300);
-  --ax-layout-outer-margin-block: var(--spacing-300);
   --ax-layout-presentation-max-width: var(--ax-color-tool-presentation-max-width);
   --ax-layout-max-inline-size: var(--ax-layout-presentation-max-width);
   --ax-layout-grid-gutter: var(--ax-grid-gutter, var(--spacing-300));
-  --ax-layout-padding-inline: 0;
-  --ax-layout-padding-block: 0;
   --ax-layout-inline-size: 100%;
 
   /* Grid configuration (desktop) */
@@ -36,10 +32,12 @@
   --ax-bg-footer: var(--color-white);
 
   /* Slot padding (mobile) */
+  --ax-padding-topbar-mobile: 0;
   --ax-padding-sidebar-mobile: 0;
   --ax-padding-canvas-mobile: 0;
 
   /* Slot padding (desktop) */
+  --ax-padding-topbar-desktop: 0;
   --ax-padding-sidebar-desktop: 0;
   --ax-padding-canvas-desktop: 0;
 
@@ -72,8 +70,9 @@
   --ax-text-body-gap: var(--spacing-100);
   --ax-logo-gap: var(--spacing-100);
 
-  padding: var(--ax-layout-padding-block) var(--ax-layout-padding-inline);
-  margin: var(--ax-layout-outer-margin-block) var(--ax-layout-outer-margin-inline);
+  box-sizing: border-box;
+  padding: 0 var(--spacing-300) var(--spacing-300);
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   row-gap: var(--ax-layout-row-gap);
@@ -91,6 +90,7 @@
   position: relative;
   order: var(--mobile-order);
   min-inline-size: 0;
+  box-sizing: border-box;
 }
 
 .ax-color-tool-layout--canvas-footer .ax-shell-slot--topbar,
@@ -101,6 +101,7 @@
 .ax-shell-slot--topbar {
   grid-area: var(--ax-area-topbar);
   background-color: var(--ax-bg-topbar);
+  padding: var(--ax-padding-topbar-mobile);
 }
 
 .ax-shell-slot--sidebar {
@@ -155,15 +156,20 @@
   outline-offset: var(--ax-focus-outline-offset);
 }
 
-@media (min-width: 888px) {
+@media (min-width: 600px) {
   .ax-color-tool-layout {
-    --ax-layout-outer-margin-inline: var(--spacing-500);
-    --ax-layout-outer-margin-block: var(--spacing-500);
+    padding: var(--spacing-400) var(--spacing-500);
   }
+}
 
+@media (min-width: 888px) {
   .ax-shell-slot {
     order: unset;
     grid-area: auto;
+  }
+
+  .ax-shell-slot--topbar {
+    padding: var(--ax-padding-topbar-desktop);
   }
 
   .ax-shell-slot--sidebar {
@@ -228,10 +234,7 @@
 
 @media (min-width: 1200px) {
   .ax-color-tool-layout {
-    --ax-layout-outer-margin-inline: var(--spacing-600);
-    --ax-layout-outer-margin-block: var(--spacing-600);
-    padding-inline: var(--spacing-600);
-    margin-inline: auto;
+    padding: var(--spacing-600);
   }
 
   .ax-shell-slot--topbar {


### PR DESCRIPTION
## Summary

- Fixes container and gap spacing for Color Contrast and Color Blindness blocks
- Reorganizes spacing into shared Color Tool Layout

---

## Jira Ticket

Resolves: [MWPW-195465](https://jira.corp.adobe.com/browse/MWPW-195465)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-accessibility |
| **After**   | https://methomas-mobile-spacing--express-color--adobecom.aem.live/create/color-accessibility |
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-contrast-analyzer |
| **After**   | https://methomas-mobile-spacing--express-color--adobecom.aem.live/create/color-contrast-analyzer |
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-wheel |
| **After**   | https://methomas-mobile-spacing--express-color--adobecom.aem.live/create/color-wheel |

---

## Verification Steps

- Verify that the container and gap spacings match the figma for each page at each breakpoint

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
