### PR TITLE
MWPW-194417 Fix mobile spacing issues on banner-bg, color-extract, how-to-v2

### DIFF
--- a/express/code/blocks/banner-bg/banner-bg.css
+++ b/express/code/blocks/banner-bg/banner-bg.css
@@ -54,7 +54,7 @@
   border: var(--border-width-2) solid var(--color-white);
   background: linear-gradient(95deg, rgba(255, 255, 255, 0.80) 18%, rgba(255, 255, 255, 0.40) 93%);
   padding: var(--spacing-600) var(--spacing-500);
-  width: calc(100vw - var(--spacing-500));
+  width: 100%;
   box-sizing: border-box;
   max-width: none;
 }
@@ -65,7 +65,7 @@
   background: linear-gradient(var(--color-black), var(--color-black)) padding-box,
     linear-gradient(90deg, var(--color-green-800), var(--color-blue-800), var(--color-purple-1000), var(--color-orange-700)) border-box;
   padding: var(--spacing-600) var(--spacing-500);
-  width: calc(100vw - var(--spacing-500));
+  width: 100%;
   box-sizing: border-box;
   max-width: none;
 }
@@ -250,7 +250,7 @@
 
   .banner-bg[class*="-bg"] .background-container {
     padding: var(--spacing-700) var(--spacing-500);
-    width: calc(100vw - var(--spacing-800));
+    width: 100%;
   }
 
   /* Paragraph styling for background variants */

--- a/express/code/blocks/color-extract/color-extract.css
+++ b/express/code/blocks/color-extract/color-extract.css
@@ -993,7 +993,6 @@ body:has(.color-headline.extract) .color-extract .color-extract-landing-bg {
   .section:has(.color-extract-marquee-wrapper) {
     align-items: center;
     min-height: 800px;
-    padding-inline: 0;
   }
 
   .color-extract .color-extract-landing {

--- a/express/code/blocks/how-to-v2/how-to-v2.css
+++ b/express/code/blocks/how-to-v2/how-to-v2.css
@@ -184,12 +184,10 @@ main .section:has(.how-to-v2) .content em {
   margin-right: auto;
 }
 
-@media (min-width: 400px) {
-  main:has(.how-to-v2) .content {
-    max-width: unset;
-    margin-left: 20px;
-    margin-right: 20px;
-  }
+main:has(.how-to-v2) .content {
+  max-width: unset;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary

Fix various spacing issues on color extract page:
1. In the extract block, the paragraph text ("Upload a photo to extract...") now has the correct left/right padding for tablet.
2. In the cool banner bg block ("Bring your colors to life in Adobe Express"), the centering was fixed for the rainbow ring, so it now has even padding left/right on all breakpoints.
3. The heading above the how-to block now has the same left/right spacing on small phones as it does on other breakpoints.

---

## Jira Ticket

Resolves: [MWPW-194417](https://jira.corp.adobe.com/browse/MWPW-194417)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/create/image  |
| **After**   | https://methomas-padding--express-color--adobecom.aem.live/create/image?martech=off |

---

## Verification Steps

- In the extract block, the paragraph text ("Upload a photo to extract...") now has the correct left/right padding for tablet.
- In the cool banner bg block ("Bring your colors to life in Adobe Express"), the rainbow ring is centered and the block now has even padding left/right on all breakpoints. Issue seen at 1400px.
- The heading above the how-to block now has the same left/right spacing on small phones as it does on other breakpoints.

---

## Potential Regressions

- https://methomas-padding--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/how-to-v2
- https://methomas-padding--da-express-milo--adobecom.aem.page/docs/library/kitchen-sink/banner-bg

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
