### PR TITLE
MWPW-194817: keep dashed border visible on resize in firefox

### DIFF
--- a/express/code/scripts/color-shared/components/image-upload/image-upload.css
+++ b/express/code/scripts/color-shared/components/image-upload/image-upload.css
@@ -25,6 +25,8 @@
 }
 
 .image-upload-dropzone-border-svg rect {
+  width: calc(100% - 1px);
+  height: calc(100% - 1px);
   stroke: var(--dropzone-border-color);
   stroke-width: 1px;
   stroke-dasharray: 4px 4px;

--- a/express/code/scripts/color-shared/components/image-upload/image-upload.js
+++ b/express/code/scripts/color-shared/components/image-upload/image-upload.js
@@ -68,8 +68,8 @@ export function createUploadDropzone(options = {}) {
   const borderRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
   borderRect.setAttribute('x', '0.5');
   borderRect.setAttribute('y', '0.5');
-  borderRect.setAttribute('width', 'calc(100% - 1px)');
-  borderRect.setAttribute('height', 'calc(100% - 1px)');
+  borderRect.setAttribute('width', '100%');
+  borderRect.setAttribute('height', '100%');
   borderRect.setAttribute('rx', '16');
   borderRect.setAttribute('ry', '16');
   borderRect.setAttribute('fill', 'none');


### PR DESCRIPTION
## Summary

Fixes the image upload dropzone dashed SVG border disappearing or failing to track the container on resize in **Firefox**.

**Root cause:** `width` / `height` used `calc(100% - 1px)` as **SVG presentation attributes**. Firefox applies that on first paint but does not reliably re-resolve attribute `calc()` on reflow, so the border could vanish or stop resizing.

**Fix (two layers):**
1. **JS** — Use `width` / `height` of `100%` on the border `<rect>` (no `calc()` in attributes). Keeps valid rect geometry on resize in Firefox.
2. **CSS** — Set `width` / `height` to `calc(100% - 1px)` on `.image-upload-dropzone-border-svg rect` for the 1px stroke inset. Requires the JS `100%` attributes as a baseline; CSS-only sizing breaks in Firefox (rect collapses / border only on top-left).
3. **JS** — Keep `x` / `y` at `0.5` for a crisp 1px stroke on the top-left.

Existing CSS (`overflow: visible`, `vector-effect: non-scaling-stroke`) is unchanged.

---

## Jira Ticket

Resolves: [MWPW-194817](https://jira.corp.adobe.com/browse/MWPW-194817)

---

## Test URLs

| Env | URL |
|-----|-----|
| **Before** | https://stage--express-color--adobecom.aem.live/drafts/sircar/color-wheel |
| **After** | https://mwpw-194817-firefox-color-border-fix--express-color--adobecom.aem.live/drafts/sircar/color-wheel?martech=off |

---

## Verification Steps

1. Open the **Before** and **After** URLs above.
2. Select the **Image** tab and locate the upload dropzone (dashed border).
3. Resize the browser window several times, especially in **Firefox**.
4. **Before:** Dashed border can disappear or stop matching the dropzone on resize.
5. **After:**
   - Full dashed border on all four sides at any size.
   - Border tracks the dropzone on resize (Firefox, Chrome, Safari).
   - Hover, focus, and drag-highlight states still look correct.

---

## Potential Regressions

- https://mwpw-194817-firefox-color-border-fix--express-color--adobecom.aem.live/drafts/sircar/color-wheel?martech=off
- Other consumers of `createUploadDropzone` (e.g. color-extract) — confirm dashed border and resize behavior.

---

## Additional Notes

| Approach | Result |
|----------|--------|
| `calc()` in SVG **attributes** | Firefox resize bug |
| `calc()` in **CSS only** (no JS width/height) | Broken in Firefox (incomplete border) |
| JS `100%` + CSS `calc(100% - 1px)` | Intended fix |

Do not move `calc()` back into JS attributes. Do not remove JS `width` / `height="100%"` while using CSS `calc`.
