### PR TITLE
Resume builder design qa 2

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -16,7 +16,7 @@
 }
 
 main .section .grid-marquee h1 {
-  font-size: var(--heading-font-size-m);
+  font-size: 28px;
   padding-bottom: var(--spacing-100);
 }
 
@@ -37,16 +37,6 @@ main .section .grid-marquee h1 {
 }
 
 .grid-marquee .headline .ctas {
-  display: none;
-}
-
-.grid-marquee .headline a.button .text-group {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-100);
-}
-
-.grid-marquee .headline a.button .icon {
   display: none;
 }
 
@@ -355,6 +345,7 @@ main .section .grid-marquee.pricing-page h1 {
   }
   .grid-marquee .headline .ctas {
     display: flex;
+    margin-top: 16px;
     padding-top: 16px;
     justify-content: center;
     gap: 8px;
@@ -420,11 +411,11 @@ main .section .grid-marquee.pricing-page h1 {
     padding-bottom: 0;
   }
   main .section .grid-marquee .headline h1 {
-    font-size: var(--heading-font-size-xl);
+    font-size: 36px;
     font-weight: var(--heading-font-weight-extra);
   }
   .grid-marquee .headline .ctas {
-    padding-top: 24px;
+    padding-top: 16px;
   }
   .grid-marquee .headline a.button {
     border-width: 1px;
@@ -542,6 +533,27 @@ main .section .grid-marquee.pricing-page h1 {
   height: 20px;
   padding-block-start: 0;
   padding-block-end: var(--spacing-300);
+}
+
+/* resume-builder variant */
+.grid-marquee.resume-builder .express-logo {
+  height: 18px;
+}
+
+.grid-marquee.resume-builder .headline a.button .text-group {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-100);
+}
+
+.grid-marquee.resume-builder .headline a.button .icon {
+  display: none;
+}
+
+@media screen and (min-width: 768px) {
+  .grid-marquee.resume-builder .headline .ctas {
+    margin-top: 0;
+  }
 }
 
 .grid-marquee.narrow .headline {

--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -355,7 +355,6 @@ main .section .grid-marquee.pricing-page h1 {
   }
   .grid-marquee .headline .ctas {
     display: flex;
-    margin-top: 16px;
     padding-top: 16px;
     justify-content: center;
     gap: 8px;

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -288,16 +288,18 @@ export default async function init(el) {
     const heading = headline.querySelector('h1, h2, h3, h4, h5, h6');
     ctas.forEach((cta) => {
       cta.classList.add('button');
-      if (cta.querySelector('.icon')) return;
-      const icon = cta.parentElement?.querySelector(':scope > .icon');
-      const match = icon && iconRegex.exec(icon.className);
-      if (match?.[1]) {
-        const hasExistingGraphic = icon.querySelector('svg, img');
-        if (!hasExistingGraphic) icon.append(getIconElementDeprecated(match[1]));
-        const ctaText = cta.textContent.trim();
-        cta.textContent = '';
-        cta.title = cta.title || ctaText;
-        cta.append(createTag('div', { class: 'text-group' }, [icon, ctaText]));
+      if (el.classList.contains('resume-builder')) {
+        if (cta.querySelector('.icon')) return;
+        const icon = cta.parentElement?.querySelector(':scope > .icon');
+        const match = icon && iconRegex.exec(icon.className);
+        if (match?.[1]) {
+          const hasExistingGraphic = icon.querySelector('svg, img');
+          if (!hasExistingGraphic) icon.append(getIconElementDeprecated(match[1]));
+          const ctaText = cta.textContent.trim();
+          cta.textContent = '';
+          cta.title = cta.title || ctaText;
+          cta.append(createTag('div', { class: 'text-group' }, [icon, ctaText]));
+        }
       }
       if (!cta.getAttribute('aria-label') && heading) {
         cta.setAttribute('aria-label', `${cta.textContent.trim()} ${heading.textContent.trim()}`);
@@ -328,12 +330,17 @@ export default async function init(el) {
   // Legacy mode: headline + background + items inside this block
   if (hasLegacyHeadline) {
     const [headline, background, ...items] = rows;
-    const brandingLogoName = getMetadata('inject-branding-logo')?.trim()
-      || (['on', 'yes'].includes(getMetadata('marquee-inject-acrobat-logo')?.toLowerCase()) && 'cobrand-lockup-acrobat-express')
-      || null;
-    const logo = brandingLogoName
-      ? getIconElementDeprecated(brandingLogoName)
-      : getIconElementDeprecated('adobe-express-logo');
+    let logo;
+    if (el.classList.contains('resume-builder')) {
+      const brandingLogoName = getMetadata('inject-branding-logo')?.trim() || null;
+      logo = brandingLogoName
+        ? getIconElementDeprecated(brandingLogoName)
+        : getIconElementDeprecated('adobe-express-logo');
+    } else if (['on', 'yes'].includes(getMetadata('marquee-inject-acrobat-logo')?.toLowerCase())) {
+      logo = getIconElementDeprecated('cobrand-lockup-acrobat-express', '22px', 'Adobe Acrobat X Adobe Express co-brand logo', 'marquee-eyebrow-logo-wide');
+    } else {
+      logo = getIconElementDeprecated('adobe-express-logo');
+    }
 
     logo.classList.add('express-logo');
 

--- a/express/code/blocks/template-x-carousel-loop/template-x-carousel-loop.css
+++ b/express/code/blocks/template-x-carousel-loop/template-x-carousel-loop.css
@@ -9,7 +9,12 @@
   max-width: unset;
   display: flex;
   flex-direction: column;
-  padding-block-end: var(--spacing-400);
+}
+
+/* Section padding (ported from template-x-carousel .v2 default) */
+.section:has(.template-x-carousel-loop) {
+  padding-top: 0;
+  padding-bottom: 24px;
 }
 
 /* headers — v2: no padding */
@@ -39,7 +44,7 @@
   order: 3;
   display: flex;
   justify-content: center;
-  margin: 0 auto;
+  margin: 16px auto 0;
   padding: 0;
 }
 
@@ -249,6 +254,11 @@
     padding-right: 0;
     margin-left: auto;
     margin-right: 0;
+  }
+
+  .section:has(.template-x-carousel-loop) {
+    padding-top: 0;
+    padding-bottom: var(--spacing-400);
   }
 }
 

--- a/express/code/blocks/template-x-carousel-loop/template-x-carousel-loop.css
+++ b/express/code/blocks/template-x-carousel-loop/template-x-carousel-loop.css
@@ -14,7 +14,7 @@
 /* Section padding (ported from template-x-carousel .v2 default) */
 .section:has(.template-x-carousel-loop) {
   padding-top: 0;
-  padding-bottom: 24px;
+  padding-bottom: var(--spacing-400);
 }
 
 /* headers — v2: no padding */
@@ -44,7 +44,7 @@
   order: 3;
   display: flex;
   justify-content: center;
-  margin: 16px auto 0;
+  margin: var(--spacing-300) auto 0;
   padding: 0;
 }
 
@@ -75,12 +75,12 @@
 
 .template-x-carousel-loop .templates-container::before {
   left: 0;
-  background: linear-gradient(270deg, rgba(255, 255, 255, 0.00) 0%, #FFF 82.69%);
+  background: linear-gradient(270deg, transparent 0%, var(--color-white) 82.69%);
 }
 
 .template-x-carousel-loop .templates-container::after {
   right: 0;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.00) 0%, #FFF 82.69%);
+  background: linear-gradient(90deg, transparent 0%, var(--color-white) 82.69%);
 }
 
 /* Absorb the toolbar's top margin into the viewport's bottom padding so the
@@ -152,9 +152,9 @@
 .template-x-carousel-loop .template .button-container {
   position: absolute;
   top: auto;
-  bottom: 4px;
-  left: 4px;
-  right: 4px;
+  bottom: var(--spacing-75);
+  left: var(--spacing-75);
+  right: var(--spacing-75);
   width: auto;
   max-width: none;
   min-height: auto;
@@ -164,7 +164,7 @@
   align-items: center;
   z-index: 2;
   border-radius: 8px;
-  padding: 16px;
+  padding: var(--spacing-300);
   background: rgba(255, 255, 255, 0.90);
   backdrop-filter: blur(6px);
   box-shadow: none;

--- a/express/code/blocks/template-x-carousel-loop/template-x-carousel-loop.js
+++ b/express/code/blocks/template-x-carousel-loop/template-x-carousel-loop.js
@@ -17,6 +17,8 @@ async function createTemplates(recipe, customProperties = null) {
   return templates;
 }
 
+
+
 const DEFAULT_TEMPLATE_DEST = 'https://adobesparkpost.app.link/8JaoEy0DrSb';
 
 async function createTemplatesContainer(recipe, queryParams = '', destinationUrl = '') {

--- a/express/code/blocks/verb-dropzone/verb-dropzone.css
+++ b/express/code/blocks/verb-dropzone/verb-dropzone.css
@@ -593,7 +593,9 @@ main .section .verb-dropzone p {
 
 @media screen and (min-width: 600px) and (max-width: 1199px) {
   .verb-dropzone {
-    padding: 0 var(--spacing-500) 32px;
+    --verb-dropzone-top-spacing: 0px;
+
+    padding: var(--verb-dropzone-top-spacing) var(--spacing-500) 32px;
   }
 
   .verb-dropzone.tablet-dark {

--- a/express/code/blocks/verb-dropzone/verb-dropzone.css
+++ b/express/code/blocks/verb-dropzone/verb-dropzone.css
@@ -602,6 +602,7 @@ main .section .verb-dropzone p {
   }
 }
 
+
 /* ============================================================
    DESKTOP — ≥ 1200px
    Show desktop drag text and gray CTA button

--- a/express/code/blocks/verb-dropzone/verb-dropzone.css
+++ b/express/code/blocks/verb-dropzone/verb-dropzone.css
@@ -594,7 +594,6 @@ main .section .verb-dropzone p {
 @media screen and (min-width: 600px) and (max-width: 1199px) {
   .verb-dropzone {
     --verb-dropzone-top-spacing: 0px;
-
     padding: var(--verb-dropzone-top-spacing) var(--spacing-500) 32px;
   }
 

--- a/express/code/scripts/widgets/gallery/gallery-loop.css
+++ b/express/code/scripts/widgets/gallery/gallery-loop.css
@@ -5,10 +5,7 @@
 }
 
 .gallery-loop-viewport {
-  overflow: hidden;
-  /* room for the centered item to scale up without clipping */
-  padding-block: calc((var(--loop-active-scale) - 1) * var(--template-height, 300px) / 2);
-  /* allow vertical page scroll while we capture horizontal drags */
+  overflow: hidden;  
   touch-action: pan-y;
   outline: none;
 }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1003,6 +1003,26 @@ main .section.max-width-900 {
   margin-inline: auto;
 }
 
+main .section.no-margin {
+  margin: 0;
+}
+
+main .section.no-margin-top {
+  margin-top: 0;
+}
+
+main .section.no-margin-bottom {
+  margin-bottom: 0;
+}
+
+main .section.no-margin-left {
+  margin-left: 0;
+}
+
+main .section.no-margin-right {
+  margin-right: 0;
+}
+
 @media (max-width: 899px) {
   main .section.panel {
     margin: 0 var(--spacing-500) var(--spacing-600) var(--spacing-500);


### PR DESCRIPTION
## Summary

Design QA fixes for the Resume Builder page, plus CSS token cleanup across shared blocks.

  - grid-marquee resume-builder variant: Icon injection into CTA buttons and the Adobe Express logo
  rendering are now scoped to .resume-builder blocks only. Previously these behaviors applied
  globally, which risked unintended side effects on non-resume-builder marquees. Adds
  .resume-builder-specific CSS rules (logo height, text-group layout, icon visibility, CTA spacing).
  - grid-marquee font-size / spacing fixes: Hardcodes h1 font sizes to 28px / 36px to match design
  spec, reduces .ctas top padding from 24px → 16px.

  - template-x-carousel-loop padding refactor: Moves padding-block-end from the block element itself
  to a .section:has(...) rule (matching the .v2 default pattern), so section-level spacing is
  controlled at the section layer. Also applies at tablet breakpoint.
  - CSS token cleanup in template-x-carousel-loop: Replaces hardcoded rgba(255,255,255,0) with
  transparent, #FFF with var(--color-white), 4px with var(--spacing-75), 16px with var(--spacing-300).

  - verb-dropzone: Extracts tablet top padding into --verb-dropzone-top-spacing custom property for
  easier per-page overriding.

  - gallery-loop: Removes now-unnecessary padding-block scale compensation.
  - styles.css: Adds no-margin, no-margin-top, no-margin-bottom, no-margin-left, no-margin-right
  section utility classes.


