### PR TITLE
Grid Marquee Test Fix

### DIFF
--- a/test/blocks/grid-marquee/grid-marquee.test.js
+++ b/test/blocks/grid-marquee/grid-marquee.test.js
@@ -16,8 +16,15 @@ const oldAuthoring = await readFile({ path: './mocks/old-authoring.html' });
 const newAuthoring = await readFile({ path: './mocks/new-authoring.html' });
 
 describe('Grid Marquee - Legacy vs New Authoring', () => {
+  let originalRAF;
   before(() => {
     window.isTestEnv = true;
+    originalRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb) => { cb(performance.now()); return 0; };
+  });
+
+  after(() => {
+    window.requestAnimationFrame = originalRAF;
   });
 
   it('Legacy mode (h1 inside grid-marquee) decorates headline and CTAs', async () => {
@@ -59,26 +66,16 @@ describe('Grid Marquee - Legacy vs New Authoring', () => {
     await decorateHero(hero);
     await decorateGrid(gm);
 
-    // Wait for async RAF-driven rendering of cards in new mode
-    // Poll briefly until cards container appears
-    const waitForCards = async (root, timeoutMs = 4000) => {
-      const start = performance.now();
-      return new Promise((resolve, reject) => {
-        const check = () => {
-          const el = root.querySelector('.cards-container');
-          if (el) return resolve(el);
-          if (performance.now() - start > timeoutMs) return reject(new Error('Timeout waiting for .cards-container'));
-          requestAnimationFrame(check);
-          return undefined;
-        };
-        check();
-      });
+    const waitForCards = (root) => {
+      const el = root.querySelector('.cards-container');
+      if (!el) throw new Error('.cards-container not found after decorateGrid');
+      return el;
     };
 
     const headlineInGM = gm.querySelector('.headline');
     const h1InGM = gm.querySelector('h1');
     const heroH1 = hero.querySelector('h1');
-    const cards = await waitForCards(gm);
+    const cards = waitForCards(gm);
 
     expect(heroH1).to.exist;
     expect(headlineInGM).to.not.exist;

--- a/test/blocks/grid-marquee/grid-marquee.test.js
+++ b/test/blocks/grid-marquee/grid-marquee.test.js
@@ -20,7 +20,10 @@ describe('Grid Marquee - Legacy vs New Authoring', () => {
   before(() => {
     window.isTestEnv = true;
     originalRAF = window.requestAnimationFrame;
-    window.requestAnimationFrame = (cb) => { cb(performance.now()); return 0; };
+    window.requestAnimationFrame = (cb) => {
+      cb(performance.now());
+      return 0;
+    };
   });
 
   after(() => {


### PR DESCRIPTION
  When Web Test Runner runs 207 test files in parallel, most Chrome tabs are in the
  background. Chrome throttles requestAnimationFrame to ~1fps for background tabs, so the RAF callback
   in grid-marquee.js that creates .cards-container wouldn't fire within mocha's 2000ms default
  timeout.

Here's what changed — only in the test file:

  - before: saves the real requestAnimationFrame, then replaces it with a synchronous stub that invokes the callback immediately
  - after: restores the original RAF so it doesn't affect other test files
  - waitForCards: stays a simple synchronous DOM lookup, since RAF now runs inline during decorateGrid

## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves N/A

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Verify that tests pass in the GH actions workflow

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
