### PR TITLE
MWPW-198424: Unset Bold for Wayfinder links

### DIFF
--- a/express/code/blocks/wayfinder/wayfinder.css
+++ b/express/code/blocks/wayfinder/wayfinder.css
@@ -75,6 +75,10 @@ main .wayfinder h1, main .wayfinder h2, main .wayfinder h3, main .wayfinder h4, 
     font-size: 16px;
 }
 
+.wayfinder .text-row a {
+  font-weight: unset;
+}
+
 .wayfinder .cta-row strong .button {
     background-color: var(--color-info-accent);
     color: var(--color-white);


### PR DESCRIPTION
## Summary

Update CSS to not force a bold font weight for links in the Wayfinder block. This allows authors to either bold or not by normal authoring methods in DA.

This does introduce a potential issue though. As the block is created as a flex container, each item in the container has a gap associated with it. The non-bolded link now places a gap around the text, which creates an unwanted space between any non-hyperlinked text such as a period right after the hyperlink.

The authoring fix is to either not use a period or include the period in the hyperlink.

---

## Jira Ticket

Resolves: [MWPW-198424](https://jira.corp.adobe.com/browse/MWPW-198424)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/yolles/id-id-index |
| **After**   | https://mwpw-198424-wayfinder--da-express-milo--adobecom.aem.page/drafts/yolles/id-id-index?martech=off |

---

## Verification Steps

- There are two wayfinders on the sample page, one with bold text and one without in the hyperlink
- The bold text in the hyperlink should be bold and the non-bolded text should not be bold.

---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
