### PR TITLE
MWPW-195800 Remove cursor from extract markers

### DIFF
--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -903,6 +903,10 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   transition: none;
 }
 
+.color-extract:has(.color-extract-marker.is-magnified) {
+  cursor: none;
+}
+
 .color-extract .color-extract-marker.is-magnified .color-extract-marker-zoom {
   display: block;
 }

--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -892,6 +892,10 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   display: block;
 }
 
+.color-extract .color-extract-marker.is-active .color-extract-marker-zoom {
+  display: block;
+}
+
 /* ---- Magnified state (handle becomes the zoom lens on drag) ---- */
 
 .color-extract .color-extract-marker.is-magnified {

--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -854,8 +854,9 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
 }
 
 .color-extract .color-extract-marker.is-active {
-  width: 42px;
-  height: 42px;
+  width: 60px;
+  height: 60px;
+  background: transparent;
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.95), 0 0 17px rgba(0, 0, 0, 0.16);
   z-index: 10;
 }
@@ -1046,8 +1047,8 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   }
 
   .color-extract .color-extract-marker.is-active {
-    width: 56px;
-    height: 56px;
+    width: 80px;
+    height: 80px;
   }
 
   .color-extract .color-extract-marker.is-magnified {

--- a/express/code/blocks/color-extract/helpers/imageMarkers.js
+++ b/express/code/blocks/color-extract/helpers/imageMarkers.js
@@ -331,6 +331,8 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
     marker.el.setAttribute('aria-valuetext', hex);
     controller.setSwatchHex(index, hex);
     updateConnectors();
+    const zc = marker.el.querySelector('.color-extract-marker-zoom');
+    if (zc) renderMagnification(zc, canvas, cx, cy);
     if (options.onMoodOverride) options.onMoodOverride(MOODS.CUSTOM);
   }
 
@@ -358,6 +360,12 @@ export default function createImageMarkers(imageContainer, canvas, controller, o
     el.addEventListener('focus', () => {
       keyboardSnapshotPending = true;
       setActiveMarker(index);
+      const { cx, cy } = pctToCanvas(marker.pctX, marker.pctY);
+      const zc = marker.el.querySelector('.color-extract-marker-zoom');
+      if (zc) renderMagnification(zc, canvas, cx, cy);
+    });
+    el.addEventListener('blur', () => {
+      marker.el.classList.remove('is-active');
     });
 
     markers.push(marker);

--- a/express/code/blocks/color-wheel/image-extract.css
+++ b/express/code/blocks/color-wheel/image-extract.css
@@ -610,6 +610,10 @@
   display: block;
 }
 
+.image-extract .color-extract-marker.is-active .color-extract-marker-zoom {
+  display: block;
+}
+
 /* ---- Magnified state (handle becomes zoom lens on drag) ---- */
 
 .image-extract .color-extract-marker.is-magnified {

--- a/express/code/blocks/color-wheel/image-extract.css
+++ b/express/code/blocks/color-wheel/image-extract.css
@@ -572,8 +572,9 @@
 }
 
 .image-extract .color-extract-marker.is-active {
-  width: 56px;
-  height: 56px;
+  width: 80px;
+  height: 80px;
+  background: transparent;
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.95), 0 0 17px rgba(0, 0, 0, 0.16);
   z-index: 10;
 }
@@ -820,8 +821,8 @@
   }
 
   .image-extract .color-extract-marker.is-active {
-    width: 42px;
-    height: 42px;
+    width: 80px;
+    height: 80px;
   }
 
   .image-extract .color-extract-zoom {

--- a/express/code/blocks/color-wheel/image-extract.css
+++ b/express/code/blocks/color-wheel/image-extract.css
@@ -621,6 +621,10 @@
   transition: none;
 }
 
+.image-extract:has(.color-extract-marker.is-magnified) {
+  cursor: none;
+}
+
 .image-extract .color-extract-marker.is-magnified .color-extract-marker-zoom {
   display: block;
 }

--- a/express/code/blocks/color-wheel/image-extract.css
+++ b/express/code/blocks/color-wheel/image-extract.css
@@ -270,7 +270,7 @@
   position: relative;
   inset: auto;
   border-radius: 16px;
-  overflow: hidden;
+  overflow: visible;
   min-height: 360px;
   height: 490px;
   background: #f3f3f3;


### PR DESCRIPTION
## Summary

Remove cursor from extract markers when dragging

---

## Jira Ticket

Resolves: [MWPW-195800](https://jira.corp.adobe.com/browse/MWPW-195800)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/image |
| **After**   | https://methomas-cursor--express-color--adobecom.aem.live/create/image |
| **Before**  | https://main--express-color--adobecom.aem.live/create/image-gradient |
| **After**   | https://methomas-cursor--express-color--adobecom.aem.live/create/image-gradient |
| **Before**  | https://main--express-color--adobecom.aem.live/create/color-wheel |
| **After**   | https://methomas-cursor--express-color--adobecom.aem.live/create/color-wheel |


---

## Verification Steps

- Go to the page. On color wheel, click on the Image tab.
- Click on a suggested image or upload your own.
- Click and hold one of the markers.
- Before: Cursor snaps to the middle of the expanded color handle, hiding users' pixel selection.
- After: Cursor should should disappear until user releases it to make their pixel selection.

---

## Potential Regressions



---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
