### PR TITLE
Mwpw 198863: FIX: Restore params truncated by colorPalette hash fragment in color sign-in redirect

### DIFF
--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -446,6 +446,28 @@ async function buildSimplifiedSusi(el, locale, imsClientId, noRedirect) {
   const popup = el.classList.contains('popup') || false;
   const variant = 'standard';
   const destURL = await getDestURL(redirectUrl);
+  if (isColor) {
+    try {
+      const orig = new URL(redirectUrl);
+      const colorPalette = orig.searchParams.get('colorPalette');
+      const colorReferrer = orig.searchParams.get('referrer');
+      const featureEnable = orig.searchParams.get('feature-enable');
+      const entryPoint = orig.searchParams.get('entryPoint');
+      if (colorPalette) {
+        destURL.searchParams.set('colorPalette', colorPalette);
+      }
+      if (colorReferrer) {
+        destURL.searchParams.set('referrer', colorReferrer);
+      }
+      if (featureEnable) {
+        destURL.searchParams.set('feature-enable', featureEnable);
+      }
+      if (entryPoint) {
+        destURL.searchParams.set('entryPoint', entryPoint);
+      }
+      destURL.hash = '';
+    } catch { /* ignore — destURL fallback is already set */ }
+  }
   const params = buildSUSIParams({
     client_id, variant, destURL, locale, title, popup, responseType: 'token',
   });

--- a/test/blocks/susi-light/mocks/body.html
+++ b/test/blocks/susi-light/mocks/body.html
@@ -115,3 +115,11 @@
     </div>
   </div>
 </div>
+
+<div>
+  <div class="susi-light simplified color">
+    <div><div></div></div>
+    <div><div>AdobeExpressWeb</div></div>
+    <div><div>Sign in</div></div>
+  </div>
+</div>

--- a/test/blocks/susi-light/susi-light.test.js
+++ b/test/blocks/susi-light/susi-light.test.js
@@ -146,7 +146,7 @@ describe('Susi-light', async () => {
     const colorBlock = document.querySelector('.susi-light.simplified.color');
 
     before(async () => {
-      window.__susiColorRedirect = 'https://new.express.adobe.com/?colorPalette=test&referrer=express-colors&feature-enable=colors-product-entry&entryPoint=color-explorer#hash';
+      window['__susiColorRedirect'] = 'https://new.express.adobe.com/?colorPalette=test&referrer=express-colors&feature-enable=colors-product-entry&entryPoint=color-explorer#hash';
       await decorate(colorBlock);
       await delay(310);
     });

--- a/test/blocks/susi-light/susi-light.test.js
+++ b/test/blocks/susi-light/susi-light.test.js
@@ -146,7 +146,8 @@ describe('Susi-light', async () => {
     const colorBlock = document.querySelector('.susi-light.simplified.color');
 
     before(async () => {
-      window['__susiColorRedirect'] = 'https://new.express.adobe.com/?colorPalette=test&referrer=express-colors&feature-enable=colors-product-entry&entryPoint=color-explorer#hash';
+      const redirectKey = '__susiColorRedirect';
+      window[redirectKey] = 'https://new.express.adobe.com/?colorPalette=test&referrer=express-colors&feature-enable=colors-product-entry&entryPoint=color-explorer#hash';
       await decorate(colorBlock);
       await delay(310);
     });

--- a/test/blocks/susi-light/susi-light.test.js
+++ b/test/blocks/susi-light/susi-light.test.js
@@ -21,7 +21,7 @@ await import(`${getLibs()}/utils/utils.js`).then((mod) => {
 });
 
 describe('Susi-light', async () => {
-  const blocks = [...document.querySelectorAll('.susi-light')];
+  const blocks = [...document.querySelectorAll('.susi-light:not(.color)')];
   const originalFetch = window.fetch;
   const originalLoadSUSI = SUSIUtils.loadSUSIScripts;
   before(async () => {
@@ -139,6 +139,26 @@ describe('Susi-light', async () => {
       expect(blockWithEduContext).to.exist;
       const component = blockWithEduContext.querySelector('susi-sentry-light');
       expect(component.authParams.dctx_id).to.equal(DCTX_ID_MAP['context-edu'].stage);
+    });
+  });
+
+  describe('susi-light simplified color variant', () => {
+    const colorBlock = document.querySelector('.susi-light.simplified.color');
+
+    before(async () => {
+      window.__susiColorRedirect = 'https://new.express.adobe.com/?colorPalette=test&referrer=express-colors&feature-enable=colors-product-entry&entryPoint=color-explorer#hash';
+      await decorate(colorBlock);
+      await delay(310);
+    });
+
+    it('forwards color params to destURL', () => {
+      const component = colorBlock.querySelector('susi-sentry-light');
+      expect(component).to.exist;
+      const url = new URL(component.authParams.redirect_uri);
+      expect(url.searchParams.get('referrer')).to.equal('express-colors');
+      expect(url.searchParams.get('feature-enable')).to.equal('colors-product-entry');
+      expect(url.searchParams.get('entryPoint')).to.equal('color-explorer');
+      expect(component.authParams.redirect_uri).not.to.include('#');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug in the color sign-in redirect flow where query params appended after colorPalette in the Express redirect URL - specifically feature-enable=colors-product-entry and entryPoint - were silently dropped when the unauthenticated user completed sign-in.

Root cause: getTrackingAppendedURL returns a fully decoded URL string, which turns %23 → # inside the colorPalette JSON. new URL() then treats that first literal # as a fragment anchor, moving everything after it (including feature-enable and entryPoint) into url.hash. The hash is later cleared, losing those params. This caused the "Edit your color palette" modal to never open after sign-in, because feature-enable=colors-product-entry is the trigger for that modal.

Fix: After getDestURL runs, re-stamp colorPalette, referrer, feature-enable, and entryPoint from the original stored redirect URL before clearing the hash.

---

## Jira Ticket

Resolves: [MWPW-198863](https://jira.corp.adobe.com/browse/MWPW-198863)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-color--adobecom.aem.live/drafts/sircar/color-wheel |
| **After**   | https://mwpw-198863--express-color--adobecom.aem.live/drafts/sircar/color-wheel?martech=off |

---

## Verification Steps

When we are on color.adobe.com and we click on "Create with my color palette" it navigates to adobe express page where the model ("Edit your color palette') should automatically open.
Before:
When the user is not signed in then on clicking create with my color palette, we first force user to sign in. And then redirect it to express - but in this case no modal gets opened.
After:
You are redirected to Express and the "Edit your color palette" modal opens automatically. The redirect URL should contain feature-enable=colors-product-entry, a valid colorPalette JSON, and referrer=express-colors.

---
