### PR TITLE
Easy Upload: add PromoIDs to QR mobile URL and track confirm CTA analytics

### DIFF
--- a/express/code/blocks/frictionless-quick-action/easy-upload-files/easy-upload.js
+++ b/express/code/blocks/frictionless-quick-action/easy-upload-files/easy-upload.js
@@ -1,6 +1,7 @@
 import { EasyUploadControls, EasyUploadVariants, EasyUploadVariantsPromoidMap } from '../../../scripts/utils/easy-upload-utils.js';
 import { getIconElementDeprecated, getLibs } from '../../../scripts/utils.js';
 import { adjustElementPosition } from '../../../scripts/widgets/tooltip.js';
+import { sendFrictionlessEventToAdobeAnaltics } from '../../../scripts/instrument.js';
 import {
   DEBUG_MODES,
   PLACEHOLDER_DEBUG_MODES,
@@ -546,6 +547,9 @@ function bindConfirmButton(qrPane) {
         easyUploadInstance.showConfirmTooltip?.('pending');
         return;
       }
+      sendFrictionlessEventToAdobeAnaltics(easyUploadInstance.block, 'select-confirm-upload-cta', {
+        custom: { qa: { upload_method: 'qr-code' } },
+      });
       await easyUploadInstance.handleConfirmImport();
     };
     trackListener(confirmButton, 'click', handleConfirmClick);

--- a/express/code/scripts/utils/easy-upload-utils.js
+++ b/express/code/scripts/utils/easy-upload-utils.js
@@ -652,6 +652,12 @@ export class EasyUpload {
     const url = new URL(`https://${host}/uploadFromOtherDevice`);
     url.searchParams.set('upload_url', presignedUrl);
 
+    const promoEntry = EasyUploadVariantsPromoidMap[this.quickAction];
+    if (promoEntry) {
+      url.searchParams.set('promoid', promoEntry.split('&')[0]);
+      url.searchParams.set('mv', 'other');
+    }
+
     return url.toString();
   }
 


### PR DESCRIPTION
## Summary

- **PromoIDs in mobile upload URL**: `buildMobileUploadUrl` now appends `promoid` and `mv=other` to the `/uploadFromOtherDevice` QR code URL so mobile sessions carry proper campaign attribution. Values come from `EasyUploadVariantsPromoidMap`; the `&mv=other` suffix already present in each entry is stripped via `.split('&')[0]` before setting the param.
- **`select-confirm-upload-cta` analytics event**: Added `sendFrictionlessEventToAdobeAnaltics` in `bindConfirmButton` so the event fires on desktop when a user clicks the enabled confirm button after a mobile QR upload. Matches the event name used in the in-product Home/Editor tests.

---

## Jira Ticket

Resolves: [MWPW-199598](https://jira.corp.adobe.com/browse/MWPW-199598)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/drafts/echen/easy-upload/remove-background |
| **After**   | https://easy-upload-analytics--da-express-milo--adobecom.aem.page/drafts/echen/easy-upload/remove-background |

---

## Verification Steps

- Open the easy-upload variant page and scan the QR code with a mobile device.
- Inspect the URL encoded in the QR — **before**: no `promoid`/`mv` params; **after**: `promoid=P3KMQHCX&mv=other` (variant) or `promoid=NYTLQM3Y&mv=other` (control).
- Upload a file via the QR code on mobile, wait for the confirm button to become enabled on desktop, then click it.
- **Before**: no `select-confirm-upload-cta` event fires; **after**: event appears in the Launch/Analytics debugger with `qa.upload_method: qr-code`.
- Confirm the desktop direct file upload path is unaffected.

---

## Potential Regressions

- https://easy-upload-analytics--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

The `EasyUploadVariantsPromoidMap` values are stored as `'P3KMQHCX&mv=other'` (promoid + mv combined). The URL fix splits on `&` to extract the clean promoid before appending it as a query param, then sets `mv=other` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)