### PR TITLE
Improve build-block-from-figma token mapping

### DIFF
--- a/.claude/skills/build-block-from-figma/SKILL.md
+++ b/.claude/skills/build-block-from-figma/SKILL.md
@@ -39,7 +39,7 @@ to read at the point it becomes relevant.
 ### references/
 | File | Purpose |
 |------|---------|
-| `design-tokens.md` | Express token system — `--color-*`, `--spacing-*`, `--body-font-size-*`, `--heading-font-size-*`, and font-family usage. |
+| `design-tokens.md` | Express token system + the Figma→token **mapping algorithm** (exact name match → in-category value match → new token / hardcoded), semantic-category guardrails, and the token-mapping report format. |
 | `grid-system.md` | Breakpoints, column counts, container variants, n-up layouts. |
 | `eds-patterns.md` | EDS block anatomy, Express utilities, CTA patterns, icon helpers, placeholder text. |
 | `acceptance-criteria.md` | JS/CSS rules, quality checklists, media-query syntax, token usage. |
@@ -163,17 +163,47 @@ Before writing any code:
 
 ## Phase 3 — Read Figma designs
 
-For each provided frame URL, call **both** tools:
+For each provided frame URL, call **all three** tools:
 
 1. **`get_screenshot`** — captures the visual appearance.
 2. **`get_design_context`** — extracts exact computed values (padding,
    gap, max-width, aspect-ratio, flex direction, font sizes, border-radius).
    Screenshots alone miss these values; `get_design_context` is the
    source of truth for any numeric property.
+3. **`get_variable_defs`** — returns the **named design-system variables**
+   Figma bound to each layer (e.g. `Palette/gray-100 → #E9E9E9`,
+   `Corner-radius/corner-radius-100 → 8px`). The variable **name** is what
+   lets you match against Express tokens by name rather than guessing from
+   the raw value. `get_design_context` gives value + property;
+   `get_variable_defs` gives the name — you need both to map tokens.
 
-> **Do not skip `get_design_context`.** Visual estimation from screenshots
-> is the leading cause of incorrect padding, wrong breakpoints, wrong
-> aspect-ratios, and mismatched max-widths in the initial implementation.
+> **Do not skip `get_design_context` or `get_variable_defs`.** Visual
+> estimation from screenshots is the leading cause of incorrect padding,
+> wrong breakpoints, wrong aspect-ratios, and mismatched max-widths. Mapping
+> from raw values without the Figma variable names is the leading cause of
+> picking the wrong same-valued token (e.g. a spacing token on a radius).
+
+### Figma tool error fallbacks
+
+These three errors are common with `?m=dev` links and large frames. Handle
+them rather than stalling; never guess a node ID to work around them.
+
+- **"Invalid node" / "node was not found"** — the node was moved, renamed,
+  or deleted (dev links go stale). Call `get_metadata` **without** a
+  `nodeId` to list the file's pages, drill in to locate the target, and if
+  it no longer exists ask the user for a fresh **Copy link to selection**
+  URL (or the correct file / branch).
+- **"You currently have nothing selected"** — the server is using the Figma
+  **desktop-app bridge** (live selection) instead of resolving the node
+  remotely, typically because the file isn't reachable via the MCP
+  account's remote API. Ask the user to open the file in the Figma
+  **desktop app** and select the target layer, then retry.
+- **`get_design_context` output exceeds the token limit** — the frame is
+  large. The token-mapping workflow only needs `get_variable_defs` (which
+  pairs each variable's name with its value) plus the screenshot, so
+  proceed with those. If you need specific computed values from the
+  oversized context, read the saved result file in chunks (or re-run
+  `get_design_context` on a smaller child node) rather than the whole frame.
 
 From `get_design_context` for each frame, extract and record:
 
@@ -188,9 +218,12 @@ From `get_design_context` for each frame, extract and record:
 - **Image aspect-ratio** and whether `border-radius` is `0` or non-zero.
 - **Gap values** between each level of nesting (block gap vs column gap
   vs element gap within a column).
-- Typography (font-size, weight, line-height), colours, and spacing —
-  match against Express CSS variables; always prefer a variable over a
-  hardcoded value.
+- Typography (font-size, weight, line-height), colours, spacing, and
+  radius — for each, capture **both** the Figma variable name (from
+  `get_variable_defs`) and the raw value (from `get_design_context`), then
+  resolve to an Express token using the mapping algorithm in
+  `references/design-tokens.md` (exact name match → in-category value match
+  → new token / hardcoded). Always prefer a token over a hardcoded value.
 
 If multiple frames are provided, explicitly note layout differences
 between breakpoints — these drive your CSS overrides. Pay particular
@@ -234,6 +267,24 @@ If an element (especially media — images, video, icons) appears in
 which do not.  Carry this inventory forward into Phase 4 as a
 checklist — the implementation must match element presence per
 breakpoint exactly.
+
+### Build the token-mapping table
+
+Using the Figma variable names (`get_variable_defs`) and raw values
+(`get_design_context`) gathered above, resolve every styled value to an
+Express token **now**, following the algorithm in
+`references/design-tokens.md`. Read `express/code/styles/styles.css` first
+if you have not already (Phase 2 step 3).
+
+Record each resolution so the Phase 9 token-mapping report writes itself.
+Carry forward in particular:
+
+- Every value that did **not** resolve via an exact name match.
+- Any proposed **new `:root` token** — these require user confirmation
+  before commit; raise them as soon as the table is built rather than at the
+  end.
+- Any value you had to **hardcode**, or any value-match you are unsure is
+  semantically correct (mark `review`).
 
 ---
 
@@ -561,9 +612,17 @@ Output:
 2. **Feature branch** (remote-branch-mode only) — branch name, repo,
    and number of commits pushed.
 3. **Breakpoints implemented** and which Figma frames they correspond to.
-4. **CSS variables used** — list every Express token referenced.
-5. **Hardcoded values** — any Figma values with no matching token,
-   with an explanatory comment in the CSS.
+4. **Token-mapping report** — the table defined in
+   `references/design-tokens.md`. Note the count of clean exact-name
+   matches, then list every Figma variable/value that did **not** resolve
+   via an exact name match, with: Figma variable name, raw value, CSS
+   property, resolution (value-match → which token / new token / hardcoded),
+   and a **Needs decision?** column. Call out every `YES` and `review` row
+   explicitly — these are the items the user must adjudicate.
+5. **New tokens & hardcoded values** — any `:root` token you propose to add
+   (with name, value, and where added) and any Figma value left hardcoded
+   (with the explanatory CSS comment). New `:root` tokens must have been
+   confirmed with the user before commit.
 6. **Acceptance criteria checklist** — confirm each criterion from
    Phase 4 passes (or note exceptions with reasoning).
 7. **Unit test results** — number of tests, pass/fail, any skipped.

--- a/.claude/skills/build-block-from-figma/references/design-tokens.md
+++ b/.claude/skills/build-block-from-figma/references/design-tokens.md
@@ -1,157 +1,255 @@
 # Design Tokens Reference
 
-Express design tokens live in `express/code/styles/styles.css`.
-They are defined as CSS custom properties on `:root` and are the
-**single source of truth** for the design system.
+Express design tokens live in `express/code/styles/styles.css`, defined as
+CSS custom properties on `:root`. They are the **single source of truth**
+for the design system, and most of them mirror the variables in the Figma
+design system.
+
+## Two generations of tokens coexist
+
+The `:root` block has accreted over time and contains **two naming
+generations** that you must recognize:
+
+- **Older, kebab-case tokens** near the **top** of `:root` —
+  `--color-gray-100`, `--spacing-300`, `--heading-font-size-l`,
+  `--border-radius-10`. These predate the current Figma variable system.
+- **Newer, Figma-mirrored tokens** near the **bottom** of `:root` —
+  `--Palette-gray-100`, `--Corner-radius-corner-radius-100`,
+  `--Alias-content-typography-Body`, `--Global-Typography-Size-Headings-Heading-L`.
+  These are named to match Figma variables almost character-for-character.
+
+**Ordering convention: newest at the bottom, oldest at the top.** When two
+candidate tokens are otherwise equally valid, prefer the **newer (lower)**
+one — it reflects the current Figma naming and is less likely to be
+deprecated. If you add a token, add it at the **bottom** of `:root`.
+
+Because Figma names map directly onto the newer tokens, your first move is
+always to match by **name**, not by value.
 
 ---
 
-## Token mapping workflow
+## Token mapping algorithm
 
-When building a block from Figma:
+For **every** variable/value Figma reports for a property you are styling,
+work through these steps **in order** and stop at the first that succeeds.
+Record the outcome of each one for the token-mapping report (see below).
 
-1. **Extract the raw value** from the Figma frame (colour, spacing,
-   font size, etc.).
-2. **Search `express/code/styles/styles.css`** for a CSS variable whose
-   value matches (or is very close to) the Figma value.
-3. **Use the variable** in your block CSS.  Never hardcode a value when
-   a matching token exists.
-4. If no matching token exists, hardcode the value **and** leave a
-   comment explaining why:
-   ```css
-   /* No token for this 6px radius — verify with design */
-   border-radius: 6px;
-   ```
+### Step 0 — Get the Figma variable names
+
+In Phase 3, call **`get_variable_defs`** for each frame (in addition to
+`get_screenshot` and `get_design_context`). It returns the **named
+variables** Figma applied, e.g.:
+
+```
+Palette/gray-100          → #E9E9E9
+Corner-radius/corner-radius-100 → 8px
+Alias/content-typography-Body   → #505050
+spacing/spacing-300       → 16px
+```
+
+The variable **name** is what powers Step 1. `get_design_context` gives you
+the raw value and the CSS property it applies to; `get_variable_defs` gives
+you the name. You need both.
+
+> If `get_variable_defs` returns nothing for a node (some layers use raw
+> values with no bound variable), skip to Step 2 and match by value.
+
+### Step 1 — Exact name match (case-insensitive)
+
+Normalize the Figma variable name and look for an identical CSS custom
+property in `:root`:
+
+1. Replace `/` and spaces with `-`.
+2. Prepend `--`.
+3. Compare **case-insensitively** against existing `--*` names.
+
+Examples:
+| Figma variable | Normalized | Existing token? |
+|---|---|---|
+| `Palette/gray-100` | `--Palette-gray-100` | ✅ exact |
+| `Corner-radius/corner-radius-100` | `--Corner-radius-corner-radius-100` | ✅ exact |
+| `Alias/content-typography-Body` | `--Alias-content-typography-Body` | ✅ exact |
+| `spacing/spacing-300` | `--spacing-spacing-300` | only `--spacing-300` / `--Spacing-spacing-300` exist → not exact, go to Step 2 |
+
+If you find a case-insensitive exact match, **use it** and record it as an
+exact-name match. This is the strongly preferred outcome.
+
+### Step 2 — Value match within the correct semantic category
+
+No exact name match. Search `:root` for a token whose **value** equals (or
+is within ~1px / a rounding hair of) the Figma raw value — **but only among
+tokens whose semantic category fits the CSS property** you are setting.
+
+This guardrail is critical: many tokens share a value. `16px` is the value
+of `--spacing-300`, `--Corner-radius-corner-radius-200`, and
+`--Global-Typography-Size-Body-Body-M` all at once. Picking the wrong one
+is a real bug even though the rendered pixels match.
+
+**Semantic category → allowed CSS properties:**
+
+| Category | Token families (examples) | Use for | Never use for |
+|---|---|---|---|
+| **Spacing** | `--spacing-*`, `--Spacing-*`, `--ax-grid-margin/-gutter` | `padding`, `margin`, `gap`, `row-gap`, `column-gap`, `inset`/`top/left/...` offsets | width, height, border-radius, border-width, font-size, line-height |
+| **Radius** | `--Corner-radius-*`, `--corner-radius-*`, `--Radius-*`, `--border-radius-*`, `--corner-radius-80` | `border-radius` only | spacing, size |
+| **Color** | `--color-*`, `--Palette-*`, `--palette-*`, `--Alias-content-*`, `--Background-*`, `--Buttons-*`, `--text-color-*`, `--gradient-*`, `--S2-Buttons-*`, `--transparent-*` | `color`, `background`/`-color`, `border-color`, `fill`, `stroke` | any non-color property |
+| **Font size** | `--body-font-size-*`, `--heading-font-size-*`, `--ax-*-size`, `--typography-*`, `--Global-Typography-Size-*` | `font-size` only | line-height, spacing |
+| **Line height** | `--ax-*-lh`, `--*-line-height-*`, `--Global-Typography-Line-height-*`, `--heading-line-height`, `--body-line-height` | `line-height` only | font-size |
+| **Font weight** | `--heading-font-weight*`, `--body-font-weight`, `--subheading-font-weight`, `--font-weight-medium`, `--ax-*-weight` | `font-weight` only | — |
+| **Width / max-width** | `--block-*-max-width`, `--ax-grid-*-col-width`, `--ax-grid-container-width` | `width`, `max-width`, `flex-basis` | padding/margin/gap |
+| **Shadow / elevation** | `--Alias-drop-shadow-*`, `--Elevation-*`, `--Modal-*-shadow-*` | `box-shadow` | — |
+| **Border width** | `--border-width-2` | `border-width` | — |
+
+When a value matches a token **outside** the property's category, that is
+**not** a valid match — continue to Step 3.
+
+Also sanity-check **role**, not just category: `--Alias-content-typography-Body`
+(#505050) is for body text color specifically — don't reach for it just
+because you need some gray. Prefer the token whose name describes the role
+you are filling.
+
+When you use a value match, record: the Figma variable name (or "(unnamed)"),
+the raw value, and which token you substituted.
+
+### Step 3 — No suitable token: evaluate adding one
+
+No exact-name match and no value match in the right category. Decide
+between two outcomes and **flag it for the user either way** (see report):
+
+- **Add a new token** when the value is clearly a reusable design-system
+  value (a named Figma variable that simply isn't in `styles.css` yet, or a
+  value you expect to recur). Add it at the **bottom** of `:root`, named to
+  mirror the Figma variable (Step 1 normalization). Prefer aliasing an
+  existing primitive if one holds the value
+  (e.g. `--Corner-radius-corner-radius-200: var(--spacing-300);` style).
+- **Hardcode with a comment** when it's a true one-off with no Figma
+  variable behind it:
+  ```css
+  /* No token for this 6px radius — Figma value, verify with design */
+  border-radius: 6px;
+  ```
+
+Adding to `:root` in `styles.css` touches a global file — **never add a
+token silently.** Surface it in the report and let the user confirm before
+you commit a new `:root` entry.
 
 ---
 
-## Colour tokens
+## Token-mapping report
 
-Colours are prefixed `--color-*` or use descriptive names:
+This is a required deliverable, folded into the Phase 9 summary. Its
+purpose is to make every non-obvious token decision auditable.
 
-```css
---color-white: #fff;
---color-black: #000;
---color-gray-100 through --color-gray-950   /* neutrals */
---color-info-accent: #5c5ce0;               /* primary accent (indigo) */
---color-info-accent-hover / -down / -reverse
---color-info-primary: #242424;              /* primary button */
---color-info-secondary: #e8e8e8;            /* secondary button */
---color-info-premium: #ebcf2d;              /* premium/gold */
---color-blue-600: #0066CC;
---color-focus-ring-strong: #4B75FF;
---text-color-secondary: #6e6e6e;
---color-brand-title: #000b1d;
---gradient-highlight-vertical / -horizontal / -diagonal
+Produce a table covering **every Figma variable/value you encountered that
+did not resolve via a Step 1 exact-name match** (exact-name matches are the
+happy path and don't need individual reporting — just note the count):
+
+```
+Figma variable            | Raw value | CSS property      | Resolution                              | Needs decision?
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────
+spacing/spacing-300        | 16px      | padding           | value-match → --spacing-300             | no
+(unnamed)                  | #2C2C2C   | color             | value-match → --c1-text-text            | review: odd one-off token
+Card/corner-radius-large   | 12px      | border-radius     | NEW TOKEN proposed: --Card-corner-...   | YES — confirm before commit
+(unnamed)                  | 6px       | border-radius     | hardcoded (no token, no Figma var)      | YES — verify w/ design
+Heading/size-display       | 64px      | font-size         | no category match; closest --heading... | YES — value differs, confirm
 ```
 
-Always match Figma hex/rgb values against these tokens before
-hardcoding a colour.
+Columns:
+- **Figma variable** — the name from `get_variable_defs`, or `(unnamed)` if
+  the layer used a raw value.
+- **Raw value** — from `get_design_context`.
+- **CSS property** — what you were styling.
+- **Resolution** — one of: `value-match → --token`, `NEW TOKEN proposed: --token`,
+  `hardcoded`, or a near-miss note.
+- **Needs decision?** — `YES` for anything that adds a `:root` token,
+  hardcodes a value, or substitutes a token whose value isn't an exact match;
+  `review` for a match you're not fully confident is semantically right;
+  `no` for clean in-category value matches.
+
+Anything marked `YES` must be raised with the user **before** it ships,
+since it either changes the global stylesheet or leaves an unmatched value.
 
 ---
 
-## Font families
+## Quick token inventory
 
-Font families are referenced by these two variables only:
+A non-exhaustive map of what exists today, to orient value searches. Always
+read the live `:root` in `styles.css` — this list drifts.
 
-| Variable | Usage |
-|----------|-------|
-| `--body-font-family` | Body copy, paragraphs, labels, captions — most text. Value: `'adobe-clean', 'Adobe Clean', 'adobe-clean-fallback', sans-serif` |
+### Colour
+`--color-white`, `--color-black`, `--color-gray-100`…`--color-gray-950`
+(plus `-variant` shades), `--text-color-secondary`, `--color-info-accent`
+(+ `-hover/-down/-reverse/-light`), `--color-info-primary/-secondary`
+(+ states), `--color-info-premium`, `--color-blue-600/-700/-800`,
+`--color-green-800/-900/-1000`, `--color-orange-700`, `--color-purple-1000`,
+`--color-focus-ring-strong`, `--color-brand-title`, `--gradient-highlight-*`.
+Newer Figma-mirrored: `--Palette-gray-100`…`-1000`, `--Palette-blue-1000`,
+`--Alias-content-typography-Title/-Heading/-Body`,
+`--Alias-content-neutral-default/-hover`, `--Background-accent-default`,
+`--Background-secondary-default`, `--Buttons-default/-hover`,
+`--S2-Buttons-*`.
 
-Headings do not have a separate font-family variable in Express —
-they use `--body-font-family` with heavier font weights.  Use
-`--heading-font-weight` (800) or `--heading-font-weight-extra` (900)
-to style heading elements.
+### Spacing
+`--spacing-0` (0px), `-50` (2px), `-75` (4px), `-80` (6px), `-100` (8px),
+`-200` (12px), `-250` (14px), `-300` (16px, base), `-325` (18px),
+`-350` (20px), `-400` (24px), `-500` (32px), `-600` (40px), `-700` (48px),
+`-800` (64px), `-900` (80px), `-1000` (96px).
 
----
+### Radius
+`--border-radius-10` (10px), `--border-radius-max` (999px),
+`--Corner-radius-corner-radius-100` (8px), `-200` (16px), `-500` (100px),
+`--Radius-corner-radius-75` (4px), `--corner-radius-80` (6px),
+`--SN-Radius-corner-radius-full` (2000px).
 
-## Typography tokens
+### Typography (legacy rem scale)
+Body: `--body-font-size-xxl` (1.5rem) → `--body-font-size-xs` (0.75rem).
+Heading: `--heading-font-size-xxxl` (5rem) → `--heading-font-size-xs`
+(1.25rem), plus `--heading-font-size-ml` (2rem) and `-2xl` (45px).
 
-Font sizes follow a named scale. Do not hardcode `rem` or `px`
-values when a token exists.
+### Typography (`ax-` px scale, mirrors current Figma)
+`--ax-heading-{xxxl…xxs}-size` / `-lh`, `--ax-body-{xxl…xxs}-size` / `-lh`,
+`--ax-detail-{xl…s}-size` / `-lh`, weights `--ax-heading-weight` (700),
+`--ax-body-weight` (400), `--ax-body-weight-bold` (700),
+`--ax-detail-weight` (700).
 
-### Body
+### Font family / weight
+`--body-font-family` (Adobe Clean — use for body **and** headings),
+`--body-serif-font-family`, `--heading-font-weight` (800),
+`--heading-font-weight-extra` (900), `--heading-font-weight-medium` (700),
+`--heading-font-weight-regular` (400), `--body-font-weight` (normal),
+`--subheading-font-weight` (700), `--font-weight-medium` (500).
 
-```css
---body-font-size-xxl: 1.5rem
---body-font-size-xl:  1.25rem
---body-font-size-l:   1.125rem
---body-font-size-m:   1rem        ← base body
---body-font-size-s:   0.875rem
---body-font-size-xs:  0.75rem
-```
+Headings have **no** dedicated font-family token — they use
+`--body-font-family` with a heavier `--heading-font-weight*`.
 
-### Headings
+> **Known exception — do not flag the font family.** Figma's design system
+> uses **Adobe Clean Spectrum VF** (the Spectrum 2 variable font), which has
+> no matching token; the codebase uses `--body-font-family` ('adobe-clean').
+> This is a **known, intentional** difference between design and dev that we
+> are not addressing yet. When Figma reports a Spectrum VF font family
+> (`Family/font-family-*`, `Font family/Sans serif`, etc.), silently map it
+> to `--body-font-family` and **omit it from the token-mapping report** — do
+> not raise it as a gap or a decision.
 
-```css
---heading-font-size-xxxl: 5rem
---heading-font-size-xxl:  3.75rem
---heading-font-size-xl:   2.8125rem
---heading-font-size-l:    2.25rem
---heading-font-size-ml:   2rem
---heading-font-size-m:    1.75rem
---heading-font-size-s:    1.375rem
---heading-font-size-xs:   1.25rem
-```
-
-### Font weights
-
-```css
---heading-font-weight:         800   ← standard heading weight
---heading-font-weight-medium:  700
---heading-font-weight-regular: 400
---heading-font-weight-extra:   900
---body-font-weight:            normal
-```
-
----
-
-## Spacing tokens
-
-Spacing follows a numeric scale (the number approximates pixels at 1rem = 16px):
-
-```css
---spacing-0:    0px
---spacing-50:   2px
---spacing-75:   4px
---spacing-80:   6px
---spacing-100:  8px
---spacing-200:  12px
---spacing-250:  14px
---spacing-300:  16px    ← base unit
---spacing-325:  18px
---spacing-350:  20px
---spacing-400:  24px
---spacing-500:  32px
---spacing-600:  40px
---spacing-700:  48px
---spacing-800:  64px
---spacing-900:  80px
---spacing-1000: 96px
-```
-
-Map every Figma spacing value to the closest token.  If the value
-falls exactly between two tokens, prefer the one that matches the
-Figma spec and leave a comment.
+### Width / shadow / misc
+`--block-{sm/md/lg/wd}-max-width`, `--block-wd-grid-max-width`,
+`--ax-grid-*` (margins, gutters, n-col widths),
+`--Alias-drop-shadow-*`, `--Elevation-Dialog`, `--Modal-*-shadow-*`,
+`--border-width-2`.
 
 ---
 
 ## Responsive behaviour
 
-Unlike some token systems, Express spacing and font tokens do **not**
-change values automatically per breakpoint in the token layer.
-When Figma shows different sizes at different viewports, use media
-queries in the block CSS to switch token references:
+Spacing and font tokens do **not** change value per breakpoint in the token
+layer (a few `--ax-grid-*` values do, in `@media` `:root` blocks). When
+Figma shows different sizes at different viewports, switch **which token**
+you reference inside a media query:
 
 ```css
-.my-block .heading {
-  font-size: var(--heading-font-size-m);
-}
+.my-block .heading { font-size: var(--heading-font-size-m); }
 
-@media (width >= 768px) {
-  .my-block .heading {
-    font-size: var(--heading-font-size-l);
-  }
+@media (width >= 900px) {
+  .my-block .heading { font-size: var(--heading-font-size-l); }
 }
 ```
 
@@ -159,9 +257,11 @@ queries in the block CSS to switch token references:
 
 ## Checklist before submitting block CSS
 
-- [ ] Every colour value maps to a `--color-*` / `--gradient-*` token or has a comment.
-- [ ] Every spacing value maps to a `--spacing-*` token or has a comment.
-- [ ] Every font-size maps to a `--body-font-size-*` or `--heading-font-size-*` token.
-- [ ] Font families use only `--body-font-family`.
-- [ ] Font weights use the `--heading-font-weight-*` or `--body-font-weight` variables.
-- [ ] No hardcoded hex/rgb values or pixel measurements without a comment.
+- [ ] Ran `get_variable_defs` for every frame; have Figma variable names, not just values.
+- [ ] Every value resolved through the algorithm: exact-name → in-category value-match → new token / hardcoded.
+- [ ] No value-match crosses semantic categories (no spacing token on a radius, etc.).
+- [ ] Colours map to a colour-family token (matched by role, not just hue) or are flagged.
+- [ ] Font families use only `--body-font-family` (or `--body-serif-font-family`).
+- [ ] Font weights use the weight tokens.
+- [ ] Any new `:root` token was confirmed with the user before commit and added at the bottom of `:root`.
+- [ ] Token-mapping report compiled for the Phase 9 summary, with every `YES`/`review` row called out.


### PR DESCRIPTION
## Summary

- Improves the Figma→Express design-token mapping in the `build-block-from-figma` Claude skill

What changed:

- **Name-first mapping algorithm** in `references/design-tokens.md`:
  1. Exact variable-name match (case-insensitive, `/`→`-` normalized) against
     `:root` in `express/code/styles/styles.css`.
  2. In-category value match with **semantic guardrails** — a spacing token is
     valid for `padding`/`margin`/`gap` but never for `height`/`width`/
     `border-radius`, etc. (table of category → allowed CSS properties).
  3. No match → evaluate adding a `:root` token (user-confirmed, added at the
     bottom) or hardcode with a comment.
- **Wires in Figma `get_variable_defs`** (previously unused) in Phase 3 so the
  skill matches by the actual Figma variable *name*, not just the raw value —
  this is what prevents picking a wrong same-valued token.
- **Token-mapping report** added to the Phase 9 summary: lists every value that
  didn't resolve via an exact name match, the substitute used, and a
  `Needs decision?` column for new tokens / hardcodes / uncertain matches.
- **Phase 3 error fallbacks** for common Figma MCP failures: invalid/stale node
  (relocate via `get_metadata` or ask for a fresh link), "nothing selected"
  desktop-bridge mode (open in Figma desktop + select), and oversized
  `get_design_context` (proceed on `get_variable_defs` + screenshot).
- **Known exception:** Adobe Clean *Spectrum VF* font is documented as an
  intentional dev/design difference — mapped to `--body-font-family` and
  omitted from the report rather than flagged.

---

## Jira Ticket

N/A — tooling/skill improvement.

---

## Test URLs

N/A — no site-facing changes. Validated by dry-running the skill's token
mapping against two real Figma frames (a Spectrum 2 dropzone button and a
Font-Generator SEO section). In both, exact-name matching (incl.
case-insensitive hits), the radius/size guardrails, and the decision flags
behaved as intended.

---

## Verification Steps

- Review `.claude/skills/build-block-from-figma/references/design-tokens.md`
  and the Phase 3 / Phase 9 edits in `SKILL.md`.
- **Before:** token mapping was value-only, with no Figma variable names, no
  category guardrails, and no structured report.
- **After:** name-first + category-aware mapping, `get_variable_defs` in the
  flow, a token-mapping report, and Figma-MCP error fallbacks.

---

## Potential Regressions

- None at runtime — changes are confined to skill instructions/docs under
  `.claude/`.

---

## Additional Notes

The dry-runs surfaced real design-system drift worth a follow-up (e.g. Figma
`Title/Title-2XS` = 16px vs repo `--typography-title-2xs` = 14px, and several
Figma aliases with no name-matching token). Those are token-system decisions,
out of scope for this skill change.