### PR TITLE
Improve build-block-from-figma and build-content-from-figma skills

### DIFF
--- a/.claude/skills/build-block-from-figma/SKILL.md
+++ b/.claude/skills/build-block-from-figma/SKILL.md
@@ -307,6 +307,13 @@ DOM.  Pattern from existing blocks:
 </main>
 ```
 
+> **EDS single-value cells**: when a row contains only one value (e.g. a
+> background color string, a card title), EDS delivers it as plain text
+> inside the cell `<div>` — no `<p>` wrapper. Write these cells as
+> `<div>value</div>`, not `<div><p>value</p></div>`, so that JS selectors
+> and tests match live behavior. See `references/eds-patterns.md` for the
+> full explanation and workaround pattern.
+
 Add a second mock `inject-logo.html` if the block supports logo
 injection via the `marquee-inject-logo` meta tag.
 

--- a/.claude/skills/build-block-from-figma/agents/visual-comparison.md
+++ b/.claude/skills/build-block-from-figma/agents/visual-comparison.md
@@ -208,6 +208,23 @@ If a breakpoint differs meaningfully from the Figma design:
 
 ---
 
+## Cleanup
+
+After the visual comparison phase is complete (all breakpoints assessed,
+obstacles documented), **delete all Playwright screenshots** taken during
+this session:
+
+```bash
+rm -rf .playwright-mcp/
+```
+
+Screenshots are disposable artefacts — they exist only to support the
+comparison loop and must not be left as untracked files in the repo.
+`.playwright-mcp/` is listed in `.gitignore`, but the directory will still
+show up in `git status` as untracked until it is removed.
+
+---
+
 ## Obstacles Encountered
 
 At the end of the visual comparison phase, compile a list of:

--- a/.claude/skills/build-block-from-figma/agents/visual-comparison.md
+++ b/.claude/skills/build-block-from-figma/agents/visual-comparison.md
@@ -84,6 +84,44 @@ For each breakpoint:
    Verify `flexDirection` matches the expected layout (column vs row)
    for this breakpoint. If it doesn't match, treat as a layout failure
    regardless of how the screenshot looks — the CSS breakpoint is wrong.
+
+9. **Express-specific computed value checks**: run these checks on every
+   block before declaring visual comparison done. These target known
+   Express global style conflicts that screenshots frequently miss.
+
+   ```js
+   const block = document.querySelector('.<block-name>');
+
+   // Check all <p> elements for 32px margin injected by main .section p
+   const pMargins = [...block.querySelectorAll('p')].map((p) => ({
+     text: p.textContent.slice(0, 40),
+     marginBlock: getComputedStyle(p).marginBlock,
+   }));
+
+   // Check CTA button background — blue means the block lost to
+   // main a.con-button.blue:any-link; must match Figma dark color
+   const btn = block.querySelector('a.con-button');
+   const btnBg = btn ? getComputedStyle(btn).backgroundColor : null;
+
+   return { pMargins, btnBg };
+   ```
+
+   **Failure conditions** (fix before passing the block):
+   - Any `<p>` has `marginBlock` that is not `0px` — the block's CSS
+     specificity is losing to `main .section p { margin: var(--spacing-500) 0 }`.
+     Fix: add a second class to the selector, e.g.
+     `.block-header .block-text p { margin: 0 }` (specificity `(0,2,1)`
+     beats `(0,1,2)`).
+   - `btnBg` is `rgb(92, 92, 224)` (milo blue) when the Figma shows a dark
+     button — the block's CSS is losing to `main a.con-button.blue:any-link`
+     (specificity `(0,3,2)`). Fix: use `main .block-header a.con-button.blue:any-link`
+     to match the same specificity and win via cascade order (block CSS
+     loads after Express's global styles.css).
+
+   **Never dismiss a color or spacing difference as "design system default"**
+   without first cross-referencing `get_variable_defs` from Phase 3. If the
+   Figma variable def shows a dark background on a CTA, the implementation
+   must also be dark — milo's blue is a default, not Express design intent.
 9. **Load the cached Figma frame** for this breakpoint from
    `/tmp/build-block-figma/<viewport>.png` (saved during Phase 3).
    Do **not** re-fetch from the Figma MCP — the cached file is the

--- a/.claude/skills/build-block-from-figma/agents/visual-comparison.md
+++ b/.claude/skills/build-block-from-figma/agents/visual-comparison.md
@@ -98,12 +98,7 @@ For each breakpoint:
      marginBlock: getComputedStyle(p).marginBlock,
    }));
 
-   // Check CTA button background — blue means the block lost to
-   // main a.con-button.blue:any-link; must match Figma dark color
-   const btn = block.querySelector('a.con-button');
-   const btnBg = btn ? getComputedStyle(btn).backgroundColor : null;
-
-   return { pMargins, btnBg };
+   return { pMargins };
    ```
 
    **Failure conditions** (fix before passing the block):
@@ -112,16 +107,9 @@ For each breakpoint:
      Fix: add a second class to the selector, e.g.
      `.block-header .block-text p { margin: 0 }` (specificity `(0,2,1)`
      beats `(0,1,2)`).
-   - `btnBg` is `rgb(92, 92, 224)` (milo blue) when the Figma shows a dark
-     button — the block's CSS is losing to `main a.con-button.blue:any-link`
-     (specificity `(0,3,2)`). Fix: use `main .block-header a.con-button.blue:any-link`
-     to match the same specificity and win via cascade order (block CSS
-     loads after Express's global styles.css).
 
    **Never dismiss a color or spacing difference as "design system default"**
-   without first cross-referencing `get_variable_defs` from Phase 3. If the
-   Figma variable def shows a dark background on a CTA, the implementation
-   must also be dark — milo's blue is a default, not Express design intent.
+   without first cross-referencing `get_variable_defs` from Phase 3.
 9. **Load the cached Figma frame** for this breakpoint from
    `/tmp/build-block-figma/<viewport>.png` (saved during Phase 3).
    Do **not** re-fetch from the Figma MCP — the cached file is the

--- a/.claude/skills/build-block-from-figma/references/acceptance-criteria.md
+++ b/.claude/skills/build-block-from-figma/references/acceptance-criteria.md
@@ -106,17 +106,6 @@ Minimum pattern:
 ```
 Never use a single-class selector for `<p>` margins — it will lose silently.
 
-**Rule 2 — button background**: `main a.con-button.blue:any-link { background-color: ... }` = `(0,3,2)`.
-If the Figma button is not milo-blue, the block CSS must reach `(0,3,2)`
-and load after `styles.css` (block CSS always does):
-```css
-/* (0,3,2) + later cascade position = wins */
-main .block-header a.con-button.blue:any-link {
-  background-color: <token-or-value>;
-  border-color: <token-or-value>;
-}
-```
-
 ## CSS quality checklist
 
 - No `!important`.

--- a/.claude/skills/build-block-from-figma/references/acceptance-criteria.md
+++ b/.claude/skills/build-block-from-figma/references/acceptance-criteria.md
@@ -91,6 +91,32 @@ token rules and `references/grid-system.md` for the grid/container system.
   different sizes at different viewports (tokens do not auto-switch
   in Express — you must override per breakpoint).
 
+## CSS specificity pre-flight
+
+Before committing any CSS, verify these two rules won't be overridden by
+Express's global styles. Both come from `main .section` in `styles.css`
+and affect nearly every block.
+
+**Rule 1 — paragraph margins**: `main .section p { margin: var(--spacing-500) 0 }` = `(0,1,2)`.
+Any block rule that resets paragraph margins must have specificity ≥ `(0,2,1)`.
+Minimum pattern:
+```css
+/* (0,2,1) — beats (0,1,2) */
+.block-container .block-text p { margin: 0 }
+```
+Never use a single-class selector for `<p>` margins — it will lose silently.
+
+**Rule 2 — button background**: `main a.con-button.blue:any-link { background-color: ... }` = `(0,3,2)`.
+If the Figma button is not milo-blue, the block CSS must reach `(0,3,2)`
+and load after `styles.css` (block CSS always does):
+```css
+/* (0,3,2) + later cascade position = wins */
+main .block-header a.con-button.blue:any-link {
+  background-color: <token-or-value>;
+  border-color: <token-or-value>;
+}
+```
+
 ## CSS quality checklist
 
 - No `!important`.

--- a/.claude/skills/build-block-from-figma/references/acceptance-criteria.md
+++ b/.claude/skills/build-block-from-figma/references/acceptance-criteria.md
@@ -140,8 +140,14 @@ main .block-header a.con-button.blue:any-link {
   `&.is-open`.
 - Use `:is()` and `:has()` where they reduce duplication.
 - Selector chain depth ≤ 3.
-- Use **CSS logical properties** (`margin-inline`, `padding-block`,
-  `inset-inline-start`, etc.) instead of physical properties.
+- **Shorthand first, logical properties for single-axis only**: use
+  `padding` / `margin` shorthand when all four sides (or both vertical +
+  horizontal pairs) have values — `padding: var(--spacing-900) var(--spacing-600)`
+  is cleaner than two declarations. Reach for individual logical properties
+  (`padding-block`, `padding-inline`, `margin-inline`, `inset-inline-start`,
+  etc.) only when setting **one axis** without touching the other, e.g.
+  `padding-inline: var(--spacing-500)` inside a breakpoint override where
+  block padding stays the same.
 - No magic numbers — every value maps to a token or has an
   explanatory comment.
 - Scope block-level custom properties with a block-name prefix

--- a/.claude/skills/build-block-from-figma/references/eds-patterns.md
+++ b/.claude/skills/build-block-from-figma/references/eds-patterns.md
@@ -196,6 +196,122 @@ await trackBranchParameters(ctaLinks);
 
 ---
 
+## Common EDS/Express pitfalls
+
+These are non-obvious problems that appear in nearly every new block.
+Address them proactively — waiting until visual comparison to discover
+them costs an extra push/CDN-refresh cycle each.
+
+### 1. Single-value cell delivery (no `<p>` wrapper)
+
+EDS delivers multi-cell rows with `<p>` wrappers inside each cell,
+but **single-value cells arrive as plain text with no `<p>`**:
+
+```html
+<!-- Multi-cell row (EDS delivers <p> wrappers) -->
+<div>
+  <div><h2>Heading</h2><p>Body text</p></div>
+  <div><picture>...</picture></div>
+</div>
+
+<!-- Single-value cell (EDS delivers plain text — NO <p> wrapper) -->
+<div>
+  <div>#f8f8f8</div>   ← just text, no <p>
+</div>
+```
+
+**Impact**: Any JS selector `cell.querySelector('p')` on a single-value
+cell returns `null`. Always read `cell.textContent.trim()` as a fallback
+when `querySelector('p')` might miss the value:
+
+```js
+const text = cell.querySelector('p')?.textContent?.trim()
+          ?? cell.textContent?.trim();
+```
+
+**Mock HTML must mirror this**: write `<div>#f8f8f8</div>` (no `<p>`)
+in the mock for single-value cells, not `<div><p>#f8f8f8</p></div>`.
+If the mock doesn't match EDS delivery, unit tests will pass but the
+live block will silently fail.
+
+---
+
+### 2. `decorateButtonsDeprecated` DOM transformation
+
+`decorateButtonsDeprecated` transforms authored `<strong>/<em><a>` markup
+into decorated button elements. The JS code written to separate CTAs from
+body text must use the **post-decoration** class names, not the pre-decoration
+markup structure.
+
+| Before decoration | After decoration |
+|---|---|
+| `<p><strong><a href="...">CTA</a></strong></p>` | `<p class="action-area"><a class="con-button blue" href="...">CTA</a></p>` |
+
+Key post-decoration facts:
+- The `<strong>` and `<em>` wrappers are **removed**.
+- The `<a>` gains `con-button` + a color class (`blue` for primary, `outline` for secondary).
+- The wrapping `<p>` gains class `action-area` (not `button-container`).
+
+**Wrong selector** (breaks after decoration):
+```js
+// <strong> is gone — this matches nothing
+const cta = cell.querySelector('strong');
+```
+
+**Correct selector**:
+```js
+// Use the decorated class that milo actually adds
+const ctaArea = [...cell.children].find(
+  (el) => el.classList.contains('action-area')
+);
+```
+
+And in CSS, `.button` alone won't match — use `:is(.button, .con-button)`:
+```css
+.block-header :is(.button, .con-button) { display: inline-block; }
+```
+
+---
+
+### 3. Express specificity conflicts
+
+Express's global `styles.css` contains two rules that routinely override
+block CSS due to higher specificity. Know them before writing any block CSS.
+
+**`main .section p` (specificity `(0,1,2)`)**:
+```css
+/* from styles.css */
+main .section p { margin: var(--spacing-500) 0 }  /* = 32px top + bottom */
+```
+Any block `<p>` rule with only 1 class loses:
+```css
+.block-text p { margin: 0 }      /* (0,1,1) — LOSES */
+```
+Fix: use 2 classes on the selector:
+```css
+.block-header .block-text p { margin: 0 }   /* (0,2,1) — WINS */
+.block-card .block-card-title { margin: 0 } /* (0,2,0) — WINS */
+```
+
+**`main a.con-button.blue:any-link` (specificity `(0,3,2)`)**:
+```css
+/* from styles.css — turns all primary CTAs blue */
+main a.con-button.blue:any-link {
+  background-color: var(--color-accent);  /* milo blue */
+}
+```
+To apply a different button background (e.g. dark from Figma), match
+the same specificity and win via **cascade order** (block CSS loads after
+styles.css, so equal-specificity rules in block CSS win):
+```css
+main .block-header a.con-button.blue:any-link {
+  background-color: #292929;   /* (0,3,2) — equal specificity, wins via cascade */
+  border-color: #292929;
+}
+```
+
+---
+
 ## Fluffyjaws MCP
 
 When in doubt about any EDS convention — block loading, page

--- a/.claude/skills/build-block-from-figma/references/eds-patterns.md
+++ b/.claude/skills/build-block-from-figma/references/eds-patterns.md
@@ -293,23 +293,6 @@ Fix: use 2 classes on the selector:
 .block-card .block-card-title { margin: 0 } /* (0,2,0) — WINS */
 ```
 
-**`main a.con-button.blue:any-link` (specificity `(0,3,2)`)**:
-```css
-/* from styles.css — turns all primary CTAs blue */
-main a.con-button.blue:any-link {
-  background-color: var(--color-accent);  /* milo blue */
-}
-```
-To apply a different button background (e.g. dark from Figma), match
-the same specificity and win via **cascade order** (block CSS loads after
-styles.css, so equal-specificity rules in block CSS win):
-```css
-main .block-header a.con-button.blue:any-link {
-  background-color: #292929;   /* (0,3,2) — equal specificity, wins via cascade */
-  border-color: #292929;
-}
-```
-
 ---
 
 ## Fluffyjaws MCP

--- a/.claude/skills/build-block-from-figma/references/remote-branch-workflow.md
+++ b/.claude/skills/build-block-from-figma/references/remote-branch-workflow.md
@@ -129,6 +129,11 @@ Use **git CLI** to commit and push to the feature branch on
    git push origin HEAD:<branch-name>
    ```
 
+   > **No debug commits**: use `console.log` in memory only. If a temporary
+   > `data-*` attribute or other debug marker is added to the DOM for
+   > tracing, remove it before committing. Debug commits that do land on the
+   > branch must be squashed before opening a PR.
+
 4. **Clean up** the temporary local branch:
    ```bash
    git checkout <previous-branch>

--- a/.claude/skills/build-content-from-figma/references/authoring-pattern.md
+++ b/.claude/skills/build-content-from-figma/references/authoring-pattern.md
@@ -50,6 +50,14 @@ name + variants), and subsequent rows hold content.
 - Header: a single `<td colspan="2">` with `<p>block-name (variant-a, variant-b)</p>`.
   Variants in parentheses, comma-separated. No variants: `<p>block-name</p>`.
 
+> **DA colspan rule**: DA normalizes every table to have the same number of
+> columns across all rows, padding short rows with empty cells to match the
+> widest row. Any row that should span the full table width — the block name
+> header, a background color row, a section heading row, or any other
+> single-cell row — must use `colspan="N"` where N is the table's column
+> count. Omitting it causes DA to render an unexpected empty second cell,
+> which shifts content into the wrong column in the editor and in EDS delivery.
+
 ---
 
 ## Content rows — text column + stacked media column

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ dev/
 actionlint
 .claude/worktrees/
 .claude/**.local.*
+.playwright-mcp/
 !.eslintrc-code-compatibility.js
 !.browserslistrc


### PR DESCRIPTION
## Summary

- Updates the Claude skills related to the /build-express-block command when run for Font Bento block

What Changed:
- **Visual comparison**: add Express-specific computed value check for `<p>` margins (catches `main .section p` specificity loss); add screenshot cleanup step (`rm -rf .playwright-mcp/`) at end of each session
- **EDS patterns**: new "Common EDS/Express pitfalls" section covering single-value cell delivery (no `<p>` wrapper), `decorateButtons` DOM transformation, and `main .section p` specificity conflict
- **Acceptance criteria**: add CSS specificity pre-flight for the `main .section p` rule; replace "always use logical properties" with "shorthand first, logical for single-axis only"
- **Authoring pattern**: document DA's colspan normalization behavior — single-cell rows must use `colspan="N"` or DA pads them with empty cells
- **Remote branch workflow**: warn against debug commits on feature branches
- **SKILL.md**: document EDS single-value cell behavior in mock HTML guidance
- **`.gitignore`**: add `.playwright-mcp/`

## Jira Ticket

Related to: [MWPW-193971](https://jira.corp.adobe.com/browse/MWPW-193971)

---

## Test URLs

N/A — no site-facing changes. 

---

## Verification Steps

N/A

---

## Potential Regressions



---

## Additional Notes