### PR TITLE
better fix for the mobile fork dismissible

### DIFF
--- a/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
+++ b/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
@@ -1,6 +1,6 @@
 import { getLibs, getMobileOperatingSystem, getIconElementDeprecated, addTempWrapperDeprecated } from '../../scripts/utils.js';
 import { createFloatingButton } from '../../scripts/widgets/floating-cta.js';
-import { createMultiFunctionButton, androidCheck, collectFloatingButtonData, createMetadataMap, SUPPORTED_MWEB_OS } from '../../scripts/utils/mobile-fork-button-utils.js';
+import { createMultiFunctionButton, collectFloatingButtonData, createMetadataMap, SUPPORTED_MWEB_OS } from '../../scripts/utils/mobile-fork-button-utils.js';
 
 let createTag; let getMetadata;
 
@@ -84,7 +84,8 @@ function mWebVariant() {
 
 export default async function decorate(block) {
   ({ createTag, getMetadata } = await import(`${getLibs()}/utils/utils.js`));
-  if (!androidCheck(getMetadata, getMobileOperatingSystem)) {
+  const eligibilityOn = getMetadata('fork-eligibility-check')?.toLowerCase()?.trim() === 'on';
+  if (eligibilityOn && !SUPPORTED_MWEB_OS.includes(getMobileOperatingSystem())) {
     const { default: decorateNormal } = await import('../floating-button/floating-button.js');
     decorateNormal(block);
     return;

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -51,7 +51,7 @@ export function buildAction(createTag, entry, buttonType) {
 }
 
 /**
- * Checks if the device OS is eligible for the mobile fork button.
+ * Checks if the device is Android, enables the mobile gating if it is.
  * If there is no metadata check enabled, still enable the gating block in case authors want it.
  * @param {Function} getMetadata - Function to get metadata
  * @param {Function} getMobileOperatingSystem - Function to get mobile OS
@@ -59,7 +59,7 @@ export function buildAction(createTag, entry, buttonType) {
  */
 export function androidCheck(getMetadata, getMobileOperatingSystem) {
   if (getMetadata('fork-eligibility-check')?.toLowerCase()?.trim() !== 'on') return true;
-  return SUPPORTED_MWEB_OS.includes(getMobileOperatingSystem());
+  return getMobileOperatingSystem() === 'Android';
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends the mobile fork button dismissable overlay to iOS devices (previously Android-only) **for the mobile fork dismissible block only**

Reverts the android check change to vanilla since its a shared function.

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-198018

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/langstore/en/uk/express/ |
| **After**   | https://ios-mobile-fork-2--da-express-milo--adobecom.aem.page/langstore/en/uk/express/?martech=off |

---

## Verification Steps

- Open the After URL on an iOS device (or iOS Safari user agent).
- Confirm the dismissible fork button overlay appears.
- Tap the close button and confirm the page scroll position is preserved.
- Repeat on Android to confirm no regression.
- Check the se regression branch for no difference between branch and main, this one does not have the dismissible variant authored.
---

## Potential Regressions

- https://ios-mobile-fork-2--da-express-milo--adobecom.aem.page/se/express/feature/image/convert/png-to-svg

---

## Additional Notes

- `androidCheck` has been renamed in behavior only — the function name is unchanged to avoid a larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)