### PR TITLE
MWPW-198304 mobile-fork-button-unity

### DIFF
--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -19,7 +19,7 @@ export default async function decorate(block) {
     block.closest('.section').remove();
   }
 
-  const data = collectFloatingButtonData(createTag, getIconElementDeprecated, eligible);
+  const data = collectFloatingButtonData(createTag, getIconElementDeprecated, eligible, {}, eligible ? 'mobile-fqa-upload' : '');
   const blockWrapper = await createMultiFunctionButton(
     createTag,
     createFloatingButton,

--- a/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.js
+++ b/express/code/blocks/mobile-fork-button-os-split/mobile-fork-button-os-split.js
@@ -35,6 +35,8 @@ export default async function decorate(block) {
     createTag,
     getIconElementDeprecated,
     metadataPrefix,
+    {},
+    'mobile-fqa-upload',
   );
   const blockWrapper = await createMultiFunctionButton(
     createTag,

--- a/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.css
+++ b/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.css
@@ -6,6 +6,11 @@ main .mobile-fork-button-unity {
   padding: 0;
 }
 
+main .floating-button-wrapper.mobile-fork-button-unity.floating-button--hidden {
+  bottom: -300px;
+}
+
+
 main .mobile-fork-button-unity .floating-button.block {
   background-color: var(--color-white);
   border-radius: var(--Radius-corner-radius-200);

--- a/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.css
+++ b/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.css
@@ -1,0 +1,59 @@
+main .floating-button-wrapper.mobile-fork-button-unity,
+main .mobile-fork-button-unity {
+  --mfb-outside-spacing: calc(var(--spacing-300) * 2);
+
+  z-index: 10;
+  padding: 0;
+}
+
+main .mobile-fork-button-unity .floating-button.block {
+  background-color: var(--color-white);
+  border-radius: var(--Radius-corner-radius-200);
+  box-shadow: 0px 4px 16px 0px rgba(0, 0, 0, 0.16);
+  padding: var(--spacing-300);
+  width: calc(100% - var(--mfb-outside-spacing));
+  max-width: 480px;
+  margin-bottom: var(--spacing-300);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-100);
+}
+
+main .mobile-fork-button-unity .mobile-gating-header {
+  font-size: var(--typography-title-xs);
+  line-height: var(--typography-line-height-Title-xs);
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: var(--spacing-200);
+  color: var(--Alias-content-typography-Title);
+}
+
+main .mobile-fork-button-unity .mobile-gating-row {
+  display: flex;
+  min-height: 40px;
+}
+
+main .mobile-fork-button-unity .floating-button a.button:any-link {
+  border-radius: 24px;
+  font-size: var(--ax-body-m-size);
+  line-height: 22px;
+  width: 100%;
+  margin: auto;
+  padding: var(--button-padding-top) var(--spacing-400);
+}
+
+main .mobile-fork-button-unity .floating-button a.button:any-link.accent {
+  color: var(--color-white);
+  background-color: var(--S2-Buttons-Accent-Color-Default);
+  border-color: var(--S2-Buttons-Accent-Color-Default);
+}
+
+main .mobile-fork-button-unity .floating-button a.button:any-link.outline {
+  background-color: var(--color-white);
+  border: 2px solid var(--Background-secondary-default);
+  color: var(--Palette-gray-800);
+}
+
+main .mobile-fork-button-unity.floating-button--hidden .floating-button.block {
+  margin-bottom: -10px;
+}

--- a/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.css
+++ b/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.css
@@ -44,8 +44,13 @@ main .mobile-fork-button-unity .floating-button a.button:any-link {
 
 main .mobile-fork-button-unity .floating-button a.button:any-link.accent {
   color: var(--color-white);
-  background-color: var(--S2-Buttons-Accent-Color-Default);
-  border-color: var(--S2-Buttons-Accent-Color-Default);
+  background-color: var(--Buttons-default);
+  border-color: var(--Buttons-default);
+}
+
+main .mobile-fork-button-unity .floating-button a.button:any-link.accent:hover {
+  background-color: var(--Buttons-hover);
+  border-color: var(--Buttons-hover);
 }
 
 main .mobile-fork-button-unity .floating-button a.button:any-link.outline {

--- a/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js
+++ b/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js
@@ -1,0 +1,65 @@
+import { getLibs, getMobileOperatingSystem, getIconElementDeprecated, addTempWrapperDeprecated } from '../../scripts/utils.js';
+import { createFloatingButton } from '../../scripts/widgets/floating-cta.js';
+import { collectFloatingButtonData, collectOsSplitFloatingButtonData, SUPPORTED_MWEB_OS } from '../../scripts/utils/mobile-fork-button-utils.js';
+
+let createTag;
+let getMetadata;
+
+function buildUnityAction(entry, buttonType) {
+  const wrapper = createTag('div', { class: 'floating-button-inner-row mobile-gating-row' });
+  const a = entry?.anchor;
+  if (a) {
+    a.classList.add(buttonType, 'button', 'mobile-gating-link');
+    wrapper.append(a);
+  }
+  return wrapper;
+}
+
+async function createUnityMultiFunctionButton(block, data, audience) {
+  const buttonWrapper = await createFloatingButton(block, audience, data);
+  buttonWrapper.classList.add('multifunction', 'mobile-fork-button-unity');
+
+  const floatingButton = buttonWrapper.querySelector('.floating-button');
+  floatingButton.children[0].remove();
+  const header = createTag('div', { class: 'mobile-gating-header' });
+  header.textContent = data.forkButtonHeader;
+  floatingButton.append(
+    header,
+    buildUnityAction(data.tools[0], 'accent'),
+    buildUnityAction(data.tools[1], 'outline'),
+  );
+
+  return buttonWrapper;
+}
+
+export default async function decorate(block) {
+  ({ createTag, getMetadata } = await import(`${getLibs()}/utils/utils.js`));
+  const eligibilityOn = getMetadata('fork-eligibility-check')?.toLowerCase()?.trim() === 'on';
+  if (eligibilityOn && !SUPPORTED_MWEB_OS.includes(getMobileOperatingSystem())) {
+    const { default: decorateNormal } = await import('../floating-button/floating-button.js');
+    decorateNormal(block);
+    return;
+  }
+  addTempWrapperDeprecated(block, 'multifunction-button');
+  if (!block.classList.contains('meta-powered')) return;
+
+  const audience = block.querySelector(':scope > div').textContent.trim();
+  if (audience === 'mobile') {
+    block.closest('.section').remove();
+  }
+
+  const os = getMobileOperatingSystem();
+  const osPrefixes = { Android: 'android', iOS: 'ios' };
+  const platform = osPrefixes[os];
+  const data = platform
+    ? collectOsSplitFloatingButtonData(createTag, getIconElementDeprecated, platform, {}, 'unity-upload')
+    : collectFloatingButtonData(createTag, getIconElementDeprecated, false, {}, 'unity-upload');
+
+  const blockWrapper = await createUnityMultiFunctionButton(block, data, audience);
+  const blockLinks = blockWrapper.querySelectorAll('a');
+  if (blockLinks && blockLinks.length > 0) {
+    const linksPopulated = new CustomEvent('linkspopulated', { detail: blockLinks });
+    document.dispatchEvent(linksPopulated);
+  }
+  if (data.longText) blockWrapper.classList.add('long-text');
+}

--- a/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js
+++ b/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js
@@ -22,7 +22,7 @@ async function createUnityMultiFunctionButton(block, data, audience) {
   const floatingButton = buttonWrapper.querySelector('.floating-button');
   floatingButton.firstElementChild?.remove();
   const header = createTag('div', { class: 'mobile-gating-header' });
-  header.textContent = data.forkButtonHeader;
+  header.textContent = data.forkButtonHeader ?? '';
   floatingButton.append(
     header,
     buildUnityAction(data.tools[0], 'accent'),

--- a/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js
+++ b/express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js
@@ -20,7 +20,7 @@ async function createUnityMultiFunctionButton(block, data, audience) {
   buttonWrapper.classList.add('multifunction', 'mobile-fork-button-unity');
 
   const floatingButton = buttonWrapper.querySelector('.floating-button');
-  floatingButton.children[0].remove();
+  floatingButton.firstElementChild?.remove();
   const header = createTag('div', { class: 'mobile-gating-header' });
   header.textContent = data.forkButtonHeader;
   floatingButton.append(

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -627,7 +627,7 @@ export function buildAutoBlocks() {
     const lastDiv = document.querySelector('main > div:last-of-type');
     const newDiv = document.createElement('div');
     lastDiv.insertAdjacentElement('afterend', newDiv);
-    const validButtonVersion = ['floating-button', 'multifunction-button', 'mobile-fork-button', 'mobile-fork-button-frictionless', 'mobile-fork-button-dismissable', 'mobile-fork-button-os-split'];
+    const validButtonVersion = ['floating-button', 'multifunction-button', 'mobile-fork-button', 'mobile-fork-button-frictionless', 'mobile-fork-button-dismissable', 'mobile-fork-button-os-split', 'mobile-fork-button-unity'];
     const device = document.body.dataset?.device;
     const blockName = getMetadata(`${device}-floating-cta`);
 

--- a/express/code/scripts/utils/mobile-fork-button-utils.js
+++ b/express/code/scripts/utils/mobile-fork-button-utils.js
@@ -80,7 +80,7 @@ export function createToolData(
   index,
   useFrictionless = false,
   metadataPrefix = '',
-  enableMobileFqaUpload = useFrictionless,
+  uploadTargetId = '',
 ) {
   const prefix = `${metadataPrefix}fork-cta-${index}`;
   // Metadata lookup with optional frictionless fallback
@@ -100,10 +100,10 @@ export function createToolData(
   const aTag = createTag('a', { title: textMetadata, href: hrefMetadata });
 
   // Special handler for frictionless upload
-  if (enableMobileFqaUpload && hrefMetadata.toLowerCase().trim() === '#mobile-fqa-upload') {
+  if (uploadTargetId && hrefMetadata.toLowerCase().trim() === `#${uploadTargetId}`) {
     aTag.addEventListener('click', (e) => {
       e.preventDefault();
-      document.getElementById('mobile-fqa-upload').click();
+      document.getElementById(uploadTargetId).click();
     });
   }
 
@@ -129,6 +129,7 @@ export function collectFloatingButtonData(
   getIconElementDeprecated,
   useFrictionless = false,
   extraMainCtaProps = {},
+  uploadTargetId = '',
 ) {
   const metadataMap = createMetadataMap();
   const getMetadataLocal = (key) => metadataMap[key];
@@ -160,6 +161,8 @@ export function collectFloatingButtonData(
       metadataMap,
       i,
       useFrictionless,
+      '',
+      uploadTargetId,
     );
     if (toolData) {
       data.tools.push(toolData);
@@ -185,6 +188,7 @@ export function collectOsSplitFloatingButtonData(
   getIconElementDeprecated,
   platform,
   extraMainCtaProps = {},
+  uploadTargetId = '',
 ) {
   const metadataMap = createMetadataMap();
   const getMetadataLocal = (key) => metadataMap[key];
@@ -233,7 +237,7 @@ export function collectOsSplitFloatingButtonData(
       i,
       false,
       metadataPrefix,
-      true,
+      uploadTargetId,
     );
     if (toolData) {
       data.tools.push(toolData);

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -332,7 +332,9 @@
   --Global-Typography-Size-Label-Label-L: 16px;
   --Global-Typography-Line-height-Label-Label-L: 22px;
   --typography-label-l: 16px;
+  --typography-title-xs: 16px;
   --typography-title-2xs: 14px;
+  --typography-line-height-Title-xs: 22px;
   --typography-line-height-Title-2xs: 20px;
 
   /* Palette tokens */

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -343,6 +343,7 @@
   --Palette-gray-400: #C6C6C6;
   --Palette-gray-600: #717171;
   --Palette-gray-700: #505050;
+  --Palette-gray-800: #292929;
   --Palette-gray-900: #131313;
   --Palette-gray-1000: #000000;
 
@@ -364,6 +365,7 @@
 
   /* Background/button semantic tokens */
   --Background-accent-default: var(--color-background-accent-default);
+  --Background-secondary-default: var(--Palette-gray-100);
   --Buttons-default: var(--S2-Buttons-Accent-Color-Default);
   --Buttons-hover: var(--S2-Buttons-Accent-Color-Hover);
 }

--- a/test/blocks/mobile-fork-button-unity/mobile-fork-button-unity.test.js
+++ b/test/blocks/mobile-fork-button-unity/mobile-fork-button-unity.test.js
@@ -201,4 +201,30 @@ describe('Mobile Fork Button Unity', () => {
 
     expect(document.querySelector('.multifunction')).to.not.exist;
   });
+
+  it('renders empty header when fork-button-header metadata is absent', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: ANDROID_USER_AGENT, configurable: true });
+    [
+      ['android-fork-cta-1-link', 'https://play.google.com/store/apps/unity'],
+      ['android-fork-cta-1-text', 'Get Android App'],
+      ['android-fork-cta-2-link', 'https://unity.com/web'],
+      ['android-fork-cta-2-text', 'Continue on web'],
+      ['floating-cta-device-and-ram-check', 'no'],
+      ['fallback-text', '((mobile-gating-fallback-text))'],
+    ].forEach(([name, content]) => {
+      const meta = document.createElement('meta');
+      meta.name = name;
+      meta.content = content;
+      document.head.appendChild(meta);
+    });
+    const block = document.createElement('div');
+    block.className = 'floating-button meta-powered';
+    block.innerHTML = '<div>mobile</div>';
+    document.querySelector('main .section').append(block);
+    await decorate(block);
+
+    const header = document.querySelector('.mobile-gating-header');
+    expect(header).to.exist;
+    expect(header.textContent).to.equal('');
+  });
 });

--- a/test/blocks/mobile-fork-button-unity/mobile-fork-button-unity.test.js
+++ b/test/blocks/mobile-fork-button-unity/mobile-fork-button-unity.test.js
@@ -1,0 +1,204 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { buildAutoBlocks, setLibs } from '../../../express/code/scripts/utils.js';
+
+setLibs('/test/mocks/libs', { hostname: 'example.com', search: '' });
+
+const { default: decorate } = await import('../../../express/code/blocks/mobile-fork-button-unity/mobile-fork-button-unity.js');
+
+const ANDROID_USER_AGENT = 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36';
+const IOS_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const DESKTOP_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36';
+
+function setDocumentMetadata(overrides = {}) {
+  const metadata = {
+    'floating-cta-live': 'Y',
+    'show-floating-cta': 'yes',
+    'mobile-floating-cta': 'mobile-fork-button-unity',
+    'desktop-floating-cta': 'floating-button',
+    'main-cta-link': 'https://www.adobe.com/express/create',
+    'main-cta-text': 'Get the full experience in the app.',
+    'floating-cta-device-and-ram-check': 'no',
+    'fallback-text': '((mobile-gating-fallback-text))',
+    'fork-button-header': 'Default header',
+    'android-fork-button-header': 'Android header',
+    'android-fork-cta-1-link': 'https://play.google.com/store/apps/unity',
+    'android-fork-cta-1-text': 'Get Android App',
+    'android-fork-cta-2-link': 'https://unity.com/web',
+    'android-fork-cta-2-text': 'Continue on web',
+    'ios-fork-button-header': 'iOS header',
+    'ios-fork-cta-1-link': 'https://apps.apple.com/unity',
+    'ios-fork-cta-1-text': 'Get iOS App',
+    'ios-fork-cta-2-link': 'https://unity.com/web',
+    'ios-fork-cta-2-text': 'Continue on web',
+    ...overrides,
+  };
+
+  Object.entries(metadata).forEach(([name, content]) => {
+    const meta = document.createElement('meta');
+    meta.name = name;
+    meta.content = content;
+    document.head.appendChild(meta);
+  });
+}
+
+async function render(userAgent, metadataOverrides = {}) {
+  Object.defineProperty(navigator, 'userAgent', { value: userAgent, configurable: true });
+  setDocumentMetadata(metadataOverrides);
+  const block = document.createElement('div');
+  block.className = 'floating-button meta-powered';
+  block.innerHTML = '<div>mobile</div>';
+  document.querySelector('main .section').append(block);
+  await decorate(block);
+}
+
+describe('Mobile Fork Button Unity', () => {
+  beforeEach(async () => {
+    window.isTestEnv = true;
+    window.hlx = {};
+    window.floatingCta = [{ path: 'default', live: 'Y' }];
+    window.placeholders = { 'see-more': 'See More' };
+    document.head.innerHTML = '';
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+    document.body.dataset.device = 'mobile';
+  });
+
+  afterEach(() => {
+    window.placeholders = undefined;
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('creates the auto block from mobile-floating-cta metadata', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: ANDROID_USER_AGENT, configurable: true });
+    setDocumentMetadata();
+
+    await buildAutoBlocks();
+
+    const block = document.querySelector('.mobile-fork-button-unity');
+    expect(block).to.exist;
+    expect(block.classList.contains('meta-powered')).to.be.true;
+  });
+
+  it('renders Android-prefixed fork metadata for Android', async () => {
+    await render(ANDROID_USER_AGENT);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(blockWrapper.querySelector('.mobile-gating-header').textContent).to.equal('Android header');
+    expect(rows.length).to.equal(2);
+    expect(rows[0].querySelector('a').textContent).to.equal('Get Android App');
+    expect(rows[0].querySelector('a').href).to.equal('https://play.google.com/store/apps/unity');
+    expect(rows[1].querySelector('a').textContent).to.equal('Continue on web');
+    expect(rows[1].querySelector('a').href).to.equal('https://unity.com/web');
+  });
+
+  it('renders iOS-prefixed fork metadata for iOS', async () => {
+    await render(IOS_USER_AGENT);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(blockWrapper.querySelector('.mobile-gating-header').textContent).to.equal('iOS header');
+    expect(rows.length).to.equal(2);
+    expect(rows[0].querySelector('a').textContent).to.equal('Get iOS App');
+    expect(rows[0].querySelector('a').href).to.equal('https://apps.apple.com/unity');
+    expect(rows[1].querySelector('a').textContent).to.equal('Continue on web');
+    expect(rows[1].querySelector('a').href).to.equal('https://unity.com/web');
+  });
+
+  it('renders no icon or icon-text elements in action rows', async () => {
+    await render(ANDROID_USER_AGENT);
+
+    const rows = document.querySelectorAll('.mobile-gating-row');
+    rows.forEach((row) => {
+      expect(row.querySelector('.icon')).to.not.exist;
+      expect(row.querySelector('.mobile-gating-icon-empty')).to.not.exist;
+      expect(row.querySelector('.mobile-gating-text')).to.not.exist;
+    });
+  });
+
+  it('dispatches linkspopulated with both CTA anchors', async () => {
+    const linksPopulated = new Promise((resolve) => {
+      document.addEventListener('linkspopulated', (event) => {
+        if (event.detail.length === 2) resolve(event.detail);
+      });
+    });
+
+    await render(ANDROID_USER_AGENT);
+
+    const links = await linksPopulated;
+    expect(links.length).to.equal(2);
+    expect(links[0].textContent).to.equal('Get Android App');
+    expect(links[1].textContent).to.equal('Continue on web');
+  });
+
+  it('delegates #unity-upload click to upload target on Android', async () => {
+    let uploadClicks = 0;
+    const uploadButton = document.createElement('button');
+    uploadButton.id = 'unity-upload';
+    uploadButton.addEventListener('click', () => { uploadClicks += 1; });
+    document.body.append(uploadButton);
+
+    await render(ANDROID_USER_AGENT, { 'android-fork-cta-1-link': '#unity-upload' });
+
+    document.querySelectorAll('.mobile-gating-row')[0].querySelector('a').click();
+
+    expect(uploadClicks).to.equal(1);
+  });
+
+  it('delegates #unity-upload click to upload target on iOS', async () => {
+    let uploadClicks = 0;
+    const uploadButton = document.createElement('button');
+    uploadButton.id = 'unity-upload';
+    uploadButton.addEventListener('click', () => { uploadClicks += 1; });
+    document.body.append(uploadButton);
+
+    await render(IOS_USER_AGENT, { 'ios-fork-cta-1-link': '#unity-upload' });
+
+    document.querySelectorAll('.mobile-gating-row')[0].querySelector('a').click();
+
+    expect(uploadClicks).to.equal(1);
+  });
+
+  it('falls back to unprefixed fork metadata when OS-prefixed metadata is missing', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: ANDROID_USER_AGENT, configurable: true });
+    setDocumentMetadata({
+      'fork-cta-1-text': 'Default CTA 1',
+      'fork-cta-1-link': 'https://example.com/default-1',
+      'fork-cta-2-text': 'Default CTA 2',
+      'fork-cta-2-link': 'https://example.com/default-2',
+    });
+    ['android-fork-cta-1-text', 'android-fork-cta-1-link', 'android-fork-cta-2-text', 'android-fork-cta-2-link', 'android-fork-button-header'].forEach((name) => {
+      document.head.querySelector(`meta[name="${name}"]`)?.remove();
+    });
+    const block = document.createElement('div');
+    block.className = 'floating-button meta-powered';
+    block.innerHTML = '<div>mobile</div>';
+    document.querySelector('main .section').append(block);
+    await decorate(block);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(blockWrapper.querySelector('.mobile-gating-header').textContent).to.equal('Default header');
+    expect(rows[0].querySelector('a').textContent).to.equal('Default CTA 1');
+    expect(rows[0].querySelector('a').href).to.equal('https://example.com/default-1');
+    expect(rows[1].querySelector('a').textContent).to.equal('Default CTA 2');
+    expect(rows[1].querySelector('a').href).to.equal('https://example.com/default-2');
+  });
+
+  it('falls back to floating-button when fork-eligibility-check is on and OS is not mobile', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: DESKTOP_USER_AGENT, configurable: true });
+    setDocumentMetadata({ 'fork-eligibility-check': 'on' });
+    const block = document.createElement('div');
+    block.className = 'floating-button meta-powered';
+    block.innerHTML = '<div>mobile</div>';
+    document.querySelector('main .section').append(block);
+
+    await decorate(block);
+
+    expect(document.querySelector('.multifunction')).to.not.exist;
+  });
+});

--- a/test/blocks/mobile-fork-button-unity/mocks/body.html
+++ b/test/blocks/mobile-fork-button-unity/mocks/body.html
@@ -1,0 +1,3 @@
+<main>
+  <div class="section"></div>
+</main>


### PR DESCRIPTION
## Summary

- Adds a new type of mobile fork button for use with verb-dropzone: "mobile-fork-button-unity"

---

## Jira Ticket

Resolves: [MWPW-198304](https://jira.corp.adobe.com/browse/MWPW-198304)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://methomas-mobile-unity--da-express-milo--adobecom.aem.page/drafts/methomas/resume-test |
| **After**   | https://methomas-mobile-unity--da-express-milo--adobecom.aem.page/drafts/methomas/resume-test?martech=off |

---

## Verification Steps

- On Android mobile, the primary CTA should go to a link (TBD)
- On iOS mobile, the primary CTA should go to a different link (TBD) and have a different text than Android
- Secondary CTA for both should trigger the file picker to open. The unity workflow isn't hooked up yet, but once it is, selecting a file will continue the flow.
- Styles should match the figma

---

## Potential Regressions

- https://methomas-mobile-unity--da-express-milo--adobecom.aem.live/express/
- https://methomas-mobile-unity--da-express-milo--adobecom.aem.live/express/feature/video/editor

---

## Additional Notes


