### PR TITLE
Fix blog date locale formatting and invalid-date handling

### DIFF
--- a/express/code/blocks/blog-article-marquee/blog-article-marquee.js
+++ b/express/code/blocks/blog-article-marquee/blog-article-marquee.js
@@ -21,7 +21,7 @@ function getDateFormatter(language) {
 }
 
 function formatPublicationDate(dateStr, formatter) {
-  if (!dateStr || !formatter) return dateStr;
+  if (!dateStr || !formatter) return '';
   const trimmed = dateStr.trim();
   const isTimestamp = /^\d+$/.test(trimmed);
   let publicationDate;

--- a/express/code/blocks/blog-article-marquee/blog-article-marquee.js
+++ b/express/code/blocks/blog-article-marquee/blog-article-marquee.js
@@ -34,7 +34,7 @@ function formatPublicationDate(dateStr, formatter) {
       publicationDate = new Date(Date.UTC(y, m - 1, d));
     }
   }
-  if (!publicationDate || Number.isNaN(publicationDate.getTime())) return dateStr;
+  if (!publicationDate || Number.isNaN(publicationDate.getTime())) return '';
   return formatter.format(publicationDate);
 }
 

--- a/express/code/blocks/blog-article-marquee/blog-article-marquee.js
+++ b/express/code/blocks/blog-article-marquee/blog-article-marquee.js
@@ -2,6 +2,7 @@ import { getLibs } from '../../scripts/utils.js';
 
 let createTag;
 let getMetadata;
+let getConfig;
 
 const MOBILE_MAX = 600;
 const TABLET_MAX = 900;
@@ -9,6 +10,33 @@ const HERO_IMAGE_WIDTHS = { mobile: 480, tablet: 720, desktop: 960 };
 const PRECONNECT_DATA_ATTRIBUTE = 'blogArticleMarquee';
 const DEFAULT_PRODUCT_ICON_PATH = '/express/code/icons/fallback_author_icon.png';
 const PRODUCT_ICON_SIZE = 48;
+
+function getDateFormatter(language) {
+  return Intl.DateTimeFormat(language, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function formatPublicationDate(dateStr, formatter) {
+  if (!dateStr || !formatter) return dateStr;
+  const trimmed = dateStr.trim();
+  const isTimestamp = /^\d+$/.test(trimmed);
+  let publicationDate;
+  if (isTimestamp) {
+    publicationDate = new Date(Number(trimmed) * 1000);
+  } else {
+    const parts = trimmed.split('/');
+    if (parts.length === 3) {
+      const [m, d, y] = parts.map(Number);
+      publicationDate = new Date(Date.UTC(y, m - 1, d));
+    }
+  }
+  if (!publicationDate || Number.isNaN(publicationDate.getTime())) return dateStr;
+  return formatter.format(publicationDate);
+}
 
 const METADATA_KEYS = {
   eyebrow: 'category',
@@ -463,11 +491,15 @@ function prepareStructure(block) {
 }
 
 export default async function decorate(block) {
-  ({ createTag, getMetadata } = await import(`${getLibs()}/utils/utils.js`));
+  ({ createTag, getMetadata, getConfig } = await import(`${getLibs()}/utils/utils.js`));
   const { decorateButtons } = await import(`${getLibs()}/utils/decorate.js`);
   block.classList.add('blog-article-marquee');
 
   const metadata = getBlogArticleMarqueeMetadata();
+  if (metadata.date) {
+    const formatter = getDateFormatter(getConfig().locale.ietf);
+    metadata.date = formatPublicationDate(metadata.date, formatter);
+  }
 
   const {
     wrapper,

--- a/express/code/blocks/blog-posts-v2/blog-posts-v2.js
+++ b/express/code/blocks/blog-posts-v2/blog-posts-v2.js
@@ -337,8 +337,17 @@ async function getReadMoreString() {
 function getCardParameters(post, dateFormatter) {
   const path = post.path.split('.')[0];
   const { title, teaser, image } = post;
-  const publicationDate = new Date(post.date * 1000);
-  const dateString = dateFormatter.format(publicationDate);
+  const normalizedDate = typeof post.date === 'string' ? post.date.trim() : post.date;
+  const hasTimestamp = (typeof normalizedDate === 'number' && Number.isFinite(normalizedDate))
+    || (typeof normalizedDate === 'string' && /^\d+$/.test(normalizedDate));
+  const timestamp = hasTimestamp ? Number(normalizedDate) : NaN;
+  let dateString = '';
+  if (Number.isFinite(timestamp) && timestamp > 0) {
+    const publicationDate = new Date(timestamp * 1000);
+    if (!Number.isNaN(publicationDate.getTime())) {
+      dateString = dateFormatter.format(publicationDate);
+    }
+  }
   const filteredTitle = title.replace(/(\s?)(｜|\|)(\s?Adobe\sExpress\s?)$/g, '');
   const imagePath = image.split('?')[0].split('_')[1];
   return {
@@ -362,6 +371,7 @@ async function getHeroCard(post, dateFormatter, blogTag) {
   imageWrapper.appendChild(heroPicture);
 
   const pictureTag = imageWrapper.outerHTML;
+  const dateMarkup = dateString ? `<p class="blog-card-date">${dateString}</p>` : '';
   card.innerHTML = `<div class="blog-card-image">
     ${pictureTag}
     <span class="blog-tag">${blogTag}</span>
@@ -369,7 +379,7 @@ async function getHeroCard(post, dateFormatter, blogTag) {
     <div class="blog-hero-card-body">
       <h3 class="blog-card-title">${filteredTitle}</h3>
       <p class="blog-card-teaser">${teaser}</p>
-      <p class="blog-card-date">${dateString}</p>
+      ${dateMarkup}
       <p class="blog-card-cta button-container">
         <a href="${path}" title="${readMoreString}" class="button accent">${readMoreString}</a></p>
     </div>`;
@@ -389,6 +399,7 @@ function getCard(post, dateFormatter, blogTag) {
   imageWrapper.appendChild(cardPicture);
 
   const pictureTag = imageWrapper.outerHTML;
+  const dateMarkup = dateString ? `<p class="blog-card-date">${dateString}</p>` : '';
   card.innerHTML = `<div class="blog-card-image">
         ${pictureTag}
         <span class="blog-tag">${blogTag}</span>
@@ -396,7 +407,7 @@ function getCard(post, dateFormatter, blogTag) {
         <section class="blog-card-body">
         <h3 class="blog-card-title">${filteredTitle}</h3>
         <p class="blog-card-teaser">${teaser}</p>
-        <p class="blog-card-date">${dateString}</p>
+        ${dateMarkup}
         </section>`;
   return card;
 }

--- a/test/blocks/blog-article-marquee/blog-article-marquee.test.js
+++ b/test/blocks/blog-article-marquee/blog-article-marquee.test.js
@@ -199,6 +199,31 @@ describe('Blog Article Marquee block', () => {
     expect(buttonContainer).to.not.exist;
   });
 
+  it('formats a unix timestamp publication date using the locale formatter', async () => {
+    const block = document.getElementById('blog-article-marquee-block');
+    const dateMeta = document.head.querySelector('meta[name="publication-date"]');
+    dateMeta?.setAttribute('content', '1729382400');
+
+    await decorate(block);
+
+    const productDate = block.querySelector('.blog-article-marquee-product-date');
+    expect(productDate).to.exist;
+    const expected = Intl.DateTimeFormat('en-US', {
+      day: '2-digit', month: '2-digit', year: 'numeric', timeZone: 'UTC',
+    }).format(new Date(1729382400 * 1000));
+    expect(productDate.textContent.trim()).to.equal(expected);
+  });
+
+  it('suppresses the date element when publication date is unparseable', async () => {
+    const block = document.getElementById('blog-article-marquee-block');
+    const dateMeta = document.head.querySelector('meta[name="publication-date"]');
+    dateMeta?.setAttribute('content', 'not-a-date');
+
+    await decorate(block);
+
+    expect(block.querySelector('.blog-article-marquee-product-date')).to.not.exist;
+  });
+
   it('omits product highlight when product metadata is absent', async () => {
     const block = document.getElementById('blog-article-marquee-block');
     ['author', 'publication-date', 'description', 'tags']

--- a/test/blocks/blog-posts-v2/blog-posts-v2.test.js
+++ b/test/blocks/blog-posts-v2/blog-posts-v2.test.js
@@ -319,6 +319,58 @@ describe('Blog Posts V2 Block', () => {
     }
   });
 
+  it('should not render a date when post date is invalid', async () => {
+    const invalidDatePost = {
+      path: '/blog/invalid-date-post.html',
+      title: 'Invalid Date Post',
+      teaser: 'Post teaser with invalid date',
+      image: 'test_image1.jpg',
+      date: '',
+      tags: '["design"]',
+      category: 'Design',
+    };
+    const validDatePost = {
+      path: '/blog/valid-date-post.html',
+      title: 'Valid Date Post',
+      teaser: 'Post teaser with valid date',
+      image: 'test_image2.jpg',
+      date: 1641081600,
+      tags: '["design"]',
+      category: 'Design',
+    };
+    const mockBlogData = {
+      data: [invalidDatePost, validDatePost],
+      byPath: {
+        '/blog/invalid-date-post': invalidDatePost,
+        '/blog/valid-date-post': validDatePost,
+      },
+    };
+
+    fetchStub.resolves({
+      ok: true,
+      json: () => Promise.resolve(mockBlogData),
+    });
+
+    document.body.innerHTML = `
+      <div class="blog-posts-v2">
+        <div>
+          <div>
+            <a href="/blog/invalid-date-post.html">Invalid Date Post</a>
+            <a href="/blog/valid-date-post.html">Valid Date Post</a>
+          </div>
+        </div>
+      </div>
+    `;
+    const invalidDateBlock = document.querySelector('.blog-posts-v2');
+    await decorate(invalidDateBlock);
+
+    const invalidCard = [...invalidDateBlock.querySelectorAll('.blog-card')].find(
+      (card) => card.href.includes('/blog/invalid-date-post'),
+    );
+    expect(invalidCard).to.exist;
+    expect(invalidCard.querySelector('.blog-card-date')).to.not.exist;
+  });
+
   it('should handle view all link localization', async () => {
     // Mock blog index data
     const mockBlogData = {


### PR DESCRIPTION
## Summary

- **blog-article-marquee:** Adds locale-aware date formatting using `Intl.DateTimeFormat` (lifted from `blog-posts-v2`). Publication date from page metadata is now formatted to the visitor's locale standard (e.g. `10/20/2025` → `20/10/2025` for `en-GB`). Unrecognized/unparseable date formats now return an empty string (suppressing the element) rather than rendering the raw metadata string verbatim.
- **blog-posts-v2:** Hardens date handling to guard against missing, zero, or non-numeric `post.date` values from the query index. Cards with invalid dates no longer render an empty `<p class="blog-card-date">` tag.

---

## Jira Ticket

Resolves: [MWPW-194551](https://jira.corp.adobe.com/browse/MWPW-194551)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/learn/blog/introducing-creative-cloud-express |
| **After**   | https://blog-date-bug--da-express-milo--adobecom.aem.page/express/learn/blog/introducing-creative-cloud-express?martech=off |

---

## Verification Steps

- Open the After URL and confirm the publication date in the blog article marquee is formatted to the visitor's locale standard (e.g. switch browser language to `en-GB` and confirm day/month order changes).
- On a blog-posts-v2 page, confirm cards still display dates correctly and no empty date elements appear.

---

## Potential Regressions

- (default locale, should expect no regressions) https://blog-date-bug--da-express-milo--adobecom.aem.page/express/learn/blog/introducing-creative-cloud-express?martech=off
- 
- (de locale, expect different date format) https://blog-date-bug--da-express-milo--adobecom.aem.page/de/express/learn/blog/introducing-creative-cloud-express?martech=off

---

## Additional Notes

N/A