### PR TITLE
Color bugfix: Sort and time filters not applied to explore results on first load

### DIFF
--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -462,6 +462,9 @@ export default async function decorate(block) {
           } else {
             allData = await activeDataService.fetchData();
           }
+          if (!isSearchActive) {
+            allData = activeDataService.filter({ sort: 'most-popular' });
+          }
           visibleCount = alignToFullRow(
             Math.min(config.initialLoad, allData.length),
             allData.length,
@@ -511,6 +514,8 @@ export default async function decorate(block) {
               Math.min(config.initialLoad, allData.length),
               allData.length,
             );
+            // eslint-disable-next-line no-console
+            console.log('[ColorExplore] Visible gradients after filter:', allData.slice(0, visibleCount));
             await activeRenderer.update(allData.slice(0, visibleCount));
             updateLoadMoreState();
             block.classList.remove(CSS_CLASSES.LOADING);
@@ -639,6 +644,9 @@ export default async function decorate(block) {
           } else {
             allData = await activeDataService.fetchData();
           }
+          if (!isSearchActive) {
+            allData = activeDataService.filter({ sort: 'most-popular' });
+          }
           const alignedCount = Math.min(config.initialLoad, allData.length);
           visibleCount = alignToFullRow(alignedCount, allData.length);
 
@@ -671,6 +679,8 @@ export default async function decorate(block) {
               Math.min(config.initialLoad, allData.length),
               allData.length,
             );
+            // eslint-disable-next-line no-console
+            console.log('[ColorExplore] Visible palettes after filter:', allData.slice(0, visibleCount));
             activeRenderer.update(allData.slice(0, visibleCount));
             updateLoadMoreState();
             block.classList.remove(CSS_CLASSES.LOADING);

--- a/express/code/blocks/color-explore/color-explore.js
+++ b/express/code/blocks/color-explore/color-explore.js
@@ -514,8 +514,6 @@ export default async function decorate(block) {
               Math.min(config.initialLoad, allData.length),
               allData.length,
             );
-            // eslint-disable-next-line no-console
-            console.log('[ColorExplore] Visible gradients after filter:', allData.slice(0, visibleCount));
             await activeRenderer.update(allData.slice(0, visibleCount));
             updateLoadMoreState();
             block.classList.remove(CSS_CLASSES.LOADING);
@@ -679,8 +677,6 @@ export default async function decorate(block) {
               Math.min(config.initialLoad, allData.length),
               allData.length,
             );
-            // eslint-disable-next-line no-console
-            console.log('[ColorExplore] Visible palettes after filter:', allData.slice(0, visibleCount));
             activeRenderer.update(allData.slice(0, visibleCount));
             updateLoadMoreState();
             block.classList.remove(CSS_CLASSES.LOADING);

--- a/express/code/scripts/color-shared/services/createColorDataService.js
+++ b/express/code/scripts/color-shared/services/createColorDataService.js
@@ -152,7 +152,7 @@ export function createColorDataService(config) {
         if (kuler) {
           let raw = null;
           if (config.variant === 'gradients') {
-            raw = await kuler.exploreGradients({ filter: 'public', sort: 'create_time', time: 'month' });
+            raw = await kuler.exploreGradients({ filter: 'public', sort: 'create_time', time: 'all' });
             // eslint-disable-next-line no-console
             console.log('[DataService] Kuler gradients raw response:', raw);
             const items = raw?.gradients || raw?.themes || raw?.items
@@ -165,7 +165,7 @@ export function createColorDataService(config) {
               return data;
             }
           } else if (config.variant === 'strips' || config.variant === 'palettes') {
-            raw = await kuler.exploreThemes({ filter: 'public', sort: 'create_time', time: 'month' });
+            raw = await kuler.exploreThemes({ filter: 'public', sort: 'create_time', time: 'all' });
             // eslint-disable-next-line no-console
             console.log('[DataService] Kuler themes raw response:', raw);
             const items = raw?.themes || raw?.items || (Array.isArray(raw) ? raw : null);


### PR DESCRIPTION
## Summary

- Fixes issue on color-explore page where Sort and Time filters weren't applied to results on first load
- Noticed because we were only seeing 2 palette results

---

## Jira Ticket

Resolves: [MWPW-198785](https://jira.corp.adobe.com/browse/MWPW-198785)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-color--adobecom.aem.live/explore |
| **After**   | https://methomas-2-palettes-bug--express-color--adobecom.aem.live/explore?martech=off |

---

## Verification Steps

- Go to the page. Observe the number of palettes.
- Before: Only 2 results.
- After: Many rows of results.
- Change from "Most popular" to another sort option such as "All". Then switch back to "Most popular". These palettes should be the same as the ones that we first loaded.
- Switch from "Color palettes" to "Color gradients"
- Before: No results showed for gradients
- After: Plenty of results

---

## Potential Regressions

- https://methomas-2-palettes-bug--express-color--adobecom.aem.live/explore

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
