### PR TITLE
MWPW-196048: AX Columns Acrobat logo injection

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -181,13 +181,20 @@ const LOGO_WHITE = 'adobe-express-logo-white';
 function injectLogo(block) {
   const injectRegularLogo = ['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase());
   const injectPhotoLogo = ['on', 'yes'].includes(getMetadata('marquee-inject-photo-logo')?.toLowerCase());
+  const injectAcrobatLogo = ['on', 'yes'].includes(getMetadata('marquee-inject-acrobat-logo')?.toLowerCase());
 
-  if (!injectRegularLogo && !injectPhotoLogo) return null;
+  if (!injectRegularLogo && !injectPhotoLogo && !injectAcrobatLogo) return null;
 
   let logo;
 
   if (injectPhotoLogo) {
     logo = getIconElementDeprecated('adobe-express-photos-logo');
+  } else if (injectAcrobatLogo) {
+    const logoName = 'cobrand-lockup-acrobat-express';
+    const logoSize = '22px';
+    const logoAlt = 'Adobe Acrobat X Adobe Express co-brand logo';
+    const logoClass = 'acrobat-express-lockup';
+    logo = getIconElementDeprecated(logoName, logoSize, logoAlt, logoClass);
   } else {
     const mediaQuery = window.matchMedia('(min-width: 900px)');
     logo = getIconElementDeprecated(block.classList.contains('dark') && mediaQuery.matches ? LOGO_WHITE : LOGO);

--- a/test/blocks/ax-columns/ax-columns.test.js
+++ b/test/blocks/ax-columns/ax-columns.test.js
@@ -16,11 +16,12 @@ await import(`${getLibs()}/utils/utils.js`).then((mod) => {
 const { default: decorate } = await import('../../../express/code/blocks/ax-columns/ax-columns.js');
 
 // eslint-disable-next-line max-len
-const [buttonLight, color, fullsize, highlight, icon, iconWithSibling, iconList, notHighlight, numbered30, offer, offerIcon, picture, video, marquee, fullsizeTwoButtons] = await Promise.all(
+const [buttonLight, color, fullsize, highlight, icon, iconWithSibling, iconList, notHighlight, numbered30, offer, offerIcon, picture, video, marquee, fullsizeTwoButtons, injectLogo] = await Promise.all(
   [readFile({ path: './mocks/button-light.html' }), readFile({ path: './mocks/color.html' }), readFile({ path: './mocks/fullsize.html' }), readFile({ path: './mocks/highlight.html' }),
     readFile({ path: './mocks/icon.html' }), readFile({ path: './mocks/icon-with-sibling.html' }), readFile({ path: './mocks/icon-list.html' }), readFile({ path: './mocks/not-highlight.html' }), readFile({ path: './mocks/numbered-30.html' }),
     readFile({ path: './mocks/offer.html' }), readFile({ path: './mocks/offer-icon.html' }), readFile({ path: './mocks/picture.html' }), readFile({ path: './mocks/video.html' }),
-    readFile({ path: './mocks/marquee.html' }), readFile({ path: './mocks/fullsize-two-buttons.html' })],
+    readFile({ path: './mocks/marquee.html' }), readFile({ path: './mocks/fullsize-two-buttons.html' }),
+    readFile({ path: './mocks/inject-logo.html' })],
 );
 
 describe('Columns', () => {
@@ -183,5 +184,49 @@ describe('Columns', () => {
     const secondaryButton = buttons[1];
     expect(secondaryButton.classList.contains('primary')).to.be.true;
     expect(secondaryButton.classList.contains('reverse')).to.be.true;
+  });
+});
+
+describe('Logo injection', () => {
+  function addMeta(name, content) {
+    const meta = document.createElement('meta');
+    meta.name = name;
+    meta.content = content;
+    document.head.appendChild(meta);
+  }
+
+  afterEach(() => {
+    document.head.querySelectorAll('meta[name^="marquee-inject"]').forEach((m) => m.remove());
+  });
+
+  it('Should inject the regular logo when marquee-inject-logo is on', async () => {
+    document.body.innerHTML = injectLogo;
+    addMeta('marquee-inject-logo', 'on');
+    const block = document.querySelector('.ax-columns');
+    await decorate(block);
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.exist;
+    expect(logo.classList.contains('icon-adobe-express-logo')).to.be.true;
+  });
+
+  it('Should inject the photo logo when marquee-inject-photo-logo is on', async () => {
+    document.body.innerHTML = injectLogo;
+    addMeta('marquee-inject-photo-logo', 'on');
+    const block = document.querySelector('.ax-columns');
+    await decorate(block);
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.exist;
+    expect(logo.classList.contains('icon-adobe-express-photos-logo')).to.be.true;
+  });
+
+  it('Should inject the acrobat co-brand logo when marquee-inject-acrobat-logo is on', async () => {
+    document.body.innerHTML = injectLogo;
+    addMeta('marquee-inject-acrobat-logo', 'on');
+    const block = document.querySelector('.ax-columns');
+    await decorate(block);
+    const logo = block.querySelector('.express-logo');
+    expect(logo).to.exist;
+    expect(logo.classList.contains('acrobat-express-lockup')).to.be.true;
+    expect(logo.alt).to.equal('Adobe Acrobat X Adobe Express co-brand logo');
   });
 });

--- a/test/blocks/ax-columns/mocks/inject-logo.html
+++ b/test/blocks/ax-columns/mocks/inject-logo.html
@@ -1,0 +1,12 @@
+<main>
+  <div>
+    <div class="ax-columns block">
+      <div>
+        <div>
+          <h2>Test heading</h2>
+          <p><a href="https://example.com" class="button con-button">Get started</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary

Add ability to inject Acrobat logo into the AX Columns block using metadata. Retain ability to inject Express logo and photo logo.

---

## Jira Ticket

Resolves: [MWPW-196048](https://jira.corp.adobe.com/browse/MWPW-196048)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/yolles/resume-no-inject |
| **After**   | https://mwpw-196048-acrobat-logo--da-express-milo--adobecom.aem.page/drafts/yolles/resume-no-inject?martech=off |

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/yolles/resume-logo-inject |
| **After**   | https://mwpw-196048-acrobat-logo--da-express-milo--adobecom.aem.page/drafts/yolles/resume-logo-inject?martech=off |

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/yolles/resume-photo-inject |
| **After**   | https://mwpw-196048-acrobat-logo--da-express-milo--adobecom.aem.page/drafts/yolles/resume-photo-inject?martech=off |

| Env | URL |
|-------------|-----|
| **Before**  |  https://main--da-express-milo--adobecom.aem.page/drafts/yolles/resume-acrobat-inject |
| **After**   | https://mwpw-196048-acrobat-logo--da-express-milo--adobecom.aem.page/drafts/yolles/resume-acrobat-inject?martech=off |

---

## Verification Steps

- Verify all existing before and after options are the same, that no inject, logo inject and photo inject show the correct logos in each.
- For Acrobat, the before won't show any logos, but after should show the Acrobat logo.

---

## Potential Regressions

- https://main--da-express-milo--adobecom.aem.live/express/create/resume?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
