### PR TITLE
[MWPW-198863] FIX: Restore params truncated by colorPalette hash fragment in color sign-in redirect

### DIFF
--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -446,6 +446,28 @@ async function buildSimplifiedSusi(el, locale, imsClientId, noRedirect) {
   const popup = el.classList.contains('popup') || false;
   const variant = 'standard';
   const destURL = await getDestURL(redirectUrl);
+  if (isColor) {
+    try {
+      const orig = new URL(redirectUrl);
+      const colorPalette = orig.searchParams.get('colorPalette');
+      const colorReferrer = orig.searchParams.get('referrer');
+      const featureEnable = orig.searchParams.get('feature-enable');
+      const entryPoint = orig.searchParams.get('entryPoint');
+      if (colorPalette) {
+        destURL.searchParams.set('colorPalette', colorPalette);
+      }
+      if (colorReferrer) {
+        destURL.searchParams.set('referrer', colorReferrer);
+      }
+      if (featureEnable) {
+        destURL.searchParams.set('feature-enable', featureEnable);
+      }
+      if (entryPoint) {
+        destURL.searchParams.set('entryPoint', entryPoint);
+      }
+      destURL.hash = '';
+    } catch { /* ignore — destURL fallback is already set */ }
+  }
   const params = buildSUSIParams({
     client_id, variant, destURL, locale, title, popup, responseType: 'token',
   });


### PR DESCRIPTION
## Summary

Fixes a bug in the color sign-in redirect flow where query params appended after colorPalette in the Express redirect URL - specifically feature-enable=colors-product-entry and entryPoint - were silently dropped when the unauthenticated user completed sign-in.

Root cause: getTrackingAppendedURL returns a fully decoded URL string, which turns %23 → # inside the colorPalette JSON. new URL() then treats that first literal # as a fragment anchor, moving everything after it (including feature-enable and entryPoint) into url.hash. The hash is later cleared, losing those params. This caused the "Edit your color palette" modal to never open after sign-in, because feature-enable=colors-product-entry is the trigger for that modal.

Fix: After getDestURL runs, re-stamp colorPalette, referrer, feature-enable, and entryPoint from the original stored redirect URL before clearing the hash.

---

## Jira Ticket

Resolves: [198863](https://jira.corp.adobe.com/browse/MWPW-198863)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

When we are on color.adobe.com and we click on "Create with my color palette" it navigates to adobe express page where the model ("Edit your color palette') should automatically open. 
Before:
When the user is not signed in then on clicking create with my color palette, we first force user to sign in. And then redirect it to express - but in this case no modal gets opened.
After:
You are redirected to Express and the "Edit your color palette" modal opens automatically. The redirect URL should contain feature-enable=colors-product-entry, a valid colorPalette JSON, and referrer=express-colors.

---
