### PR TITLE
MWPW-199166: update iconsExcludeBlocks config

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -82,6 +82,7 @@ const CONFIG = {
     onDemand: !jarvisImmediatelyVisible,
   },
   imsClientId: 'AdobeExpressWeb',
+  iconsExcludeBlocks: ['unity', 'firefly-howto'],
   prodDomains,
   geoRouting: 'on',
   lingoProjectSuccessLogging: 'on',


### PR DESCRIPTION
## Summary

Add unity and firefly-howto blocks to the iconsExcludeBlocks config to prevent icons 404'ing on the upcoming test.

---

## Jira Ticket

Resolves: [MWPW-199166](https://jira.corp.adobe.com/browse/MWPW-199166)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://www.stage.adobe.com/express/feature/image/remove-background?at_preview_token=lLr7bJrDlMCVKw90nSqAxA&at_preview_index=1_2&at_preview_listed_activities_only=true&at_preview_evaluate_as_true_audience_ids=2515310 |
| **After**   | [https://<branch>--da-express-milo--adobecom.aem.page/express/?martech=off](https://www.stage.adobe.com/express/feature/image/remove-background?at_preview_token=lLr7bJrDlMCVKw90nSqAxA&at_preview_index=1_2&at_preview_listed_activities_only=true&at_preview_evaluate_as_true_audience_ids=2515310) |

---

## Verification Steps

- Open the page in an incognito browser and verify that you are seeing the Target test content.
- Ensure that the are no 404's for SVGs coming from https://www.stage.adobe.com/federal/assets/icons/svgs/*.svg
