### PR TITLE
Susi Light Width Fix

### DIFF
--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -5,8 +5,10 @@
   --susi-standard-padding: 24px;
 }
 
+
 .susi-light {
   display: flex;
+  width: 100%;
   align-items: center;
   justify-content: center;
   line-height: initial;
@@ -15,6 +17,7 @@
 
 .susi-layout {
   display: flex;
+  width: 100%;
   flex-direction: column;
   align-items: center;
   text-align: center;
@@ -135,6 +138,10 @@
 .susi-light.student .susi-wrapper {
   min-height: 421.5px;
   width: var(--susi-modal-width);
+}
+
+.susi-light.color .susi-wrapper {
+  width: 100%;
 }
 
 /* student styles */

--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -89,7 +89,7 @@
 .susi-light.tabs [role='tablist'] {
   margin-top: var(--spacing-300);
   border-radius: 8px;
-  padding: var(--spacing-75);
+  padding: 4px;
   display: flex;
   gap: var(--spacing-75);
   background-color: var(--susi-grey);
@@ -202,9 +202,11 @@
 .section.ax-login-page .susi-light {
   padding-bottom: var(--spacing-700);
 }
+
 .section.ax-login-page .susi-light.b2b {
   width: var(--susi-modal-width);
 }
+
 .section.ax-login-page .susi-layout .footer {
   border-radius: 8px;
 }
@@ -219,6 +221,7 @@
     position: absolute;
     padding-top: 30px;
   }
+
   .section.ax-login-page .susi-layout .footer {
     border-radius: 0 0 16px 16px;
   }

--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -43,7 +43,7 @@
   font-size: var(--body-font-size-s);
   text-align: center;
   font-weight: 700;
-  color: #292929;
+  color: var(--color-gray-800-variant);
 }
 
 .susi-layout .footer a {
@@ -82,16 +82,16 @@
   display: flex;
   flex-direction: column;
   font-size: var(--body-font-size-s);
-  background-color: #f3f3f3;
+  background-color: var(--color-gray-150);
 }
 
 /* tabs styles */
 .susi-light.tabs [role='tablist'] {
   margin-top: var(--spacing-300);
   border-radius: 8px;
-  padding: 4px;
+  padding: var(--spacing-75);
   display: flex;
-  gap: 4px;
+  gap: var(--spacing-75);
   background-color: var(--susi-grey);
 }
 
@@ -106,7 +106,7 @@
   font-size: var(--body-font-size-xs);
   font-weight: 700;
   background-color: var(--susi-grey);
-  color: #222222;
+  color: var(--color-gray-900);
   line-height: 130%;
   cursor: pointer;
 }
@@ -171,7 +171,7 @@
   font-size: var(--body-font-size-s);
   padding: 0 var(--susi-standard-padding);
   line-height: 1.3;
-  color: #464646;
+  color: var(--color-gray-700-variant);
 }
 
 /* modal styles */

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -426,8 +426,6 @@
 }
 
 body {
-  -webkit-text-size-adjust: 100%;
-  text-size-adjust: 100%;
   background-color: var(--body-background-color);
 }
 

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -426,6 +426,8 @@
 }
 
 body {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   background-color: var(--body-background-color);
 }
 


### PR DESCRIPTION
## Summary

Fixes layout/padding issues in the `susi-light` block by ensuring `.susi-light` and `.susi-layout` take full width, and adding a specific `width: 100%` override for `.susi-light.color .susi-wrapper`. Also applies CSS variable token fixes (colors + spacing) per the lint-css rules.

---

## Jira Ticket

Resolves: [MWPW-194373](https://jira.corp.adobe.com/browse/MWPW-194373)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/explore?env=prod |
| **After**   | https://susi-padding-fix--express-color--adobecom.aem.live/explore?env=prod |

---

## Verification Steps

- Navigate to the After URL (VPN required — susi buttons may not load without it)
- Confirm the susi-light color variant renders with correct full-width padding layout
- Compare against the Before URL to verify the padding/alignment fix

---

## Potential Regressions

- https://susi-padding-fix--express-color--adobecom.aem.live/create/color-wheel?env=prod
- https://susi-padding-fix--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/susi-light
- https://susi-padding-fix--da-express-milo--adobecom.aem.page/uk/express/fragments/susi-light-student
- https://susi-padding-fix--da-express-milo--adobecom.aem.page/dk/education/express/#susi-light-3
- https://susi-padding-fix--da-express-milo--adobecom.aem.page/it/express/fragments/susi-light-teacher

vs

- https://main--express-color--adobecom.aem.live/create/color-wheel?env=prod
- https://main--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/susi-light
- https://main-da-express-milo--adobecom.aem.page/uk/express/fragments/susi-light-student
- https://main--da-express-milo--adobecom.aem.page/dk/education/express/#susi-light-3
- https://mai--da-express-milo--adobecom.aem.page/it/express/fragments/susi-light-teacher

---

## Additional Notes

**Note:** VPN is required when testing — susi buttons may not load without it. 