### PR TITLE
MWPW-199666 Video encode cc everywhere calling logic

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -93,6 +93,9 @@ export async function runQuickAction(quickActionId, data, block) {
       isFrictionlessQa: 'true',
       ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage }),
     },
+    analyticsData: {
+      ...(quickActionId === 'video-encode' && { entryPoint: "seo-quick-action-video-compress" })
+    },
     receiveQuickActionErrors: true,
     callbacks: {
       onIntentChange: () => {

--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -94,7 +94,8 @@ export async function runQuickAction(quickActionId, data, block) {
       ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage }),
     },
     analyticsData: {
-      ...(quickActionId === 'video-encode' && { entryPoint: 'seo-quick-action-video-compress' }),
+      ...(quickActionId === 'video-compress' && { entryPoint: 'seo-quick-action-video-compress' }),
+      ...(quickActionId === 'video-convert' && { entryPoint: 'seo-quick-action-video-convert' }),
     },
     receiveQuickActionErrors: true,
     callbacks: {

--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -94,7 +94,7 @@ export async function runQuickAction(quickActionId, data, block) {
       ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage }),
     },
     analyticsData: {
-      ...(quickActionId === 'video-encode' && { entryPoint: "seo-quick-action-video-compress" })
+      ...(quickActionId === 'video-encode' && { entryPoint: 'seo-quick-action-video-compress' }),
     },
     receiveQuickActionErrors: true,
     callbacks: {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -232,7 +232,10 @@ export async function runQuickAction(quickActionId, data, block, fromQrCode = fa
   const appConfig = {
     metaData: {
       isFrictionlessQa: 'true',
-      ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage }),
+      ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage })
+    },
+    analyticsData: {
+      ...(quickActionId === 'video-encode' && { entryPoint: "seo-quick-action-video-compress" })
     },
     receiveQuickActionErrors: true,
     callbacks: {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -235,7 +235,8 @@ export async function runQuickAction(quickActionId, data, block, fromQrCode = fa
       ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage }),
     },
     analyticsData: {
-      ...(quickActionId === 'video-encode' && { entryPoint: 'seo-quick-action-video-compress' }),
+      ...(quickActionId === 'video-compress' && { entryPoint: 'seo-quick-action-video-compress' }),
+      ...(quickActionId === 'video-convert' && { entryPoint: 'seo-quick-action-video-convert' }),
     },
     receiveQuickActionErrors: true,
     callbacks: {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -235,7 +235,7 @@ export async function runQuickAction(quickActionId, data, block, fromQrCode = fa
       ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage })
     },
     analyticsData: {
-      ...(quickActionId === 'video-encode' && { entryPoint: "seo-quick-action-video-compress" })
+      ...(quickActionId === 'video-encode' && { entryPoint: 'seo-quick-action-video-compress' }),
     },
     receiveQuickActionErrors: true,
     callbacks: {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -232,7 +232,7 @@ export async function runQuickAction(quickActionId, data, block, fromQrCode = fa
   const appConfig = {
     metaData: {
       isFrictionlessQa: 'true',
-      ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage })
+      ...(quickActionId === 'caption-video' && { videoLanguage: selectedVideoLanguage }),
     },
     analyticsData: {
       ...(quickActionId === 'video-encode' && { entryPoint: 'seo-quick-action-video-compress' }),

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -130,7 +130,8 @@ export const QA_CONFIGS = {
   'qa-nba': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'convert-to-gif': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'crop-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
-  'video-encode': { ...getBaseVideoCfg(VIDEO_FORMATS) },
+  'video-convert': { ...getBaseVideoCfg(VIDEO_FORMATS) },
+  'video-compress': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'trim-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'resize-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'merge-videos': getMergeVideosCfg(),
@@ -425,7 +426,13 @@ export function executeQuickAction(
       exportConfig,
       contConfig,
     ),
-    'video-encode': () => ccEverywhere.quickAction.videoEncode(
+    'video-convert': () => ccEverywhere.quickAction.videoEncode(
+      videoDocConfig,
+      appConfig,
+      exportConfig,
+      contConfig,
+    ),
+    'video-compress': () => ccEverywhere.quickAction.videoEncode(
       videoDocConfig,
       appConfig,
       exportConfig,

--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -130,6 +130,7 @@ export const QA_CONFIGS = {
   'qa-nba': { ...getBaseImgCfg(JPG, JPEG, PNG) },
   'convert-to-gif': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'crop-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
+  'video-encode': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'trim-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'resize-video': { ...getBaseVideoCfg(VIDEO_FORMATS) },
   'merge-videos': getMergeVideosCfg(),
@@ -419,6 +420,12 @@ export function executeQuickAction(
       contConfig,
     ),
     'crop-video': () => ccEverywhere.quickAction.cropVideo(
+      videoDocConfig,
+      appConfig,
+      exportConfig,
+      contConfig,
+    ),
+    'video-encode': () => ccEverywhere.quickAction.videoEncode(
       videoDocConfig,
       appConfig,
       exportConfig,


### PR DESCRIPTION
## Summary

In this PR, we are adding the logic for opening video encode quick action with cceverywhere api when input quick action id is video-encode

---

## Jira Ticket

Resolves: [MWPW-199666](https://jira.corp.adobe.com/browse/MWPW-199666)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--da-express-milo--adobecom.aem.page/express/ |
| **After**   | https://CCEX-265067-video-encode--da-express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- [Here](https://ccex-265067-video-encode--da-express-milo--adobecom.aem.page/drafts/shairilk/compress-video?baseQA=https%3A%2F%2F283187.quick-actions-prenv.projectx.corp.adobe.com&hzenv=stage) is a draft page link for testing the integration of this new  quick actions. Open it.
- Then select a file.
- Embed editor should open with uploaded file and video encode quick action's properties panel 
<img width="1597" height="1022" alt="image" src="https://github.com/user-attachments/assets/8b09d59f-9f38-4d20-a644-335466563129" />


---

## Potential Regressions

- https://<branch>--da-express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
