### PR TITLE
Extend mobile fork button dismissable to iOS

### DIFF
--- a/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
+++ b/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
@@ -1,6 +1,6 @@
 import { getLibs, getMobileOperatingSystem, getIconElementDeprecated, addTempWrapperDeprecated } from '../../scripts/utils.js';
 import { createFloatingButton } from '../../scripts/widgets/floating-cta.js';
-import { createMultiFunctionButton, androidCheck, collectFloatingButtonData, createMetadataMap } from '../../scripts/utils/mobile-fork-button-utils.js';
+import { createMultiFunctionButton, androidCheck, collectFloatingButtonData, createMetadataMap, SUPPORTED_MWEB_OS } from '../../scripts/utils/mobile-fork-button-utils.js';
 
 let createTag; let getMetadata;
 
@@ -36,9 +36,20 @@ function mWebOverlayScroll() {
   const mobileForkButton = document.querySelector('.mobile-fork-button.mweb-mobile-fork');
   if (mobileForkButton
     && window.getComputedStyle(mobileForkButton, null).display !== 'none') {
+    const scrollY = window.scrollY || 0;
+    document.body.dataset.scrollY = scrollY;
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
     document.body.style.overflow = 'hidden';
   } else {
+    const scrollY = parseInt(document.body.dataset.scrollY || '0', 10);
+    document.body.style.top = '';
+    document.body.style.position = '';
+    document.body.style.width = '';
     document.body.style.overflow = '';
+    window.scrollTo(0, scrollY);
+    delete document.body.dataset.scrollY;
   }
 }
 
@@ -65,7 +76,7 @@ function mWebCloseEvents() {
 }
 
 function mWebVariant() {
-  if (!['Android', 'iOS'].includes(getMobileOperatingSystem())) return;
+  if (!SUPPORTED_MWEB_OS.includes(getMobileOperatingSystem())) return;
   mWebBuildElements();
   mWebCloseEvents();
   mWebOverlayScroll();

--- a/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
+++ b/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
@@ -65,7 +65,7 @@ function mWebCloseEvents() {
 }
 
 function mWebVariant() {
-  if (getMobileOperatingSystem() !== 'Android') return;
+  if (!['Android', 'iOS'].includes(getMobileOperatingSystem())) return;
   mWebBuildElements();
   mWebCloseEvents();
   mWebOverlayScroll();

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -4,6 +4,7 @@
  */
 
 export const LONG_TEXT_CUTOFF = 70;
+export const SUPPORTED_MWEB_OS = ['Android', 'iOS'];
 
 /**
  * Calculates the pixel width of text for a given font
@@ -50,7 +51,7 @@ export function buildAction(createTag, entry, buttonType) {
 }
 
 /**
- * Checks if the device is an Android, enables the mobile gating if it is.
+ * Checks if the device OS is eligible for the mobile fork button.
  * If there is no metadata check enabled, still enable the gating block in case authors want it.
  * @param {Function} getMetadata - Function to get metadata
  * @param {Function} getMobileOperatingSystem - Function to get mobile OS
@@ -58,7 +59,7 @@ export function buildAction(createTag, entry, buttonType) {
  */
 export function androidCheck(getMetadata, getMobileOperatingSystem) {
   if (getMetadata('fork-eligibility-check')?.toLowerCase()?.trim() !== 'on') return true;
-  return getMobileOperatingSystem() === 'Android';
+  return SUPPORTED_MWEB_OS.includes(getMobileOperatingSystem());
 }
 
 /**

--- a/test/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.test.js
+++ b/test/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.test.js
@@ -96,8 +96,12 @@ describe('Mobile Fork Button', () => {
 
   it('renders button with both fork-cta-1 and fork-cta-2 metadata and fork-cta-3 metadata', async () => {
     setDocumentMetadata(true, true);
-    await buildAutoBlocks();
-    const b = document.querySelector('.floating-button');
+    document.body.dataset.device = 'mobile';
+    // Mirror the authored DOM: the fork block lives inside a section.
+    document.body.innerHTML = '<main><div class="section">'
+      + '<div class="mobile-fork-button-dismissable meta-powered"><div>mobile</div></div>'
+      + '</div></main>';
+    const b = document.querySelector('.mobile-fork-button-dismissable');
 
     await decorate(b);
 
@@ -114,6 +118,31 @@ describe('Mobile Fork Button', () => {
     expect(secondRow.querySelector('a').textContent).to.equal('Free Version');
     expect(secondRow.querySelector('.mobile-gating-text').textContent).to.equal('Test');
 
+    const closeButton = blockWrapper.querySelector('.mweb-close');
+    expect(closeButton).to.exist;
+    expect(document.body.style.overflow).to.equal('hidden');
+    closeButton.click();
+    expect(document.body.style.overflow).to.equal('');
+    const newWrapper = document.querySelector('.floating-button.meta-powered');
+    expect(newWrapper).to.exist;
+  });
+
+  it('builds the dismissible close button and overlay on iOS', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      configurable: true,
+    });
+    document.body.dataset.device = 'mobile';
+    setDocumentMetadata(true);
+    // Mirror the authored DOM: the fork block lives inside a section.
+    document.body.innerHTML = '<main><div class="section">'
+      + '<div class="mobile-fork-button-dismissable meta-powered"><div>mobile</div></div>'
+      + '</div></main>';
+    const b = document.querySelector('.mobile-fork-button-dismissable');
+
+    await decorate(b);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
     const closeButton = blockWrapper.querySelector('.mweb-close');
     expect(closeButton).to.exist;
     expect(document.body.style.overflow).to.equal('hidden');

--- a/test/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.test.js
+++ b/test/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.test.js
@@ -11,7 +11,7 @@ const imports = await Promise.all([
 ]);
 const { default: decorate } = imports[1];
 
-function setDocumentMetadata(includeForkCta2 = true, includForkCta3 = false) {
+function setDocumentMetadata(includeForkCta2 = true, includForkCta3 = false, includeEligibilityCheck = false) {
   const metadata = {
     'floating-cta-live': 'Y',
     'show-floating-cta': 'yes',
@@ -39,12 +39,24 @@ function setDocumentMetadata(includeForkCta2 = true, includForkCta3 = false) {
     metadata['cta-1-link'] = 'https://adobesparkpost-web.app.link/';
   }
 
+  if (includeEligibilityCheck) {
+    metadata['fork-eligibility-check'] = 'on';
+  }
+
   Object.entries(metadata).forEach(([name, content]) => {
     const meta = document.createElement('meta');
     meta.name = name;
     meta.content = content;
     document.head.appendChild(meta);
   });
+}
+
+function setMobileDom() {
+  document.body.dataset.device = 'mobile';
+  document.body.innerHTML = '<main><div class="section">'
+    + '<div class="mobile-fork-button-dismissable meta-powered"><div>mobile</div></div>'
+    + '</div></main>';
+  return document.querySelector('.mobile-fork-button-dismissable');
 }
 
 describe('Mobile Fork Button', () => {
@@ -96,12 +108,7 @@ describe('Mobile Fork Button', () => {
 
   it('renders button with both fork-cta-1 and fork-cta-2 metadata and fork-cta-3 metadata', async () => {
     setDocumentMetadata(true, true);
-    document.body.dataset.device = 'mobile';
-    // Mirror the authored DOM: the fork block lives inside a section.
-    document.body.innerHTML = '<main><div class="section">'
-      + '<div class="mobile-fork-button-dismissable meta-powered"><div>mobile</div></div>'
-      + '</div></main>';
-    const b = document.querySelector('.mobile-fork-button-dismissable');
+    const b = setMobileDom();
 
     await decorate(b);
 
@@ -132,13 +139,8 @@ describe('Mobile Fork Button', () => {
       value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
       configurable: true,
     });
-    document.body.dataset.device = 'mobile';
     setDocumentMetadata(true);
-    // Mirror the authored DOM: the fork block lives inside a section.
-    document.body.innerHTML = '<main><div class="section">'
-      + '<div class="mobile-fork-button-dismissable meta-powered"><div>mobile</div></div>'
-      + '</div></main>';
-    const b = document.querySelector('.mobile-fork-button-dismissable');
+    const b = setMobileDom();
 
     await decorate(b);
 
@@ -150,5 +152,21 @@ describe('Mobile Fork Button', () => {
     expect(document.body.style.overflow).to.equal('');
     const newWrapper = document.querySelector('.floating-button.meta-powered');
     expect(newWrapper).to.exist;
+  });
+
+  it('renders dismissible overlay on iOS when fork-eligibility-check is on', async () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      configurable: true,
+    });
+    setDocumentMetadata(true, false, true);
+    const b = setMobileDom();
+
+    await decorate(b);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    expect(blockWrapper).to.exist;
+    const closeButton = blockWrapper.querySelector('.mweb-close');
+    expect(closeButton).to.exist;
   });
 });

--- a/test/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.test.js
+++ b/test/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.test.js
@@ -11,7 +11,11 @@ const imports = await Promise.all([
 ]);
 const { default: decorate } = imports[1];
 
-function setDocumentMetadata(includeForkCta2 = true, includForkCta3 = false, includeEligibilityCheck = false) {
+function setDocumentMetadata(
+  includeForkCta2 = true,
+  includForkCta3 = false,
+  includeEligibilityCheck = false,
+) {
   const metadata = {
     'floating-cta-live': 'Y',
     'show-floating-cta': 'yes',


### PR DESCRIPTION
## Summary

Extends the mobile fork button dismissable overlay to iOS devices (previously Android-only). Adds a `SUPPORTED_MWEB_OS` constant, updates eligibility checks to include iOS, and fixes scroll position preservation on overlay open/close using the fixed-position scroll-freeze pattern.

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-198018

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/langstore/en/uk/express/ |
| **After**   | https://ios-mobile-fork-dis--da-express-milo--adobecom.aem.page/langstore/en/uk/express/?martech=off |

---

## Verification Steps

- Open the After URL on an iOS device (or iOS Safari user agent).
- Confirm the dismissible fork button overlay appears.
- Tap the close button and confirm the page scroll position is preserved.
- Repeat on Android to confirm no regression.

---

## Potential Regressions

- https://ios-mobile-fork-dis--da-express-milo--adobecom.aem.live/langstore/en/uk/express/?martech=off

---

## Additional Notes

- `androidCheck` has been renamed in behavior only — the function name is unchanged to avoid a larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)