### PR TITLE
MWPW-197621: Acrobat logo inject on grid marquee

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -12,6 +12,7 @@
   width: initial;
   height: 30px;
   padding: 1rem 0 1rem;
+  max-width: 340px;
 }
 
 main .section .grid-marquee h1 {
@@ -325,7 +326,7 @@ main .section .grid-marquee.pricing-page h1 {
   line-height: 130%;
   text-align: center;
   padding-bottom: var(--padding-bottom);
- 
+
 }
 .grid-marquee.pricing-page .express-logo {
   padding: 0px 0px var(--spacing-300) 0px
@@ -506,7 +507,7 @@ main .section .grid-marquee.pricing-page h1 {
   .grid-marquee.pricing-page .headline {
     max-width: var(--ax-grid-6-col-width);
   }
-  
+
 }
 
 

--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -11,7 +11,7 @@
 .grid-marquee .express-logo {
   width: initial;
   height: 30px;
-  padding: 1rem 0 1rem;
+  padding: 2rem 0 1rem;
   max-width: 340px;
 }
 

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -1,5 +1,6 @@
 import { getLibs, yieldToMain, getMobileOperatingSystem, getIconElementDeprecated, createTag, formatDynamicCartLink } from '../../scripts/utils.js';
 
+let getMetadata;
 let currDrawer = null;
 const largeMQ = window.matchMedia('(min-width: 1280px)');
 const mediumMQ = window.matchMedia('(min-width: 768px)');
@@ -254,6 +255,9 @@ async function makeRatings(
 }
 
 export default async function init(el) {
+  await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
+    ({ getMetadata } = utils);
+  });
   const rows = [...el.querySelectorAll(':scope > div')];
   const hasLegacyHeadline = !!rows[0]?.querySelector('h1');
   const foreground = createTag('div', { class: 'foreground' });
@@ -305,7 +309,19 @@ export default async function init(el) {
   // Legacy mode: headline + background + items inside this block
   if (hasLegacyHeadline) {
     const [headline, background, ...items] = rows;
-    const logo = getIconElementDeprecated('adobe-express-logo');
+    const injectAcrobatLogo = ['on', 'yes'].includes(getMetadata('marquee-inject-acrobat-logo')?.toLowerCase());
+    let logo;
+
+    if (injectAcrobatLogo) {
+      const logoName = 'cobrand-lockup-acrobat-express';
+      const logoSize = '22px';
+      const logoAlt = 'Adobe Acrobat X Adobe Express co-brand logo';
+      const logoClass = 'marquee-eyebrow-logo-wide';
+      logo = getIconElementDeprecated(logoName, logoSize, logoAlt, logoClass);
+    } else {
+      logo = getIconElementDeprecated('adobe-express-logo');
+    }
+
     logo.classList.add('express-logo');
 
     background.classList.add('background');

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -1,6 +1,13 @@
-import { getLibs, yieldToMain, getMobileOperatingSystem, getIconElementDeprecated, createTag, formatDynamicCartLink } from '../../scripts/utils.js';
+import {
+  getLibs,
+  yieldToMain,
+  getMobileOperatingSystem,
+  getIconElementDeprecated,
+  createTag,
+  formatDynamicCartLink,
+  getMetadata,
+} from '../../scripts/utils.js';
 
-let getMetadata;
 let currDrawer = null;
 const largeMQ = window.matchMedia('(min-width: 1280px)');
 const mediumMQ = window.matchMedia('(min-width: 768px)');
@@ -255,9 +262,6 @@ async function makeRatings(
 }
 
 export default async function init(el) {
-  await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
-    ({ getMetadata } = utils);
-  });
   const rows = [...el.querySelectorAll(':scope > div')];
   const hasLegacyHeadline = !!rows[0]?.querySelector('h1');
   const foreground = createTag('div', { class: 'foreground' });


### PR DESCRIPTION
## Summary

Add the ability to inject the Acrobat cobranding logo on the grid marquee block just like we have on AX Columns and Interactive Marquee. Ensure the image doesn't encroach on the browser border in mobile.

---

## Jira Ticket

Resolves: [MWPW-197621](https://jira.corp.adobe.com/browse/MWPW-197621)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/drafts/yolles/homepage |
| **After**   | https://mwpw-197621-acrobat-grit-marquee--da-express-milo--adobecom.aem.page/drafts/yolles/homepage?martech=off |


| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/drafts/yolles/homepage-acrobat-logo |
| **After**   | https://mwpw-197621-acrobat-grit-marquee--da-express-milo--adobecom.aem.page/drafts/yolles/homepage-acrobat-logo?martech=off |

---

## Verification Steps

- Ensure homepage without metadata logo injection shows the Express logo
- Ensure page with metadata logo injections hows the Acrobat logo
- Test in desktop and mobile

---

## Potential Regressions

- https://main--da-express-milo--adobecom.aem.live/express/?martech=off
