### PR TITLE
Fix base swatch drag-over outline in color-swatch-rail

### DIFF
--- a/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
+++ b/express/code/libs/color-components/components/color-swatch-rail/styles.css.js
@@ -936,7 +936,7 @@ export const style = css`
   }
 
   
-  .swatch-column.base-color {
+  .swatch-column.base-color:not(.swatch-column--drag-over) {
     outline: none;
   }
 


### PR DESCRIPTION
## Summary

Fixes a CSS specificity bug where the base color swatch in `color-swatch-rail` never displayed the dashed drop-target outline when another swatch was dragged over it. `.swatch-column.base-color { outline: none }` was winning over `.swatch-column--drag-over { outline: 2px dashed ... }` on specificity, so the base swatch — by default the first one instantiated — silently never showed the drop indicator (the reorder itself still worked).

The selector now excludes the drag-over state: `.swatch-column.base-color:not(.swatch-column--drag-over)`.

---

## Jira Ticket

Resolves: [MWPW-194743](https://jira.corp.adobe.com/browse/MWPW-194743)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.page/create/color-wheel?milolibs=local |
| **After**   | https://color-wheel-palette-border-fix--express-color--adobecom.aem.page/create/color-wheel?milolibs=local |

---

## Verification Steps

- Open the color-wheel page on each URL.
- Grab the drag handle on any non-base swatch and drag it over the base swatch (the one with the base-color target icon — index 0 by default).
- **Before:** the base swatch shows no dashed outline while being hovered as a drop target. Every other swatch shows the dashed outline correctly. Dropping still reorders.
- **After:** the base swatch displays the same `2px dashed` blue outline as the other swatches during drag-over. Outline disappears on drag-leave/drop. Reorder behavior is unchanged.
- Reorder so the base swatch ends up at a different position (the base index follows the moved swatch) — confirm the outline still appears on it in its new position.

---

## Potential Regressions

- Static (non-drag) base-color appearance — confirm the base swatch still has no permanent outline at rest.
- Focus ring on the base swatch — confirm keyboard `:focus-visible` styling is unaffected.
- Other consumers of `color-swatch-rail` (color-blindness block, color-explore strips) — confirm base swatch rendering is unchanged.

---

## Additional Notes

One-line selector change in `express/code/libs/color-components/components/color-swatch-rail/styles.css.js`. No JS changes, no API changes.