### PR TITLE
MWPW-197535: Localize one-up promo Free tag and Edit template label

### DIFF
--- a/express/code/blocks/template-x-promo/template-x-promo.js
+++ b/express/code/blocks/template-x-promo/template-x-promo.js
@@ -451,7 +451,7 @@ function createDirectCarousel(block, templates, createTagFn) {
   };
 }
 
-/* c8 ignore next 55 */
+/* c8 ignore next 59 */
 async function handleOneUpFromApiData(block, templateData) {
   const parent = block.parentElement;
   parent.classList.add('one-up');
@@ -479,16 +479,23 @@ async function handleOneUpFromApiData(block, templateData) {
   const imgWrapper = createTag('div', { class: 'image-wrapper' });
   imgWrapper.append(img);
 
+  const [editThisTemplateKey, freeKey] = await Promise.all([
+    replaceKey('edit-this-template', getConfig()),
+    replaceKey('free', getConfig()),
+  ]);
+
+  console.log('editThisTemplateKey', editThisTemplateKey);
+  const editThisTemplate = editThisTemplateKey ?? 'Edit this template';
+  const freeLabel = freeKey && freeKey !== 'free' ? freeKey : 'Free';
+
   if (metadata.isFree) {
     const freeTag = createTag('span', { class: 'free-tag' });
-    freeTag.textContent = 'Free';
+    freeTag.textContent = freeLabel;
     imgWrapper.append(freeTag);
   } else if (metadata.isPremium) {
     const premiumIcon = getIconElementDeprecated('premium');
     imgWrapper.append(premiumIcon);
   }
-
-  const editThisTemplate = await replaceKey('edit-this-template', getConfig()) ?? 'Edit this template';
 
   const imageLink = createTag('a', {
     href: metadata.editUrl,
@@ -769,7 +776,7 @@ const initializeUtilities = async () => {
   const libsPath = getLibs() || '../../scripts';
   try {
     const [utils, placeholders] = await Promise.all([
-      import(`${libsPath}/utils.js`),
+      import(`${libsPath}/utils/utils.js`),
       import(`${libsPath}/features/placeholders.js`),
     ]);
 

--- a/express/code/blocks/template-x-promo/template-x-promo.js
+++ b/express/code/blocks/template-x-promo/template-x-promo.js
@@ -451,7 +451,7 @@ function createDirectCarousel(block, templates, createTagFn) {
   };
 }
 
-/* c8 ignore next 59 */
+/* c8 ignore next 58 */
 async function handleOneUpFromApiData(block, templateData) {
   const parent = block.parentElement;
   parent.classList.add('one-up');
@@ -484,7 +484,6 @@ async function handleOneUpFromApiData(block, templateData) {
     replaceKey('free', getConfig()),
   ]);
 
-  console.log('editThisTemplateKey', editThisTemplateKey);
   const editThisTemplate = editThisTemplateKey ?? 'Edit this template';
   const freeLabel = freeKey && freeKey !== 'free' ? freeKey : 'Free';
 


### PR DESCRIPTION
## Summary

Makes the `template-x-promo` one-up promo's UI labels localizable instead of hardcoded English:

- The **"Free"** tag and **"Edit this template"** label now resolve via `replaceKey` (with English fallbacks), so non-`en` locales render translated text.
- The two placeholder lookups are batched in a single `Promise.all`.
- Fixes a broken import path (`utils.js` → `utils/utils.js`) in `initializeUtilities`.

---

## Jira Ticket

Resolves: [MWPW-197535](https://jira.corp.adobe.com/browse/MWPW-197535)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/de/express/learn/blog/social-media-post-ideas-business |
| **After**   | https://template-x-promo-cta--da-express-milo--adobecom.aem.page/de/express/learn/blog/social-media-post-ideas-business |

---

## Verification Steps

- Open the **Before** and **After** URLs (German `/de/` locale) and locate the one-up `template-x-promo` block.
- **Before:** the free-template tag reads "Free" and the image CTA reads "Edit this template" in English regardless of locale.
- **After:** both labels render the locale-appropriate translations (e.g. German), falling back to the English strings only when no placeholder is authored.

---

## Potential Regressions

- https://template-x-promo-cta--da-express-milo--adobecom.aem.page/de/express/learn/blog/social-media-post-ideas-business

---

## Additional Notes

N/A