### PR TITLE
MWPW-198010 Resume Builder Feedback

### DIFF
--- a/express/code/blocks/verb-dropzone/verb-dropzone.css
+++ b/express/code/blocks/verb-dropzone/verb-dropzone.css
@@ -8,7 +8,6 @@
 
   position: relative;
   padding: 0 var(--spacing-300) 24px;
-  overflow: hidden;
   box-sizing: border-box;
 }
 
@@ -30,10 +29,11 @@ main .section .verb-dropzone p {
    ============================================================ */
 
 .verb-dropzone-area {
-  border: 1.043px dashed var(--Palette-gray-500);
+  border: none;
   border-radius: 24px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'%3E%3Crect width='100%25' height='100%25' rx='24' ry='24' fill='none' stroke='%23868686' stroke-width='2' stroke-dasharray='4%2C 4'/%3E%3C/svg%3E");
   padding: var(--spacing-500) var(--spacing-400);
-  background: var(--color-gray-100);
+  background-color: var(--color-gray-100);
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -41,7 +41,7 @@ main .section .verb-dropzone p {
   align-items: center;
   gap: 12px;
   cursor: pointer;
-  transition: border-color 0.2s ease, background-color 0.2s ease;
+  transition: background-color 0.2s ease;
   box-sizing: border-box;
   width: 100%;
   min-height: var(--verb-dropzone-height);
@@ -61,13 +61,13 @@ main .section .verb-dropzone p {
   outline-offset: 2px;
 }
 
-/* dark overrides */
+/* dark overrides - adapted from unity-verb-marquee - not design approved */
 .verb-dropzone.dark .verb-dropzone-area,
 .verb-dropzone.mobile-dark .verb-dropzone-area,
 .verb-dropzone.tablet-dark .verb-dropzone-area,
 .verb-dropzone.desktop-dark .verb-dropzone-area {
-  background: #393939;
-  border-color: #8F8F8F;
+  background-color: #393939;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'%3E%3Crect width='100%25' height='100%25' rx='24' ry='24' fill='none' stroke='%238F8F8F' stroke-width='2' stroke-dasharray='4%2C 4'/%3E%3C/svg%3E");
   color: var(--color-white);
 }
 
@@ -83,8 +83,8 @@ main .section .verb-dropzone p {
 .verb-dropzone.mobile-dark .verb-dropzone-area.dragging,
 .verb-dropzone.tablet-dark .verb-dropzone-area.dragging,
 .verb-dropzone.desktop-dark .verb-dropzone-area.dragging {
-  border-color: #B8B8B8;
-  background: #4D4D4D;
+  background-color: #4D4D4D;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'%3E%3Crect width='100%25' height='100%25' rx='24' ry='24' fill='none' stroke='%23B8B8B8' stroke-width='2' stroke-dasharray='4%2C 4'/%3E%3C/svg%3E");
 }
 
 .verb-dropzone.dragging-block {
@@ -308,7 +308,8 @@ main .section .verb-dropzone p {
   border: none;
   outline: none;
   cursor: pointer;
-  margin-left: 4px;
+  margin-inline-start: 4px;
+  margin-block-end: 2px;
 }
 
 .verb-dropzone.dark .info-icon,

--- a/express/code/blocks/verb-dropzone/verb-dropzone.js
+++ b/express/code/blocks/verb-dropzone/verb-dropzone.js
@@ -100,8 +100,7 @@ function createSvgElement(iconName) {
 const getCTA = (verb) => {
   const verbConfig = LIMITS[verb];
   return window.mph?.[`verb-dropzone-${verb}-upload-cta`]
-    || window.mph?.[`verb-widget-cta-${verbConfig?.uploadType}`]
-    || 'Upload your resume';
+    || window.mph?.[`verb-widget-cta-${verbConfig?.uploadType}`];
 };
 
 function isMobileDevice() {
@@ -283,7 +282,6 @@ function buildDragOverlay(overlayText) {
 export default async function init(element) {
   ({ createTag, getConfig } = (await import(`${miloLibs}/utils/utils.js`)));
 
-  element.classList.add('con-block');
   if (isOldBrowser()) {
     window.location.href = EOLBrowserPage;
     return;
@@ -351,8 +349,8 @@ export default async function init(element) {
   }
   headingEl.id = 'verb-dropzone-heading';
   const subLine = createTag('p', { class: 'verb-dropzone-sub', id: 'file-upload-description' });
-  const dragDesktop = createTag('span', { class: 'verb-dropzone-subcopy-desktop' }, window.mph?.['verb-dropzone-subcopy-desktop'] || 'Click to upload or drag & drop! PDF, DOCX, or DOC, up to 20 MB');
-  const dragMobile = createTag('span', { class: 'verb-dropzone-subcopy-mobile' }, window.mph?.['verb-dropzone-subcopy-mobile'] || 'Tap to upload. PDF, DOCX, or DOC, up to 20 MB');
+  const dragDesktop = createTag('span', { class: 'verb-dropzone-subcopy-desktop' }, window.mph?.['verb-dropzone-subcopy-desktop']);
+  const dragMobile = createTag('span', { class: 'verb-dropzone-subcopy-mobile' }, window.mph?.['verb-dropzone-subcopy-mobile']);
   subLine.append(dragDesktop, dragMobile);
   dzContent.append(headingEl, subLine);
   dzInner.append(iconWrapper, dzContent);
@@ -433,10 +431,10 @@ export default async function init(element) {
   const touURL = window.mph?.['verb-widget-terms-of-use-url'] || `https://www.adobe.com${locale.prefix}/legal/terms.html`;
   const genAIurl = window.mph?.['verb-widget-genai-terms-url'] || `https://www.adobe.com${locale.prefix}/legal/licenses-terms/adobe-gen-ai-user-guidelines.html`;
   const mph = window.mph || {};
-  const legalPart1 = mph['verb-dropzone-legal'] || mph['verb-widget-legal'] || 'Your file will be securely handled by Adobe servers and deleted unless you sign in to save it.';
+  const legalPart1 = mph['verb-dropzone-legal'] || mph['verb-widget-legal'];
   const legalPart2 = limits?.genAI
-    ? (mph['verb-dropzone-legal-2-ai'] || mph['verb-widget-legal-2-ai'] || 'By using this service, you agree to the Adobe Terms of Use, Generative AI User Guidelines, and acknowledge the Privacy Policy.')
-    : (mph['verb-dropzone-legal-2'] || mph['verb-widget-legal-2'] || 'By using this service, you agree to the Adobe Terms of Use and acknowledge the Privacy Policy.');
+    ? (mph['verb-dropzone-legal-2-ai'] || mph['verb-widget-legal-2-ai'])
+    : (mph['verb-dropzone-legal-2'] || mph['verb-widget-legal-2']);
   const legalText = createTag('div', { class: 'verb-dropzone-legal' });
   const legalPart1El = createTag('p', {}, legalPart1);
   const legalPart2El = createTag('p', {}, legalPart2);
@@ -448,7 +446,7 @@ export default async function init(element) {
   ];
   legalPart2El.innerHTML = legalLinks.reduce(
     (html, [key, url]) => {
-      const linkText = key === 'verb-widget-genai-guidelines' ? 'Generative AI User Guidelines' : window.mph?.[key];
+      const linkText = window.mph?.[key];
       return linkText ? html.replace(linkText, createLegalLink(linkText, url)) : html;
     },
     legalPart2El.textContent,
@@ -467,7 +465,7 @@ export default async function init(element) {
     infoIcon.appendChild(infoIconSvg);
   }
   infoIcon.appendChild(createTag('span', { id: 'info-tooltip-text', class: 'hide' }, tooltipContent));
-  legalPart2El.append(infoIcon);
+  legalPart1El.append(infoIcon);
   legalText.append(legalPart1El, legalPart2El);
   footer.append(legalText);
 
@@ -565,16 +563,22 @@ export default async function init(element) {
     }
   };
   if (useFileUpload && fileInput) {
-    const dragOverlay = buildDragOverlay(window.mph?.['verb-dropzone-drag-overlay'] || 'Drop your file anywhere');
+    const dragOverlay = buildDragOverlay(window.mph?.['verb-dropzone-drag-overlay'] || '');
     document.body.append(dragOverlay);
     const hideDragOverlay = () => dragOverlay.classList.remove('is-dragging');
     let dragLeaveTimer = null;
+    let isBlockVisible = false;
+    const visibilityObserver = new IntersectionObserver(([entry]) => {
+      isBlockVisible = entry.isIntersecting;
+    }, { threshold: 0 });
+    visibilityObserver.observe(element);
 
     dropzone.addEventListener('click', () => {
       fileInput.click();
     });
     document.addEventListener('dragenter', (e) => {
       if (!e.dataTransfer?.types?.includes('Files')) return;
+      if (!isBlockVisible) return;
       clearTimeout(dragLeaveTimer);
       dragOverlay.classList.add('is-dragging');
     });

--- a/test/blocks/verb-dropzone/verb-dropzone.test.js
+++ b/test/blocks/verb-dropzone/verb-dropzone.test.js
@@ -61,10 +61,6 @@ describe('verb-dropzone – DOM structure', () => {
 
   after(restoreGlobals);
 
-  it('adds con-block class to the element', () => {
-    expect(block.classList.contains('con-block')).to.be.true;
-  });
-
   it('renders a dropzone button with the correct id', () => {
     const dz = block.querySelector('#unity-upload');
     expect(dz).to.exist;


### PR DESCRIPTION
## Summary

Round 1 of feedback on the Resume Builder:
- Fixes dropzone focus ring getting cut off on top
- Changes dropzone border to svg image to better match figma
- Removes hardcoded text now that placeholders have been authored
- Moves tooltip icon placement
- Restricts drag overlay to only when verb-dropzone is visible (same as upload)

---

## Jira Ticket

Resolves: [MWPW-198010](https://jira.corp.adobe.com/browse/MWPW-198010)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/create/resume |
| **After**   | https://mwpw-198010--da-express-milo--adobecom.aem.page/express/create/resume?martech=off |

---

## Verification Steps

Note, you will get error "Unable to process the request" when uploading because this domain hasn't been allowlisted for unity.

- Tab to the dropzone. Before: Focus ring was cut off. After: Focus ring is fully visible.
- View the border around the dropzone. Before: Dashes were too short and too close together. After: Border matches figma.
- All text should still be visible. No change.
- Observe the tooltip icon. Before: Located at end of second sentence in legal text. After: Located at end of first sentence.
- Scroll down to the bottom of the page. Drag and hold a supported file over the page. Before: Drop screen shows. After: No drop screen. 

---

## Potential Regressions



---

## Additional Notes


